### PR TITLE
Fixes !is.na() for MS SQL

### DIFF
--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -158,10 +158,15 @@ mssql_not_sql_prefix <- function(f) {
     args_c <- as.character(args)
     if(substr(args_c, 1, 17) == "CONVERT(BIT, IIF(" &&
        substr(args_c, nchar(args_c) - 5, nchar(args_c)) ==  "1, 0))"){
-        return(build_sql(sql(substr(args_c, 1, nchar(args_c) - 6)), "0, 1))"))
+
+        build_sql(sql(substr(args_c, 1, nchar(args_c) - 6)), "0, 1))")
+
+      } else {
+
+        build_sql(sql(f), args)
+
       }
-    build_sql(sql(f), args)
-  }
+    }
 }
 
 globalVariables(c("BIT", "%is%", "convert"))

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -40,8 +40,7 @@
   sql_variant(
     sql_translator(.parent = base_odbc_scalar,
 
-
-      `!`     = mssql_not_sql_prefix("not"),
+      `!`           = mssql_not_sql_prefix("not"),
 
       as.numeric    = sql_cast("NUMERIC"),
       as.double     = sql_cast("NUMERIC"),

--- a/man/dbplyr-package.Rd
+++ b/man/dbplyr-package.Rd
@@ -22,6 +22,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Hadley Wickham \email{hadley@rstudio.com}
 
+Authors:
+\itemize{
+  \item Edgar Ruiz
+}
+
 Other contributors:
 \itemize{
   \item RStudio [copyright holder, funder]

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -73,6 +73,11 @@ test_that("filter and mutate translate is.na correctly", {
   )
 
   expect_equal(
+    mf %>% mutate(z = !is.na(x)) %>% show_query(),
+    sql("SELECT `x`, CONVERT(BIT, IIF(`x` IS NULL, 0, 1)) AS `z`\nFROM `df`")
+  )
+
+  expect_equal(
     mf %>% filter(is.na(x)) %>% show_query(),
     sql("SELECT *\nFROM `df`\nWHERE (((`x`) IS NULL))")
   )


### PR DESCRIPTION
Fixes https://github.com/tidyverse/dplyr/issues/3172

- Created a custom `sql_prefix()` for MS SQL called `mssql_not_sql_prefix()` that checks the if the inside command contains code for a WHERE clause and flips the TRUE FALSE results of the IIF statement.

- Added a test for this change