### PR TITLE
Avoid explicit over() translation when translating SQL

### DIFF
--- a/R/translate-sql-window.r
+++ b/R/translate-sql-window.r
@@ -58,8 +58,13 @@ win_over <- function(expr, partition = NULL, order = NULL, frame = NULL) {
     frame <- build_sql("ROWS ", frame)
   }
 
-  over <- sql_vector(compact(list(partition, order, frame)), parens = TRUE)
-  sql <- build_sql(expr, " OVER ", over)
+  if (length(partition) > 0 || length(order) > 0 || length(frame) > 0 || getOption("dplyr.explicit.over", FALSE)) {
+    over <- sql_vector(compact(list(partition, order, frame)), parens = TRUE)
+    sql <- build_sql(expr, " OVER ", over)
+  }
+  else {
+    sql <- build_sql(expr)
+  }
 
   sql
 }

--- a/tests/testthat/test-translate-mssql.r
+++ b/tests/testthat/test-translate-mssql.r
@@ -52,8 +52,8 @@ test_that("custom window functions translated correctly", {
     translate_sql(!!enquo(x), window = TRUE, con = simulate_mssql())
   }
 
-  expect_equal(trans(sd(x, na.rm = TRUE)),  sql("STDEV(`x`) OVER ()"))
-  expect_equal(trans(var(x, na.rm = TRUE)), sql("VAR(`x`) OVER ()"))
+  expect_equal(trans(sd(x, na.rm = TRUE)),  sql("STDEV(`x`)"))
+  expect_equal(trans(var(x, na.rm = TRUE)), sql("VAR(`x`)"))
 
   expect_error(trans(cor(x)), "not supported")
   expect_error(trans(cov(x)), "not supported")

--- a/tests/testthat/test-translate-odbc.R
+++ b/tests/testthat/test-translate-odbc.R
@@ -44,10 +44,10 @@ test_that("custom window functions translated correctly", {
     translate_sql(!!enquo(x), window = TRUE, con = simulate_odbc("OdbcConnection"))
   }
 
-  expect_equal(trans(sd(x, na.rm = TRUE)),         sql("STDDEV_SAMP(`x`) OVER ()"))
-  expect_equal(trans(count()),       sql("COUNT(*) OVER ()"))
-  expect_equal(trans(n()),           sql("COUNT(*) OVER ()"))
-  expect_equal(trans(n_distinct(x)), sql("COUNT(DISTINCT `x`) OVER ()"))
+  expect_equal(trans(sd(x, na.rm = TRUE)),         sql("STDDEV_SAMP(`x`)"))
+  expect_equal(trans(count()),       sql("COUNT(*)"))
+  expect_equal(trans(n()),           sql("COUNT(*)"))
+  expect_equal(trans(n_distinct(x)), sql("COUNT(DISTINCT `x`)"))
 
 
 })

--- a/tests/testthat/test-translate-postgresql.R
+++ b/tests/testthat/test-translate-postgresql.R
@@ -34,7 +34,7 @@ test_that("two variable aggregates are translated correctly", {
   }
 
   expect_equal(trans(cor(x, y), window = FALSE), sql("CORR(`x`, `y`)"))
-  expect_equal(trans(cor(x, y), window = TRUE),  sql("CORR(`x`, `y`) OVER ()"))
+  expect_equal(trans(cor(x, y), window = TRUE),  sql("CORR(`x`, `y`)"))
 
 })
 

--- a/tests/testthat/test-translate-teradata.r
+++ b/tests/testthat/test-translate-teradata.r
@@ -41,7 +41,7 @@ test_that("custom window functions translated correctly", {
     translate_sql(!!enquo(x), window = TRUE, con = simulate_teradata())
   }
 
-  expect_equal(trans(var(x, na.rm = TRUE)), sql("VAR_SAMP(`x`) OVER ()"))
+  expect_equal(trans(var(x, na.rm = TRUE)), sql("VAR_SAMP(`x`)"))
 
   expect_error(trans(cor(x)), "not supported")
   expect_error(trans(cov(x)), "not supported")

--- a/tests/testthat/test-translate-window.R
+++ b/tests/testthat/test-translate-window.R
@@ -1,18 +1,18 @@
 context("translate-window")
 
 test_that("window functions without group have empty over", {
-  expect_equal(translate_sql(n()), sql("COUNT(*) OVER ()"))
-  expect_equal(translate_sql(sum(x, na.rm = TRUE)), sql('sum("x") OVER ()'))
+  expect_equal(translate_sql(n()), sql("COUNT(*)"))
+  expect_equal(translate_sql(sum(x, na.rm = TRUE)), sql('sum("x")'))
 })
 
 test_that("aggregating window functions ignore order_by", {
   expect_equal(
     translate_sql(n(), vars_order = "x"),
-    sql("COUNT(*) OVER ()")
+    sql("COUNT(*)")
   )
   expect_equal(
     translate_sql(sum(x, na.rm = TRUE), vars_order = "x"),
-    sql('sum("x") OVER ()')
+    sql('sum("x")')
   )
 })
 
@@ -36,9 +36,9 @@ test_that("ntile always casts to integer", {
 })
 
 test_that("first, last, and nth translated to _value", {
-  expect_equal(translate_sql(first(x)), sql('first_value("x") OVER ()'))
-  expect_equal(translate_sql(last(x)), sql('last_value("x") OVER ()'))
-  expect_equal(translate_sql(nth(x, 1)), sql('nth_value("x", 1) OVER ()'))
+  expect_equal(translate_sql(first(x)), sql('first_value("x")'))
+  expect_equal(translate_sql(last(x)), sql('last_value("x")'))
+  expect_equal(translate_sql(nth(x, 1)), sql('nth_value("x", 1)'))
 })
 
 

--- a/tests/testthat/test-win_over.R
+++ b/tests/testthat/test-win_over.R
@@ -1,7 +1,7 @@
 context("win_over")
 
 test_that("over() only requires first argument", {
-  expect_equal(win_over("X"), sql("'X' OVER ()"))
+  expect_equal(win_over("X"), sql("'X'"))
 })
 
 test_that("multiple group by or order values don't have parens", {
@@ -19,7 +19,7 @@ test_that("connection affects quoting window function fields", {
   old <- set_current_con(simulate_test())
   on.exit(set_current_con(old))
 
-  expect_equal(win_over(ident("x")), sql("`x` OVER ()"))
+  expect_equal(win_over(ident("x")), sql("`x`"))
   expect_equal(
     win_over(ident("x"), partition = "x"),
     sql("`x` OVER (PARTITION BY `x`)")


### PR DESCRIPTION
Fix for https://github.com/tidyverse/dbplyr/issues/178, some SQL engines, like Spark, treat `OVER()` as a hint to process data differently. In general, I believe generating the minimal SQL statement required to perform an operation makes the most sense; however, I'm not sure if somehow, other SQL engines might require `OVER()` to be explicitly added, I wouldn't think so, but just in case, added a `dplyr.explicit.over` to revert this fix.

CC: @edgararuiz