### PR TITLE
Adds sd() support for 5 datasources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Added custom `db_analyze_table()` for MS SQL, Oracle, Hive and Impala (@edgararuiz)
 
+* Added support for `sd()` for scalar, aggregate and window functions (#2887) (@edgararuiz) 
+
 # dbplyr 1.0.0
 
 ## New features

--- a/R/db-odbc-hive.R
+++ b/R/db-odbc-hive.R
@@ -1,7 +1,7 @@
 #' @export
 sql_translate_env.Hive <- function(con) {
   sql_variant(
-    scalar = sql_translator(.parent = base_odbc_scalar,
+    sql_translator(.parent = base_odbc_scalar,
       var       = sql_prefix("VARIANCE"),
       cot       = function(x){
                     build_sql("1 / TAN(", x, ")")

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -47,6 +47,7 @@
       atan2         = sql_prefix("ATN2"),
       ceil          = sql_prefix("CEILING"),
       ceiling       = sql_prefix("CEILING"),
+      sd            = sql_prefix("STDEV"),
       substr        = function(x, start, stop){
                         len <- stop - start + 1
                         build_sql(
@@ -80,7 +81,10 @@
       cov           = sql_not_supported("cov()")
 
     ),
-    base_odbc_win
+    sql_variant(
+      scalar = sql_translator(.parent = base_odbc_win,
+        sd          = win_recycled("STDEV")
+      ))
   )}
 
 #' @export

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -47,7 +47,6 @@
       atan2         = sql_prefix("ATN2"),
       ceil          = sql_prefix("CEILING"),
       ceiling       = sql_prefix("CEILING"),
-      sd            = sql_prefix("STDEV"),
       substr        = function(x, start, stop){
                         len <- stop - start + 1
                         build_sql(

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -38,7 +38,7 @@
 #' @export
 `sql_translate_env.Microsoft SQL Server` <- function(con) {
   sql_variant(
-    scalar = sql_translator(.parent = base_odbc_scalar,
+    sql_translator(.parent = base_odbc_scalar,
       as.numeric    = sql_cast("NUMERIC"),
       as.double     = sql_cast("NUMERIC"),
       as.character  = sql_cast("VARCHAR(MAX)"),
@@ -73,7 +73,7 @@
                       # MSSQL supports CONCAT_WS in the CTP version of 2016
       paste         = sql_not_supported("paste()")
     ),
-    aggregate = sql_translator(.parent = base_odbc_agg,
+    sql_translator(.parent = base_odbc_agg,
       sd            = sql_prefix("STDEV"),
       var           = sql_prefix("VAR"),
                       # MSSQL does not have function for: cor and cov
@@ -81,10 +81,9 @@
       cov           = sql_not_supported("cov()")
 
     ),
-    sql_variant(
-      scalar = sql_translator(.parent = base_odbc_win,
-        sd          = win_recycled("STDEV")
-      ))
+    sql_translator(.parent = base_odbc_win,
+      sd            = win_recycled("STDEV")
+    )
   )}
 
 #' @export

--- a/R/db-odbc-oracle.R
+++ b/R/db-odbc-oracle.R
@@ -33,7 +33,7 @@ sql_select.Oracle<- function(con, select, from, where = NULL,
 #' @export
 sql_translate_env.Oracle <- function(con) {
   sql_variant(
-    scalar = sql_translator(.parent = base_odbc_scalar,
+    sql_translator(.parent = base_odbc_scalar,
       # Data type conversions are mostly based on this article
       # https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements001.htm
       as.character  = sql_cast("VARCHAR(255)"),

--- a/R/db-odbc-postgres.R
+++ b/R/db-odbc-postgres.R
@@ -39,12 +39,15 @@ sql_translate_env.PostgreSQL <- function(con) {
       n      = function() sql("count(*)"),
       cor    = sql_prefix("corr"),
       cov    = sql_prefix("covar_samp"),
-      sd     =  sql_prefix("stddev_samp"),
+      sd     = sql_prefix("stddev_samp"),
       var    = sql_prefix("var_samp"),
       all    = sql_prefix("bool_and"),
       any    = sql_prefix("bool_or"),
       paste  = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
     ),
-    base_win
+    sql_translator(.parent = base_win,
+      sd     = win_recycled("stddev_samp")
+    )
+
   )
 }

--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -11,16 +11,16 @@ db_desc.PostgreSQLConnection <- function(x) {
 sql_translate_env.PostgreSQLConnection <- function(con) {
   sql_variant(
     sql_translator(.parent = base_scalar,
-      sd    =  sql_prefix("stddev_samp"),
-      log   = function(x, base = exp(1)) {
-                if (isTRUE(all.equal(base, exp(1)))) {
-                  build_sql("ln(", x, ")")
-                } else {
-                  # Use log change-of-base because postgres doesn't support the
-                  # two-argument "log(base, x)" for floating point x.
-                  build_sql("log(", x, ") / log(", base, ")")
+      sd     = sql_prefix("stddev_samp"),
+      log    = function(x, base = exp(1)) {
+                  if (isTRUE(all.equal(base, exp(1)))) {
+                    build_sql("ln(", x, ")")
+                  } else {
+                    # Use log change-of-base because postgres doesn't support the
+                    # two-argument "log(base, x)" for floating point x.
+                    build_sql("log(", x, ") / log(", base, ")")
+                  }
                 }
-              }
     ),
     sql_translator(.parent = base_agg,
       n      = function() sql("count(*)"),

--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -11,27 +11,30 @@ db_desc.PostgreSQLConnection <- function(x) {
 sql_translate_env.PostgreSQLConnection <- function(con) {
   sql_variant(
     sql_translator(.parent = base_scalar,
-      log = function(x, base = exp(1)) {
-        if (isTRUE(all.equal(base, exp(1)))) {
-          build_sql("ln(", x, ")")
-        } else {
-          # Use log change-of-base because postgres doesn't support the
-          # two-argument "log(base, x)" for floating point x.
-          build_sql("log(", x, ") / log(", base, ")")
-        }
-      }
+      sd    =  sql_prefix("stddev_samp"),
+      log   = function(x, base = exp(1)) {
+                if (isTRUE(all.equal(base, exp(1)))) {
+                  build_sql("ln(", x, ")")
+                } else {
+                  # Use log change-of-base because postgres doesn't support the
+                  # two-argument "log(base, x)" for floating point x.
+                  build_sql("log(", x, ") / log(", base, ")")
+                }
+              }
     ),
     sql_translator(.parent = base_agg,
-      n = function() sql("count(*)"),
-      cor = sql_prefix("corr"),
-      cov = sql_prefix("covar_samp"),
-      sd =  sql_prefix("stddev_samp"),
-      var = sql_prefix("var_samp"),
-      all = sql_prefix("bool_and"),
-      any = sql_prefix("bool_or"),
-      paste = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
+      n      = function() sql("count(*)"),
+      cor    = sql_prefix("corr"),
+      cov    = sql_prefix("covar_samp"),
+      sd     = sql_prefix("stddev_samp"),
+      var    = sql_prefix("var_samp"),
+      all    = sql_prefix("bool_and"),
+      any    = sql_prefix("bool_or"),
+      paste  = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
     ),
-    base_win
+    sql_translator(.parent = base_win,
+      sd     = win_recycled("stddev_samp")
+    )
   )
 }
 

--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -11,7 +11,6 @@ db_desc.PostgreSQLConnection <- function(x) {
 sql_translate_env.PostgreSQLConnection <- function(con) {
   sql_variant(
     sql_translator(.parent = base_scalar,
-      sd = sql_prefix("stddev_samp"),
       log = function(x, base = exp(1)) {
         if (isTRUE(all.equal(base, exp(1)))) {
           build_sql("ln(", x, ")")

--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -11,29 +11,29 @@ db_desc.PostgreSQLConnection <- function(x) {
 sql_translate_env.PostgreSQLConnection <- function(con) {
   sql_variant(
     sql_translator(.parent = base_scalar,
-      sd     = sql_prefix("stddev_samp"),
-      log    = function(x, base = exp(1)) {
-                  if (isTRUE(all.equal(base, exp(1)))) {
-                    build_sql("ln(", x, ")")
-                  } else {
-                    # Use log change-of-base because postgres doesn't support the
-                    # two-argument "log(base, x)" for floating point x.
-                    build_sql("log(", x, ") / log(", base, ")")
-                  }
-                }
+      sd = sql_prefix("stddev_samp"),
+      log = function(x, base = exp(1)) {
+        if (isTRUE(all.equal(base, exp(1)))) {
+          build_sql("ln(", x, ")")
+        } else {
+          # Use log change-of-base because postgres doesn't support the
+          # two-argument "log(base, x)" for floating point x.
+          build_sql("log(", x, ") / log(", base, ")")
+        }
+      }
     ),
     sql_translator(.parent = base_agg,
-      n      = function() sql("count(*)"),
-      cor    = sql_prefix("corr"),
-      cov    = sql_prefix("covar_samp"),
-      sd     = sql_prefix("stddev_samp"),
-      var    = sql_prefix("var_samp"),
-      all    = sql_prefix("bool_and"),
-      any    = sql_prefix("bool_or"),
-      paste  = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
+      n = function() sql("count(*)"),
+      cor = sql_prefix("corr"),
+      cov = sql_prefix("covar_samp"),
+      sd = sql_prefix("stddev_samp"),
+      var = sql_prefix("var_samp"),
+      all = sql_prefix("bool_and"),
+      any = sql_prefix("bool_or"),
+      paste = function(x, collapse) build_sql("string_agg(", x, ", ", collapse, ")")
     ),
     sql_translator(.parent = base_win,
-      sd     = win_recycled("stddev_samp")
+      sd = win_recycled("stddev_samp")
     )
   )
 }

--- a/R/translate-sql-odbc.R
+++ b/R/translate-sql-odbc.R
@@ -9,6 +9,7 @@ base_odbc_scalar <- sql_translator(
   as.logical    = sql_cast("BOOLEAN"),
   as.character  = sql_cast("STRING"),
   as.Date       = sql_cast("DATE"),
+  sd            = sql_cast("STDDEV_SAMP"),
   paste0        = sql_prefix("CONCAT"),
                   # cosh, sinh, coth and tanh calculations are based on this article
                   # https://en.wikipedia.org/wiki/Hyperbolic_function
@@ -47,7 +48,8 @@ base_odbc_agg <- sql_translator(
 base_odbc_win <- sql_translator(
   .parent = base_win,
   n             = function() sql("COUNT(*)"),
-  count         = function() sql("COUNT(*)")
+  count         = function() sql("COUNT(*)"),
+  sd            = win_recycled("STDDEV_SAMP")
 )
 
 #' @export

--- a/R/translate-sql-odbc.R
+++ b/R/translate-sql-odbc.R
@@ -1,15 +1,14 @@
 #' @export
 #' @rdname sql_variant
 #' @format NULL
-base_odbc_scalar <- sql_translator(
-  .parent = base_scalar,
+base_odbc_scalar <- sql_translator(.parent = base_scalar,
   as.numeric    = sql_cast("DOUBLE"),
   as.double     = sql_cast("DOUBLE"),
   as.integer    = sql_cast("INT"),
   as.logical    = sql_cast("BOOLEAN"),
   as.character  = sql_cast("STRING"),
   as.Date       = sql_cast("DATE"),
-  sd            = sql_cast("STDDEV_SAMP"),
+  sd            = sql_prefix("STDDEV_SAMP"),
   paste0        = sql_prefix("CONCAT"),
                   # cosh, sinh, coth and tanh calculations are based on this article
                   # https://en.wikipedia.org/wiki/Hyperbolic_function

--- a/R/translate-sql-odbc.R
+++ b/R/translate-sql-odbc.R
@@ -38,14 +38,14 @@ base_odbc_scalar <- sql_translator(.parent = base_scalar,
 base_odbc_agg <- sql_translator(
   .parent = base_agg,
   n             = function() sql("COUNT(*)"),
-  count         = function() sql("COUNT(*)")
+  count         = function() sql("COUNT(*)"),
+  sd            = sql_prefix("STDDEV_SAMP")
 )
 
 #' @export
 #' @rdname sql_variant
 #' @format NULL
-base_odbc_win <- sql_translator(
-  .parent = base_win,
+base_odbc_win <- sql_translator(.parent = base_win,
   n             = function() sql("COUNT(*)"),
   count         = function() sql("COUNT(*)"),
   sd            = win_recycled("STDDEV_SAMP")

--- a/R/translate-sql-odbc.R
+++ b/R/translate-sql-odbc.R
@@ -8,7 +8,6 @@ base_odbc_scalar <- sql_translator(.parent = base_scalar,
   as.logical    = sql_cast("BOOLEAN"),
   as.character  = sql_cast("STRING"),
   as.Date       = sql_cast("DATE"),
-  sd            = sql_prefix("STDDEV_SAMP"),
   paste0        = sql_prefix("CONCAT"),
                   # cosh, sinh, coth and tanh calculations are based on this article
                   # https://en.wikipedia.org/wiki/Hyperbolic_function

--- a/tests/testthat/test-translate-odbc.R
+++ b/tests/testthat/test-translate-odbc.R
@@ -142,7 +142,7 @@ test_that("sd() translates to STDEV ", {
     translate_sql(sd(field_name),
                   window = FALSE,
                   con = simulate_odbc("OdbcConnection")),
-    sql("SD(`field_name`)"))
+    sql("STDDEV_SAMP(`field_name`)"))
 })
 
 test_that("var() translates to VARIANCE ", {


### PR DESCRIPTION
Adds sd() scalar, aggregate and window support for MSSQL, Oracle, Hive, Impala and Postgres (for both odbc and RPostgreSQL).  It also includes some further code tidying.  Addresses `dplyr` issue https://github.com/tidyverse/dplyr/issues/2887

```
> tbl(con, "iris") %>%
+   group_by(Species) %>%
+   mutate(A_sd = sd(Sepal.Length))
```

```
# Source:   lazy query [?? x 6]
# Database: Microsoft SQL Server 12.00.4422[rstudioadmin@EC2AMAZ-O5QKKM8/airontime]
# Groups:   Species
   Sepal.Length Sepal.Width Petal.Length Petal.Width Species      A_sd
          <dbl>       <dbl>        <dbl>       <dbl>   <chr>     <dbl>
 1          5.1         3.5          1.4         0.2  setosa 0.3524897
 2          4.9         3.0          1.4         0.2  setosa 0.3524897
 3          4.7         3.2          1.3         0.2  setosa 0.3524897
```