### PR TITLE
Teradata not equal fix

### DIFF
--- a/R/db-odbc-teradata.R
+++ b/R/db-odbc-teradata.R
@@ -39,6 +39,7 @@ sql_select.Teradata <- function(con, select, from, where = NULL,
 sql_translate_env.Teradata <- function(con) {
   sql_variant(
     sql_translator(.parent = base_odbc_scalar,
+      `!=`          = sql_infix("<>"),
       as.numeric    = sql_cast("NUMERIC"),
       as.double     = sql_cast("NUMERIC"),
       as.character  = sql_cast("VARCHAR(MAX)"),

--- a/tests/testthat/test-translate-teradata.r
+++ b/tests/testthat/test-translate-teradata.r
@@ -7,6 +7,7 @@ test_that("custom scalar translated correctly", {
     translate_sql(!!enquo(x), con = simulate_teradata())
   }
 
+  expect_equal(trans(x != y),          sql("`x` <> `y`"))
   expect_equal(trans(as.numeric(x)),   sql("CAST(`x` AS NUMERIC)"))
   expect_equal(trans(as.double(x)),    sql("CAST(`x` AS NUMERIC)"))
   expect_equal(trans(as.character(x)), sql("CAST(`x` AS VARCHAR(MAX))"))


### PR DESCRIPTION
- Fixes Teradata translation issue for `!=` operators, it now translates to `<>`. Reported by @weixing777.
- Adds a test for the change