### PR TITLE
Fixed SQL typo in src_dbi help.

### DIFF
--- a/R/src_dbi.R
+++ b/R/src_dbi.R
@@ -46,7 +46,7 @@
 #' src %>% tbl("mtcars")
 #'
 #' # You can also use pass raw SQL if you want a more sophisticated query
-#' src %>% tbl(sql("SELECT * FROM mtcars WHERE cyl == 8"))
+#' src %>% tbl(sql("SELECT * FROM mtcars WHERE cyl = 8"))
 #'
 #' # Alternatively, you can use the `src_sqlite()` helper
 #' src2 <- src_sqlite(":memory:", create = TRUE)

--- a/man/src_dbi.Rd
+++ b/man/src_dbi.Rd
@@ -66,7 +66,7 @@ DBI::dbListTables(con)
 src \%>\% tbl("mtcars")
 
 # You can also use pass raw SQL if you want a more sophisticated query
-src \%>\% tbl(sql("SELECT * FROM mtcars WHERE cyl == 8"))
+src \%>\% tbl(sql("SELECT * FROM mtcars WHERE cyl = 8"))
 
 # Alternatively, you can use the `src_sqlite()` helper
 src2 <- src_sqlite(":memory:", create = TRUE)


### PR DESCRIPTION
"SELECT * FROM mtcars WHERE cyl == 8" corrected to "SELECT * FROM mtcars WHERE cyl = 8". I don't know why the diff is showing such a huge change. This is my first PR to a package, I apologize for any strangeness!