### PR TITLE
Fixes instr order for default translation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr 1.2.1.9000
 
+* Fixes default parameter order for the `str_detect()` translation (#3397)
+
 * Redshift `substr()` compatibility issue resolved (#3339)
 
 # dbplyr 1.2.1

--- a/R/translate-sql-base.r
+++ b/R/translate-sql-base.r
@@ -167,7 +167,7 @@ base_scalar <- sql_translator(
                       )},
   str_detect      = function(string, pattern){
                       build_sql(
-                        "INSTR(", pattern, ", ", string, ") > 0"
+                        "INSTR(", string, ", ", pattern, ") > 0"
                       )},
   str_trim        = function(string, side = "both"){
                       build_sql(

--- a/tests/testthat/test-translate.r
+++ b/tests/testthat/test-translate.r
@@ -81,7 +81,7 @@ test_that("na_if is translated to NULL_IF", {
 })
 
 test_that("connection affects quoting character", {
-  dbTest <- src_sql("test", con = simulate_db())
+  dbTest <- src_sql("test", con = simulate_test())
   testTable <- tbl_sql("test", src = dbTest, from = ident("table1"))
 
   out <- select(testTable, field1)

--- a/tests/testthat/test-translate.r
+++ b/tests/testthat/test-translate.r
@@ -81,7 +81,7 @@ test_that("na_if is translated to NULL_IF", {
 })
 
 test_that("connection affects quoting character", {
-  dbTest <- src_sql("test", con = simulate_test())
+  dbTest <- src_sql("test", con = simulate_db())
   testTable <- tbl_sql("test", src = dbTest, from = ident("table1"))
 
   out <- select(testTable, field1)
@@ -136,7 +136,7 @@ test_that("str_detect() translates correctly ", {
   expect_equivalent(
     translate_sql(
       str_detect(field_name, "pattern")),
-      sql("INSTR('pattern', \"field_name\") > 0"))
+      sql("INSTR(\"field_name\", 'pattern') > 0"))
 })
 
 test_that("str_trim() translates correctly ", {


### PR DESCRIPTION
Fixes https://github.com/tidyverse/dplyr/issues/3397

Notes:

- Tested it against an Oracle and SQLite connections
- Re-tested the MS SQL custom translation and found that it needed no changes