### PR TITLE
Update db-sqlite.r

### DIFF
--- a/R/db-sqlite.r
+++ b/R/db-sqlite.r
@@ -17,6 +17,8 @@ sqlite_version <- function() {
 sql_translate_env.SQLiteConnection <- function(con) {
   sql_variant(
     sql_translator(.parent = base_scalar,
+      as.numeric = sql_cast("REAL"),
+      as.double = sql_cast("REAL"),
       log     = function(x, base = exp(1)) {
         if (base != exp(1)) {
           sql_expr(log(!!x) / log(!!base))


### PR DESCRIPTION
`as.numeric()` and `as.double()` on integer columns don't seem to work on SQLite. It looks like SQLite only has two numeric storage classes: `INTEGER` and `REAL`. See the [SQLite website](https://www.sqlite.org/datatype3.html).