### PR TITLE
Fix negated is na

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,7 +80,9 @@
   
     * Better support for temporary tables (@Hong-Revo)
     
-    * Different `is.na()` translations for filter/mutate contexts.
+    * Different translations for filter/mutate contexts for: `NULL` evaluation
+      (`is.na()`, `is.null()`), logical operators (`!`, `&`, `&&`, `|`, `||`),
+      and comparison operators (`==`, `!=`, `<`, `>`, `>=`, `<=`)
 
 *   MySQL: `copy_to()` (via `db_write_table()`) correctly translates logical 
     variables to integers (#3151).

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -42,17 +42,17 @@
 
       `!`           = mssql_not_sql_prefix(),
 
-      `!=`           = mssql_sql_infix("!="),
-      `==`           = mssql_sql_infix("="),
-      `<`            = mssql_sql_infix("<"),
-      `<=`           = mssql_sql_infix("<="),
-      `>`            = mssql_sql_infix(">"),
-      `>=`           = mssql_sql_infix(">="),
+      `!=`           = mssql_logical_infix("!="),
+      `==`           = mssql_logical_infix("="),
+      `<`            = mssql_logical_infix("<"),
+      `<=`           = mssql_logical_infix("<="),
+      `>`            = mssql_logical_infix(">"),
+      `>=`           = mssql_logical_infix(">="),
 
-      `&`            = mssql_logical_infix("&", "AND"),
-      `&&`           = mssql_logical_infix("&", "AND"),
-      `|`            = mssql_logical_infix("|", "OR"),
-      `||`           = mssql_logical_infix("|", "OR"),
+      `&`            = mssql_generic_infix("&", "AND"),
+      `&&`           = mssql_generic_infix("&", "AND"),
+      `|`            = mssql_generic_infix("|", "OR"),
+      `||`           = mssql_generic_infix("|", "OR"),
 
       as.numeric    = sql_cast("NUMERIC"),
       as.double     = sql_cast("NUMERIC"),
@@ -168,7 +168,7 @@ mssql_not_sql_prefix <- function() {
   }
 }
 
-mssql_sql_infix <- function(f) {
+mssql_logical_infix <- function(f) {
   assert_that(is_string(f))
 
   f <- toupper(f)
@@ -182,7 +182,7 @@ mssql_sql_infix <- function(f) {
   }
 }
 
-mssql_logical_infix <- function(if_select, if_filter) {
+mssql_generic_infix <- function(if_select, if_filter) {
   assert_that(is_string(if_select))
   assert_that(is_string(if_filter))
 

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -57,7 +57,7 @@
                         )},
                       # Casting as BIT converts the Integer result into an actual logical
                       # values TRUE and FALSE
-      is.null       = function(x) mssql_is_null(x,),
+      is.null       = function(x) mssql_is_null(x, sql_current_context()),
       is.na         = function(x) mssql_is_null(x, sql_current_context()),
                       # TRIM is not supported on MS SQL versions under 2017
                       # https://docs.microsoft.com/en-us/sql/t-sql/functions/trim-transact-sql

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -158,10 +158,15 @@ mssql_not_sql_prefix <- function(f) {
     args_c <- as.character(args)
     if(substr(args_c, 1, 17) == "CONVERT(BIT, IIF(" &&
        substr(args_c, nchar(args_c) - 5, nchar(args_c)) ==  "1, 0))"){
-        return(build_sql(sql(substr(args_c, 1, nchar(args_c) - 6)), "0, 1))"))
+
+        build_sql(sql(substr(args_c, 1, nchar(args_c) - 6)), "0, 1))")
+
+      } else {
+
+        build_sql(sql(f), args)
+
       }
-    build_sql(sql(f), args)
-  }
+    }
 }
 
 globalVariables(c("BIT", "%is%", "convert"))

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -40,8 +40,7 @@
   sql_variant(
     sql_translator(.parent = base_odbc_scalar,
 
-
-      `!`     = mssql_not_sql_prefix("not"),
+      `!`           = mssql_not_sql_prefix("not"),
 
       as.numeric    = sql_cast("NUMERIC"),
       as.double     = sql_cast("NUMERIC"),

--- a/R/translate-sql-window.r
+++ b/R/translate-sql-window.r
@@ -230,6 +230,8 @@ set_current_context <- function(context) {
 
 sql_current_context <- function() sql_context$context
 
+sql_current_select  <- function() sql_context$context %in% c("SELECT", "ORDER")
+
 # Where translation -------------------------------------------------------
 
 

--- a/man/dbplyr-package.Rd
+++ b/man/dbplyr-package.Rd
@@ -22,6 +22,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Hadley Wickham \email{hadley@rstudio.com}
 
+Authors:
+\itemize{
+  \item Edgar Ruiz
+}
+
 Other contributors:
 \itemize{
   \item RStudio [copyright holder, funder]

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -69,12 +69,12 @@ test_that("filter and mutate translate is.na correctly", {
 
   expect_equal(
     mf %>% mutate(z = is.na(x)) %>% show_query(),
-    sql("SELECT `x`, CONVERT(BIT, `x`) AS `z`\nFROM `df`")
+    sql("SELECT `x`, CONVERT(BIT, IIF(`x` IS NULL, 1, 0)) AS `z`\nFROM `df`")
   )
 
   expect_equal(
     mf %>% mutate(z = !is.na(x)) %>% show_query(),
-    sql("SELECT `x`, ~(CONVERT(BIT, `x`)) AS `z`\nFROM `df`")
+    sql("SELECT `x`, ~(CONVERT(BIT, IIF(`x` IS NULL, 1, 0))) AS `z`\nFROM `df`")
   )
 
   expect_equal(

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -73,6 +73,11 @@ test_that("filter and mutate translate is.na correctly", {
   )
 
   expect_equal(
+    mf %>% mutate(z = !is.na(x)) %>% show_query(),
+    sql("SELECT `x`, CONVERT(BIT, IIF(`x` IS NULL, 0, 1)) AS `z`\nFROM `df`")
+  )
+
+  expect_equal(
     mf %>% filter(is.na(x)) %>% show_query(),
     sql("SELECT *\nFROM `df`\nWHERE (((`x`) IS NULL))")
   )

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -82,5 +82,65 @@ test_that("filter and mutate translate is.na correctly", {
     sql("SELECT *\nFROM `df`\nWHERE (((`x`) IS NULL))")
   )
 
+  expect_equal(
+    mf %>% mutate(x = x == 1) %>% show_query(),
+    sql("SELECT CONVERT(BIT, IIF(`x` = 1.0, 1.0, 0.0)) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = x != 1) %>% show_query(),
+    sql("SELECT CONVERT(BIT, IIF(`x` != 1.0, 1.0, 0.0)) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = x > 1) %>% show_query(),
+    sql("SELECT CONVERT(BIT, IIF(`x` > 1.0, 1.0, 0.0)) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = x >= 1) %>% show_query(),
+    sql("SELECT CONVERT(BIT, IIF(`x` >= 1.0, 1.0, 0.0)) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = !(x == 1)) %>% show_query(),
+    sql("SELECT ~((CONVERT(BIT, IIF(`x` = 1.0, 1.0, 0.0)))) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = !(x != 1)) %>% show_query(),
+    sql("SELECT ~((CONVERT(BIT, IIF(`x` != 1.0, 1.0, 0.0)))) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = !(x > 1)) %>% show_query(),
+    sql("SELECT ~((CONVERT(BIT, IIF(`x` > 1.0, 1.0, 0.0)))) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = !(x >= 1)) %>% show_query(),
+    sql("SELECT ~((CONVERT(BIT, IIF(`x` >= 1.0, 1.0, 0.0)))) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = x > 4 & x < 5) %>% show_query(),
+    sql("SELECT CONVERT(BIT, IIF(`x` > 4.0, 1.0, 0.0)) & CONVERT(BIT, IIF(`x` < 5.0, 1.0, 0.0)) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% filter(x > 4 & x < 5) %>% show_query(),
+    sql("SELECT *\nFROM `df`\nWHERE (`x` > 4.0 AND `x` < 5.0)")
+  )
+
+  expect_equal(
+    mf %>% mutate(x = x > 4 | x < 5) %>% show_query(),
+    sql("SELECT CONVERT(BIT, IIF(`x` > 4.0, 1.0, 0.0)) | CONVERT(BIT, IIF(`x` < 5.0, 1.0, 0.0)) AS `x`\nFROM `df`")
+  )
+
+  expect_equal(
+    mf %>% filter(x > 4 | x < 5) %>% show_query(),
+    sql("SELECT *\nFROM `df`\nWHERE (`x` > 4.0 OR `x` < 5.0)")
+  )
+
 })
 

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -69,12 +69,12 @@ test_that("filter and mutate translate is.na correctly", {
 
   expect_equal(
     mf %>% mutate(z = is.na(x)) %>% show_query(),
-    sql("SELECT `x`, CONVERT(BIT, IIF(`x` IS NULL, 1, 0)) AS `z`\nFROM `df`")
+    sql("SELECT `x`, CONVERT(BIT, `x`) AS `z`\nFROM `df`")
   )
 
   expect_equal(
     mf %>% mutate(z = !is.na(x)) %>% show_query(),
-    sql("SELECT `x`, CONVERT(BIT, IIF(`x` IS NULL, 0, 1)) AS `z`\nFROM `df`")
+    sql("SELECT `x`, ~(CONVERT(BIT, `x`)) AS `z`\nFROM `df`")
   )
 
   expect_equal(


### PR DESCRIPTION
The new solution uses `~` for SELECT clauses and `NOT` for WHERE clauses.  It uses the `sql_currentcontext()` function to switch between the two.  

Here are the tests that worked: 

```
db_mtcars %>%
  mutate(x = !is.na(mpg))

db_mtcars %>%
  arrange(!is.na(mpg))

db_mtcars %>%
  group_by(!is.na(mpg))  %>%
  tally()

db_mtcars %>%
  filter(!is.na(mpg))

db_mtcars %>%
  filter(am != 0)

db_mtcars %>%
  filter(!am == 0)

db_mtcars %>%
  filter(!mpg < 30 )

db_mtcars %>%
  filter(!mpg < 30 | !cyl < 8 )

db_mtcars %>%
  filter(!mpg >= 30 )

db_mtcars %>%
  filter(!mpg == 21 )

db_mtcars %>%
  filter(mpg != 21 )
```

These didn't 
```
db_mtcars %>%
  mutate(x = am != 0) %>%
  show_query()

db_mtcars %>%
  mutate(x = (am == 0)) %>%
  show_query()
```