### PR TITLE
Switches to substring and adds test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr 1.2.1.9000
 
+* Redshift `substr()` compatibility issue resolved (#3339)
+
 # dbplyr 1.2.1
 
 * Forward compatibility fixes for rlang 0.2.0

--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -54,6 +54,11 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
       grepl  = postgres_grepl,
       paste  = sql_paste(" "),
       paste0 = sql_paste(""),
+      substr = function(x, start, stop){
+        len <- stop - start + 1
+        build_sql(
+          "SUBSTRING(", x, ", ", start, ", ", len, ")"
+        )},
       # stringr functions
       str_locate  = function(string, pattern) {
         sql_expr(strpos(!!string, !!pattern))

--- a/tests/testthat/test-translate-postgresql.R
+++ b/tests/testthat/test-translate-postgresql.R
@@ -13,6 +13,7 @@ test_that("custom scalar translated correctly", {
   expect_equal(trans(round(x, digits = 1.1)), sql("ROUND((`x`) :: numeric, 1)"))
   expect_equal(trans(grepl("exp", x)),        sql("(`x`) ~ ('exp')"))
   expect_equal(trans(grepl("exp", x, TRUE)),  sql("(`x`) ~* ('exp')"))
+  expect_equal(trans(substr("test", 2 , 3)),  sql("SUBSTRING('test', 2.0, 2.0)"))
 })
 
 


### PR DESCRIPTION
Fixes https://github.com/tidyverse/dplyr/issues/3339

- It overrides `substr` in the PostgreSQL translation. It now uses `substring` which will work both in PostgreSQL and Redshift