### PR TITLE
Fixes ifelse after is.na eval change

### DIFF
--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -224,15 +224,15 @@ mssql_generic_infix <- function(if_select, if_filter) {
 
 mssql_sql_if <- function(cond, if_true, if_false = NULL) {
   build_sql(
-    "CASE WHEN ((", cond, ") =  'TRUE')", " THEN (", if_true, ")",
-    if (!is.null(if_false)){
-      build_sql(" ELSE (", if_false, ")")
-    } else {
-      build_sql(" ELSE ('')")
-    }
-      ,
-    " END"
-  )
+     "CASE",
+     " WHEN ((", cond, ") =  'TRUE')", " THEN (", if_true, ")",
+     if (!is.null(if_false)){
+       build_sql(" WHEN ((", cond, ") =  'FALSE')", " THEN (", if_false, ")")
+     } else {
+       build_sql(" ELSE ('')")
+     },
+     " END"
+     )
 }
 
 globalVariables(c("BIT", "%is%", "convert", "iif"))

--- a/R/db-odbc-mssql.R
+++ b/R/db-odbc-mssql.R
@@ -54,6 +54,10 @@
       `|`            = mssql_generic_infix("|", "OR"),
       `||`           = mssql_generic_infix("|", "OR"),
 
+      `if`           = mssql_sql_if,
+      if_else        = function(condition, true, false) mssql_sql_if(condition, true, false),
+      ifelse         = function(test, yes, no) mssql_sql_if(test, yes, no),
+
       as.numeric    = sql_cast("NUMERIC"),
       as.double     = sql_cast("NUMERIC"),
       as.character  = sql_cast("VARCHAR(MAX)"),
@@ -216,6 +220,19 @@ mssql_generic_infix <- function(if_select, if_filter) {
     }
     build_sql(x, " ", sql(f), " ", y)
   }
+}
+
+mssql_sql_if <- function(cond, if_true, if_false = NULL) {
+  build_sql(
+    "CASE WHEN ((", cond, ") =  'TRUE')", " THEN (", if_true, ")",
+    if (!is.null(if_false)){
+      build_sql(" ELSE (", if_false, ")")
+    } else {
+      build_sql(" ELSE ('')")
+    }
+      ,
+    " END"
+  )
 }
 
 globalVariables(c("BIT", "%is%", "convert", "iif"))

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -142,5 +142,11 @@ test_that("filter and mutate translate is.na correctly", {
     sql("SELECT *\nFROM `df`\nWHERE (`x` > 4.0 OR `x` < 5.0)")
   )
 
+  expect_equal(
+    mf %>% mutate(x = ifelse(x == 0, 0 ,1)) %>% show_query(),
+    sql("SELECT CASE WHEN ((CONVERT(BIT, IIF(`x` = 0.0, 1.0, 0.0))) =  'TRUE') THEN (0.0) ELSE (1.0) END AS `x`\nFROM `df`")
+  )
+
+
 })
 

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -144,9 +144,7 @@ test_that("filter and mutate translate is.na correctly", {
 
   expect_equal(
     mf %>% mutate(x = ifelse(x == 0, 0 ,1)) %>% show_query(),
-    sql("SELECT CASE WHEN ((CONVERT(BIT, IIF(`x` = 0.0, 1.0, 0.0))) =  'TRUE') THEN (0.0) ELSE (1.0) END AS `x`\nFROM `df`")
+    sql("SELECT CASE WHEN ((CONVERT(BIT, IIF(`x` = 0.0, 1.0, 0.0))) =  'TRUE') THEN (0.0) WHEN ((CONVERT(BIT, IIF(`x` = 0.0, 1.0, 0.0))) =  'FALSE') THEN (1.0) END AS `x`\nFROM `df`")
   )
-
-
 })
 


### PR DESCRIPTION
Changes exclusive to MS SQL

- Adds custom a custom `mssql_is_na()` function that equates `cond` to TRUE so that CASE/WHEN works properly.  Because the options are binary, the False/No test is simplified to use ELSE
- Add custom to `if`, `ifelse` and `if_else` 
- Add tests 

Used same tests as https://github.com/tidyverse/dbplyr/pull/51 to confirm nothing originally fixed broke, and also tested these sucesfully:

```
db_mtcars %>%
  group_by(x = ifelse(mpg < 20, "good", "bad")) %>%
  select(mpg, x)

db_mtcars %>%
  group_by(x = if_else(mpg < 20, "good", "bad")) %>%
  select(mpg, x)

db_mtcars %>%
  mutate(x = ifelse(mpg <= 20 & am == 0, "good", "bad"))
```