### PR TITLE
fix sql translation of %in% with empty vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dbplyr 1.2.1.9000
 
-* sql translation of `%in%` now works with empty vectors (@mgirlich)
+* the statement `x %in% y` is now translated to `FALSE`. (@mgirlich)
 
 # dbplyr 1.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dbplyr 1.2.1.9000
 
-* the statement `x %in% y` is now translated to `FALSE`. (@mgirlich)
+* the statement `x %in% y` is now translated to `FALSE` (@mgirlich, #160).
 
 # dbplyr 1.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr 1.2.1.9000
 
+* sql translation of `%in%` now works with empty vectors (@mgirlich)
+
 # dbplyr 1.2.1
 
 * Forward compatibility fixes for rlang 0.2.0

--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -53,6 +53,8 @@ base_scalar <- sql_translator(
   `%in%` = function(x, table) {
     if (is.sql(table) || length(table) > 1) {
       build_sql(x, " IN ", table)
+    } else if (length(table) == 0) {
+      build_sql(FALSE)
     } else {
       build_sql(x, " IN (", table, ")")
     }

--- a/tests/testthat/test-translate.r
+++ b/tests/testthat/test-translate.r
@@ -66,7 +66,6 @@ test_that("%in% translation parenthesises when needed", {
 })
 
 test_that("%in% with empty vector", {
-  expect_equal(translate_sql(x %in% !!c()), sql('FALSE'))
   expect_equal(translate_sql(x %in% !!integer()), sql('FALSE'))
 })
 

--- a/tests/testthat/test-translate.r
+++ b/tests/testthat/test-translate.r
@@ -65,6 +65,11 @@ test_that("%in% translation parenthesises when needed", {
   expect_equal(translate_sql(x %in% y), sql('"x" IN "y"'))
 })
 
+test_that("%in% with empty vector", {
+  expect_equal(translate_sql(x %in% !!c()), sql('FALSE'))
+  expect_equal(translate_sql(x %in% !!integer()), sql('FALSE'))
+})
+
 test_that("n_distinct can take multiple values", {
   expect_equal(
     translate_sql(n_distinct(x), window = FALSE),


### PR DESCRIPTION
Before the PR we have the following translation

```
dbplyr::translate_sql(col %in% !!c())
<SQL> "col" IN ()
```

which isn't valid SQL. With this PR this is simply translated to FALSE

```
dbplyr::translate_sql(col %in% !!c())
<SQL> FALSE
```

Closes tidyverse/dplyr#3375.