### PR TITLE
Enable db_write_table() to append to tables, (per deprecation)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dbplyr 1.1.0.9000
 
-* Fixed `db_write_table()` to allow `append=TRUE`.  Closes tidyverse/dplyr#3120 (@drf5n).
+* Fixed `db_write_table()` to allow `append=TRUE` (@drf5n, #3120).
 
 * Fixed `n()` and `count()` for window function via `odbc` connections (@edgararuiz)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr 1.1.0.9000
 
+* Fixed `db_write_table()` to allow `append=TRUE`.  Closes tidyverse/dplyr#3120 (@drf5n).
+
 * Fixed `n()` and `count()` for window function via `odbc` connections (@edgararuiz)
 
 * SQL translation for Redshift (@edgararuiz)

--- a/R/dbi-s3.r
+++ b/R/dbi-s3.r
@@ -45,7 +45,8 @@ db_write_table.DBIConnection <- function(con, table, types, values, temporary = 
     value = values,
     field.types = types,
     temporary = temporary,
-    row.names = FALSE
+    row.names = FALSE,
+    ...
   )
 }
 


### PR DESCRIPTION
This passes the `...` argument from `db_write_table(con, table, types, values, temporary = FALSE, ...)` along into the `dbWriteTable()` call to enable arguments like `append=TRUE` per https://github.com/tidyverse/dplyr/issues/3120