### PR TITLE
Don't use on tbl_left.x = tbl_right.y when doing cross join

### DIFF
--- a/R/sql-generic.R
+++ b/R/sql-generic.R
@@ -63,7 +63,7 @@ sql_join.DBIConnection <- function(con, x, y, vars, type = "inner", by = NULL, .
     "SELECT ", select, "\n",
     "  FROM ", x, "\n",
     "  ", JOIN, " ", y, "\n",
-    if (!is.null(on)) build_sql("  ON ", on, "\n") else NULL,
+    if (!is.null(on) & type != 'cross') build_sql("  ON ", on, "\n") else NULL,
     con = con
   )
 }


### PR DESCRIPTION
It fails on SQL databases, should just ignore the [on ....] part of the query if it's a cross join