### PR TITLE
as.double should cast to double precision

### DIFF
--- a/R/db-postgres.r
+++ b/R/db-postgres.r
@@ -47,6 +47,7 @@ postgres_round <- function(x, digits = 0L) {
 sql_translate_env.PostgreSQLConnection <- function(con) {
   sql_variant(
     sql_translator(.parent = base_scalar,
+      as.double = sql_cast('DOUBLE PRECISION'),
       log10  = function(x) sql_expr(log(!!x)),
       log    = sql_log(),
       cot    = sql_cot(),


### PR DESCRIPTION
Currently, `as.double` casts to NUMERIC. This leads to an issue in PostGreSQL where aggregate functions like `mean` return integers rather than doubles. This behavior is consistent with the [docs]( https://www.postgresql.org/docs/10/static/datatype-numeric.html), since `NUMERIC` fields need a scale that defaults to 0 for integers.

This PR switches `as.double` to cast to `DOUBLE PRECISION`. Given that there is already an `as.numeric` that casts to `NUMERIC`, I believe this should be alright.