### PR TITLE
Fix error: object 'port' not found

### DIFF
--- a/R/translate-sql-odbc.R
+++ b/R/translate-sql-odbc.R
@@ -53,7 +53,7 @@ db_desc.OdbcConnection <- function(x) {
   info <- DBI::dbGetInfo(x)
 
   host <- if (info$servername == "") "localhost" else info$servername
-  port <- if (info$port == "") "" else paste0(":", port)
+  port <- if (info$port == "") "" else paste0(":", info$port)
 
   paste0(
     info$dbms.name, " ", info$db.version,


### PR DESCRIPTION
Fix an error for OdbcConnection:

```r
> library(dplyr)
> library(dbplyr)
> library(odbc)
> con <- dbConnect(odbc(), dsn = "test")
> con
<OdbcConnection>  Database: test
> db_desc(con)
Error in paste0(":", port) : object 'port' not found
```