### PR TITLE
Right, outer joins consistent with local sources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,12 @@
       
     * `full_join()` throws a clear error when you attempt to use it with a
       MySQL backend (#2045)
+      
+    * `right_join()` and `full_join()` now return results consistent with
+      local data frame sources when there are records in the right table with
+      no match in the left table. `right_join()` returns values of `by` columns
+      from the right table. `full_join()` returns coalesced values of `by` columns
+      from the left and right tables (#2578)
 
 *   `group_by()` can now perform an inline mutate for database backends (#2422).
 


### PR DESCRIPTION
Added a bullet briefly describing the user-facing impact of the change to `right_join()` and `full_join()` in https://github.com/tidyverse/dbplyr/pull/3.