### PR TITLE
Fixes MS SQL issue of select after arrange

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr 1.1.0.9000
 
+* Improvements to `sql_optimise()` (#3062) (@edgararuiz)
+
 * Adding support for stringr functions: `str_length()`, `str_to_upper()`, `str_to_lower()`,
   str_replace_all()`, `str_detect()`, `str_trim()`. Regular expression support varies 
   from database to database, but most simple regular expressions should be ok (@edgararuiz)

--- a/R/sql-optimise.R
+++ b/R/sql-optimise.R
@@ -37,6 +37,13 @@ sql_optimise.select_query <- function(x, con = NULL, ...) {
   if (length(outer) == 0 || length(inner) == 0)
     return(x)
 
+  if (as.character(inner[length(inner)]) == "order_by" && !("group_by" %in% as.character(inner)) &&
+      (as.character(outer) == "select" || as.character(outer) == "where")
+      ) {
+    from[as.character(outer)] <- x[as.character(outer)]
+    return(from)
+  }
+
   if (min(outer) > max(inner)) {
     from[as.character(outer)] <- x[as.character(outer)]
     from


### PR DESCRIPTION
Fixes https://github.com/tidyverse/dplyr/issues/3062

It adds another layer to `sql-optimise` that checks to see if the current query is a SELECT or a FILTER and if the previous query is an ORDER BY and merges the two.  The exception is that if in the previous query history is a GROUP BY.  The exception is because implementing this optimization for grouped data seems to require a more complex solution that seems to be out of scope of the reported issue.

Here are the tests I ran:
[test_optimise.pdf](https://github.com/tidyverse/dbplyr/files/1416127/test_optimise.pdf)
