### PR TITLE
Generic joins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
 
 * New `tbl_memdb()` for creating reprexes (to match `tbl_lazy()`)
 
+* All `..._join()` methods gain an `sql_on` argument that allows specifying
+  arbitrary join predicates in SQL code (#146, @krlmlr).
+
 * ORACLE: New custom translation for `paste()` and `paste0()` (@cderv, #221)
 
 * `sql_prefix()` no longer turns SQL functions into uppercase, allowing for correct translation of case-sensitive SQL functions (#181, @mtoto).

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -118,6 +118,8 @@ sql_join_tbls <- function(con, by) {
       parens = TRUE,
       con = con
     )
+  } else if (length(by$on) > 0) {
+    on <- build_sql("(", by$on, ")", con = con)
   }
 
   on

--- a/man/join.tbl_sql.Rd
+++ b/man/join.tbl_sql.Rd
@@ -11,22 +11,22 @@
 \title{Join sql tbls.}
 \usage{
 \method{inner_join}{tbl_lazy}(x, y, by = NULL, copy = FALSE,
-  suffix = c(".x", ".y"), auto_index = FALSE, ...)
+  suffix = c(".x", ".y"), auto_index = FALSE, ..., sql_on = NULL)
 
 \method{left_join}{tbl_lazy}(x, y, by = NULL, copy = FALSE,
-  suffix = c(".x", ".y"), auto_index = FALSE, ...)
+  suffix = c(".x", ".y"), auto_index = FALSE, ..., sql_on = NULL)
 
 \method{right_join}{tbl_lazy}(x, y, by = NULL, copy = FALSE,
-  suffix = c(".x", ".y"), auto_index = FALSE, ...)
+  suffix = c(".x", ".y"), auto_index = FALSE, ..., sql_on = NULL)
 
 \method{full_join}{tbl_lazy}(x, y, by = NULL, copy = FALSE,
-  suffix = c(".x", ".y"), auto_index = FALSE, ...)
+  suffix = c(".x", ".y"), auto_index = FALSE, ..., sql_on = NULL)
 
 \method{semi_join}{tbl_lazy}(x, y, by = NULL, copy = FALSE,
-  auto_index = FALSE, ...)
+  auto_index = FALSE, ..., sql_on = NULL)
 
 \method{anti_join}{tbl_lazy}(x, y, by = NULL, copy = FALSE,
-  auto_index = FALSE, ...)
+  auto_index = FALSE, ..., sql_on = NULL)
 }
 \arguments{
 \item{x}{tbls to join}
@@ -63,6 +63,10 @@ there are matching indexes in \code{x}.}
 
 \item{...}{other parameters passed onto methods, for instance, \code{na_matches}
 to control how \code{NA} values are matched.  See \link{join.tbl_df} for more.}
+
+\item{sql_on}{A custom join predicate as an SQL expression. The SQL
+can refer to the \code{LHS} and \code{RHS} aliases to disambiguate
+column names.}
 }
 \description{
 See \link{join} for a description of the general purpose of the
@@ -72,9 +76,13 @@ functions.
 
 
 Semi-joins are implemented using \code{WHERE EXISTS}, and anti-joins with
-\code{WHERE NOT EXISTS}. Support for semi-joins is somewhat partial: you
-can only create semi joins where the \code{x} and \code{y} columns are
-compared with \code{=} not with more general operators.
+\code{WHERE NOT EXISTS}.
+
+All joins use column equality by default.
+An arbitrary join predicate can be specified by passing
+an SQL expression to the \code{sql_on} argument.
+Use \code{LHS} and \code{RHS} to refer to the left-hand side or
+right-hand side table, respectively.
 }
 
 \examples{
@@ -129,6 +137,19 @@ explain(famous_manager)
 
 # batters without person covariates
 anti_join(batting, people)
+
+# Arbitrary predicates ------------------------------------------------------
+
+# Find all pairs of awards given to the same player
+# with at least 18 years between the awards:
+awards_players <- tbl(lahman_s, "AwardsPlayers")
+inner_join(
+  awards_players, awards_players,
+  sql_on = paste0(
+    "(LHS.playerID = RHS.playerID) AND ",
+    "(LHS.yearID < RHS.yearID - 18)"
+  )
+)
 }
 }
 }

--- a/tests/testthat/sql/join-on.sql
+++ b/tests/testthat/sql/join-on.sql
@@ -1,0 +1,32 @@
+$inner
+<SQL>
+SELECT `LHS`.`x` AS `x.x`, `LHS`.`y` AS `y`, `RHS`.`x` AS `x.y`, `RHS`.`z` AS `z`
+FROM `df` AS `LHS`
+INNER JOIN `df` AS `RHS`
+ON (LHS.y < RHS.z)
+
+
+$left
+<SQL>
+SELECT `LHS`.`x` AS `x.x`, `LHS`.`y` AS `y`, `RHS`.`x` AS `x.y`, `RHS`.`z` AS `z`
+FROM `df` AS `LHS`
+LEFT JOIN `df` AS `RHS`
+ON (LHS.y < RHS.z)
+
+
+$right
+<SQL>
+SELECT `LHS`.`x` AS `x.x`, `LHS`.`y` AS `y`, `RHS`.`x` AS `x.y`, `RHS`.`z` AS `z`
+FROM `df` AS `LHS`
+RIGHT JOIN `df` AS `RHS`
+ON (LHS.y < RHS.z)
+
+
+$full
+<SQL>
+SELECT `LHS`.`x` AS `x.x`, `LHS`.`y` AS `y`, `RHS`.`x` AS `x.y`, `RHS`.`z` AS `z`
+FROM `df` AS `LHS`
+FULL JOIN `df` AS `RHS`
+ON (LHS.y < RHS.z)
+
+

--- a/tests/testthat/test-query-join.R
+++ b/tests/testthat/test-query-join.R
@@ -18,3 +18,15 @@ test_that("generated sql doesn't change unexpectedly", {
   )
   expect_known_output(print(reg), test_path("sql/join.sql"))
 })
+
+test_that("sql_on query doesn't change unexpectedly", {
+  lf1 <- lazy_frame(x = 1, y = 2)
+  lf2 <- lazy_frame(x = 1, z = 3)
+  reg <- list(
+    inner = inner_join(lf1, lf2, sql_on = "LHS.y < RHS.z"),
+    left = left_join(lf1, lf2, sql_on = "LHS.y < RHS.z"),
+    right = right_join(lf1, lf2, sql_on = "LHS.y < RHS.z"),
+    full = full_join(lf1, lf2, sql_on = "LHS.y < RHS.z")
+  )
+  expect_known_output(print(reg), test_path("sql/join-on.sql"))
+})

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -27,6 +27,20 @@ test_that("join with both same and different vars", {
   expect_equal(names(j1), c("x", "y"))
 })
 
+test_that("joining over arbitrary predicates", {
+  j1 <- collect(left_join(df1, df2, sql_on = "LHS.x = RHS.b"))
+  j2 <- collect(left_join(df1, df2, by = c("x" = "b"))) %>% mutate(b = x)
+  expect_equal(j1, j2)
+
+  j1 <- collect(left_join(df1, df3, sql_on = "LHS.x = RHS.z"))
+  j2 <- collect(left_join(df1, df3, by = c("x" = "z"))) %>% mutate(z = x.x)
+  expect_equal(j1, j2)
+
+  j1 <- collect(left_join(df1, df3, sql_on = "LHS.x = RHS.x"))
+  j2 <- collect(left_join(df1, df3, by = "x")) %>% mutate(x.y = x) %>% rename(x.x = x)
+  expect_equal(j1, j2)
+})
+
 test_that("inner join doesn't result in duplicated columns ", {
   expect_equal(colnames(inner_join(df1, df1)), c("x", "y"))
 })


### PR DESCRIPTION
Proposing a syntax to pass arbitrary join predicates, e.g. for working with spatial data on the database. Needs a test.

``` r
library(tidyverse)
library(dbplyr)
#> 
#> Attaching package: 'dbplyr'
#> The following objects are masked from 'package:dplyr':
#> 
#>     ident, sql

tbl1 <- memdb_frame(a = 1:3, b = 4:2)
tbl2 <- memdb_frame(c = 1:3, b = 2:0)

tbl12 <- left_join(tbl1, tbl2, by = sql("TBL_LEFT.b < TBL_RIGHT.c"))
tbl12 %>% sql_render()
#> <SQL> SELECT `TBL_LEFT`.`a` AS `a`, `TBL_LEFT`.`b` AS `b.x`, `TBL_RIGHT`.`c` AS `c`, `TBL_RIGHT`.`b` AS `b.y`
#>   FROM `ygyjgeeqdc` AS `TBL_LEFT`
#>   LEFT JOIN `urhwkxzyib` AS `TBL_RIGHT`
#>   ON (TBL_LEFT.b < TBL_RIGHT.c)
tbl12
#> # Source:   lazy query [?? x 4]
#> # Database: sqlite 3.22.0 [:memory:]
#>       a   b.x     c   b.y
#>   <int> <int> <int> <int>
#> 1     1     4    NA    NA
#> 2     2     3    NA    NA
#> 3     3     2     3     0
```

> Created on 2018-08-23 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).