### PR TITLE
Update by column not found error messages

### DIFF
--- a/tests/testthat/test-joins.R
+++ b/tests/testthat/test-joins.R
@@ -61,11 +61,11 @@ test_that("suffix modifies duplicated variable names", {
 test_that("join functions error on column not found for SQL sources #1928", {
   expect_error(
     left_join(memdb_frame(x = 1:5), memdb_frame(y = 1:5), by = "x"),
-    "not found in rhs"
+    "missing from RHS"
   )
   expect_error(
     left_join(memdb_frame(x = 1:5), memdb_frame(y = 1:5), by = "y"),
-    "not found in lhs"
+    "missing from LHS"
   )
   expect_error(
     left_join(memdb_frame(x = 1:5), memdb_frame(y = 1:5)),


### PR DESCRIPTION
This resolves two test errors:
`Failure: join functions error on column not found for SQL sources #1928 (@test-joins.R#62)`
`Failure: join functions error on column not found for SQL sources #1928 (@test-joins.R#66)`