### PR TITLE
Simplify join_vars()

### DIFF
--- a/R/sql-query.R
+++ b/R/sql-query.R
@@ -71,7 +71,7 @@ join_query <- function(x, y, vars, type = "inner", by = NULL, suffix = c(".x", "
 
 
 # Returns NULL if variables don't need to be renamed
-join_vars <- function(x_names, y_names, type, by, suffix = c(".x", ".y")) {
+join_vars <- function(x_names, y_names, by, suffix = c(".x", ".y")) {
   # Remove join keys from y
   y_names <- setdiff(y_names, by$y)
 
@@ -80,13 +80,8 @@ join_vars <- function(x_names, y_names, type, by, suffix = c(".x", ".y")) {
   x_new <- add_suffixes(x_names, y_names, suffix$x)
   y_new <- add_suffixes(y_names, x_names, suffix$y)
 
-  # In left and inner joins, return key values only from x
-  # In right joins, return key values only from y
-  # In full joins, return key values by coalescing values from x and y
   x_x <- x_names
   x_y <- by$y[match(x_names, by$x)]
-  x_y[type == "left" | type == "inner"] <- NA
-  x_x[type == "right" & !is.na(x_y)] <- NA
   y_x <- rep_len(NA, length(y_names))
   y_y <- y_names
 

--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -225,7 +225,7 @@ add_op_join <- function(x, y, type, by = NULL, copy = FALSE,
     indexes = if (auto_index) list(by$y)
   )
 
-  vars <- join_vars(op_vars(x), op_vars(y), type = type, by = by, suffix = suffix)
+  vars <- join_vars(op_vars(x), op_vars(y), by = by, suffix = suffix)
 
   x$ops <- op_double("join", x, y, args = list(
     vars = vars,


### PR DESCRIPTION
I'd like to make the definition of the results of a join consistent between dplyr and dbplyr, in the context of https://github.com/tidyverse/dplyr/issues/3307. I don't understand why we need to pass the join type, tests seem to pass locally without it.