### PR TITLE
escaping for integer64

### DIFF
--- a/R/sql-escape.r
+++ b/R/sql-escape.r
@@ -91,6 +91,9 @@ escape.integer <- function(x, parens = NA, collapse = ", ", con = NULL) {
 }
 
 #' @export
+escape.integer64 <- escape.integer
+
+#' @export
 escape.NULL <- function(x, parens = NA, collapse = " ", con = NULL) {
   sql("NULL")
 }


### PR DESCRIPTION
This is for enabling `integer64` support on queries. Useful for filtering on `bigint` primary keys. On its absence, this is the error:

```r
int64
#> integer64
#> [1] 223743292
dplyr::filter(postgresql_table, id == !!int64)
#> Error in UseMethod("escape") : 
#>  no applicable method for 'escape' applied to an object of class "integer64"
```