### PR TITLE
Adding integer64 support to escape() function

### DIFF
--- a/R/sql-escape.r
+++ b/R/sql-escape.r
@@ -91,6 +91,13 @@ escape.integer <- function(x, parens = NA, collapse = ", ", con = NULL) {
 }
 
 #' @export
+escape.integer64 <- function(x, parens = NA, collapse = ", ", con = NULL) {
+  x <- x %>% as.character
+  x[is.na(x)] <- "NULL"
+  sql_vector(x, parens, collapse)
+}
+
+#' @export
 escape.NULL <- function(x, parens = NA, collapse = " ", con = NULL) {
   sql("NULL")
 }


### PR DESCRIPTION
`integer64` vectors are converted to character and then passed to sql_vector.
Fixes tidyverse/dplyr#3230