### PR TITLE
Fix link to dbplyr own issue board

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: A 'dplyr' back end for databases that allows you to work with
     require 'SQL' translation to be provided by the package author.
 License: MIT + file LICENSE
 URL: https://github.com/tidyverse/dbplyr
-BugReports: https://github.com/tidyverse/dplyr/issues
+BugReports: https://github.com/tidyverse/dbplyr/issues
 Depends: 
     R (>= 3.1)
 Imports: 


### PR DESCRIPTION
This fixes #136. 

There was still a link to report bug to dplyr issue board instead of dbplyr one. 

I think the fix in DESCRIPTION will also fix the package documentation
https://github.com/tidyverse/dbplyr/blob/79d2a0377561ad57f67a65b914ce3195d10de0be/man/dbplyr-package.Rd#L18

There is still the website to update, but I believe it is a separate process with another timeframe, so I did not PR anything on this.