### PR TITLE
add paste and paste0 translation for ORACLE

### DIFF
--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -44,7 +44,10 @@ sql_translate_env.Oracle <- function(con) {
       # https://docs.oracle.com/cd/B19306_01/gateways.102/b14270/apa.htm
       as.integer64  = sql_cast("NUMBER(19)"),
       as.numeric    = sql_cast("NUMBER"),
-      as.double     = sql_cast("NUMBER")
+      as.double     = sql_cast("NUMBER"),
+      # https://docs.oracle.com/cd/B19306_01/server.102/b14200/operators003.htm#i997789
+      paste = sql_paste_infix(" ", "||", function(x) sql_expr(cast(!!x %as% text))),
+      paste0 = sql_paste_infix("", "||", function(x) sql_expr(cast(!!x %as% text))),
     ),
     base_odbc_agg,
     base_odbc_win

--- a/tests/testthat/test-backend-oracle.R
+++ b/tests/testthat/test-backend-oracle.R
@@ -20,3 +20,14 @@ test_that("queries translate correctly", {
     sql("^SELECT [*] FROM [(]SELECT [*]\nFROM [(]`df`[)] [)] `[^`]*` WHERE ROWNUM [<][=] 6")
   )
 })
+
+test_that("vectorised translations", {
+  trans <- function(x) {
+    translate_sql(!!enquo(x), con = simulate_oracle(), window = FALSE)
+  }
+
+  expect_equal(trans(paste(x, y)), sql("`x` || ' ' || `y`"))
+  expect_equal(trans(paste(x, y, z)), sql("`x` || ' ' || `y` || ' ' || `z`"))
+  expect_equal(trans(paste(x, y, sep = "#")), sql("`x` || '#' || `y`"))
+  expect_equal(trans(paste0(x, y)), sql("`x` || `y`"))
+})


### PR DESCRIPTION
closes #155 

Following these documentation: 

* https://docs.oracle.com/cd/B19306_01/server.102/b14200/operators003.htm#i997789
* https://blogs.oracle.com/oraclemagazine/working-with-strings

translate `paste` and `paste0` using the infix operator `||`
