### PR TITLE
Fix parameter name in vignette

### DIFF
--- a/vignettes/dbplyr.Rmd
+++ b/vignettes/dbplyr.Rmd
@@ -59,7 +59,7 @@ To work with a database in dplyr, you must first connect to it, using `DBI::dbCo
 
 ```{r setup, message = FALSE}
 library(dplyr)
-con <- DBI::dbConnect(RSQLite::SQLite(), path = ":memory:")
+con <- DBI::dbConnect(RSQLite::SQLite(), dbname = ":memory:")
 ```
 
 The arguments to `DBI::dbConnect()` vary from database to database, but the first argument is always the database backend. It's `RSQLite::SQLite()` for RSQLite, `RMySQL::MySQL()` for RMySQL, `RPostgreSQL::PostgreSQL()` for RPostgreSQL, `odbc::odbc()` for odbc, and `bigrquery::bigquery()` for BigQuery. SQLite only needs one other argument: the path to the database. Here we use the special string `":memory:"` which causes SQLite to make a temporary in-memory database.


### PR DESCRIPTION
The name of the parameter that describes the path to the database is `dbname` [1]. Unrecognized keys are ignored. If no dbname is received, an in-memory database is created by default, so the example worked anyway. Fixing this usage avoids misleading users trying to build on this example.

[1] https://github.com/r-dbi/RSQLite/blob/33d3631f2809df4eb2ab01460ef3ce73788e1488/R/connect.R#L46