### PR TITLE
removes data_frame() in favor of tibble()

### DIFF
--- a/R/memdb.R
+++ b/R/memdb.R
@@ -13,7 +13,7 @@
 #' df %>% arrange(x)
 #' df %>% arrange(x) %>% show_query()
 memdb_frame <- function(..., .name = random_table_name()) {
-  x <- copy_to(src_memdb(), data_frame(...), name = .name)
+  x <- copy_to(src_memdb(), tibble(...), name = .name)
   x
 }
 

--- a/R/test-frame.R
+++ b/R/test-frame.R
@@ -60,7 +60,7 @@ test_load <- function(df, name = random_table_name(), srcs = test_srcs$get(),
 #' @export
 #' @rdname testing
 test_frame <- function(..., srcs = test_srcs$get(), ignore = character()) {
-  df <- data_frame(...)
+  df <- tibble(...)
   test_load(df, srcs = srcs, ignore = ignore)
 }
 

--- a/tests/testthat/test-lazy-ops.R
+++ b/tests/testthat/test-lazy-ops.R
@@ -8,22 +8,22 @@ test_that("select reduces variables", {
 })
 
 test_that("rename preserves existing", {
-  out <- data_frame(x = 1, y = 2) %>% tbl_lazy() %>% rename(z = y)
+  out <- tibble(x = 1, y = 2) %>% tbl_lazy() %>% rename(z = y)
   expect_equal(op_vars(out), c("x", "z"))
 })
 
 test_that("mutate adds new", {
-  out <- data_frame(x = 1) %>% tbl_lazy() %>% mutate(y = x + 1, z = y + 1)
+  out <- tibble(x = 1) %>% tbl_lazy() %>% mutate(y = x + 1, z = y + 1)
   expect_equal(op_vars(out), c("x", "y", "z"))
 })
 
 test_that("summarise replaces existing", {
-  out <- data_frame(x = 1, y = 2) %>% tbl_lazy() %>% summarise(z = 1)
+  out <- tibble(x = 1, y = 2) %>% tbl_lazy() %>% summarise(z = 1)
   expect_equal(op_vars(out), "z")
 })
 
 test_that("transmute replaces existing", {
-  out <- data_frame(x = 1, y = 2) %>% tbl_lazy() %>% transmute(z = 1)
+  out <- tibble(x = 1, y = 2) %>% tbl_lazy() %>% transmute(z = 1)
   expect_equal(op_vars(out), "z")
 })
 
@@ -52,7 +52,7 @@ test_that("distinct has complicated rules", {
 })
 
 test_that("grouped summary keeps groups", {
-  out <- data_frame(g = 1, x = 1) %>%
+  out <- tibble(g = 1, x = 1) %>%
     tbl_lazy() %>%
     group_by(g) %>%
     summarise(y = 1)
@@ -83,7 +83,7 @@ test_that("semi joins get vars from left", {
 # op_grps -----------------------------------------------------------------
 
 test_that("group_by overrides existing groups", {
-  df <- data_frame(g1 = 1, g2 = 2, x = 3) %>% tbl_lazy()
+  df <- tibble(g1 = 1, g2 = 2, x = 3) %>% tbl_lazy()
 
   out1 <- df %>% group_by(g1)
   expect_equal(op_grps(out1), "g1")
@@ -93,7 +93,7 @@ test_that("group_by overrides existing groups", {
 })
 
 test_that("group_by increases grouping if add = TRUE", {
-  df <- data_frame(g1 = 1, g2 = 2, x = 3) %>% tbl_lazy()
+  df <- tibble(g1 = 1, g2 = 2, x = 3) %>% tbl_lazy()
 
   out <- df %>% group_by(g1) %>% group_by(g2, add = TRUE)
   expect_equal(op_grps(out), c("g1", "g2"))
@@ -105,7 +105,7 @@ test_that("rename renames grouping vars", {
 })
 
 test_that("summarise drops one grouping level", {
-  df <- data_frame(g1 = 1, g2 = 2, x = 3) %>% tbl_lazy() %>% group_by(g1, g2)
+  df <- tibble(g1 = 1, g2 = 2, x = 3) %>% tbl_lazy() %>% group_by(g1, g2)
   out1 <- df %>% summarise(y = 1)
   out2 <- out1 %>% summarise(y = 2)
 

--- a/tests/testthat/test-sql-render.R
+++ b/tests/testthat/test-sql-render.R
@@ -7,25 +7,25 @@ context("SQL: render")
 test_that("rendering table wraps in SELECT *", {
   out <- memdb_frame(x = 1)
   expect_match(out %>% sql_render, "^SELECT [*]\nFROM `[^`]*`$")
-  expect_equal(out %>% collect, data_frame(x = 1))
+  expect_equal(out %>% collect, tibble(x = 1))
 })
 
 test_that("quoting for rendering mutated grouped table", {
   out <- memdb_frame(x = 1, y = 2) %>% mutate(y = x)
   expect_match(out %>% sql_render, "^SELECT `x`, `x` AS `y`\nFROM `[^`]*`$")
-  expect_equal(out %>% collect, data_frame(x = 1, y = 1))
+  expect_equal(out %>% collect, tibble(x = 1, y = 1))
 })
 
 test_that("quoting for rendering ordered grouped table", {
   out <- memdb_frame(x = 1, y = 2) %>% group_by(x) %>% arrange(y)
   expect_match(out %>% sql_render, "^SELECT [*]\nFROM `[^`]*`\nORDER BY `y`$")
-  expect_equal(out %>% collect, data_frame(x = 1, y = 2))
+  expect_equal(out %>% collect, tibble(x = 1, y = 2))
 })
 
 test_that("quoting for rendering summarized grouped table", {
   out <- memdb_frame(x = 1) %>% group_by(x) %>% summarize(n = n())
   expect_match(out %>% sql_render, "^SELECT `x`, COUNT[(][)] AS `n`\nFROM `[^`]*`\nGROUP BY `x`$")
-  expect_equal(out %>% collect, data_frame(x = 1, n = 1L))
+  expect_equal(out %>% collect, tibble(x = 1, n = 1L))
 })
 
 # Single table verbs ------------------------------------------------------
@@ -34,14 +34,14 @@ test_that("distinct adds DISTINCT suffix", {
   out <- memdb_frame(x = c(1, 1)) %>% distinct()
 
   expect_match(out %>% sql_render(), "SELECT DISTINCT")
-  expect_equal(out %>% collect(), data_frame(x = 1))
+  expect_equal(out %>% collect(), tibble(x = 1))
 })
 
 test_that("distinct over columns uses GROUP BY", {
   out <- memdb_frame(x = c(1, 2), y = c(1, 1)) %>% distinct(y)
 
   expect_match(out %>% sql_render(), "SELECT `y`.*GROUP BY `y`")
-  expect_equal(out %>% collect(), data_frame(y = 1))
+  expect_equal(out %>% collect(), tibble(y = 1))
 })
 
 test_that("head renders to integer fractional input", {
@@ -57,7 +57,7 @@ test_that("head works with huge whole numbers", {
     head(1e10) %>%
     collect()
 
-  expect_equal(out, data_frame(x = 1:100))
+  expect_equal(out, tibble(x = 1:100))
 })
 
 test_that("mutate overwrites previous variables", {
@@ -77,7 +77,7 @@ test_that("sequence of operations work", {
     filter(z == 2) %>%
     collect()
 
-  expect_equal(out, data_frame(y = 1, z = 2))
+  expect_equal(out, tibble(y = 1, z = 2))
 })
 
 test_that("compute creates correct column names", {
@@ -87,7 +87,7 @@ test_that("compute creates correct column names", {
     compute() %>%
     collect()
 
-  expect_equal(out, data_frame(x = 1, n = 1L))
+  expect_equal(out, tibble(x = 1, n = 1L))
 })
 
 # Joins make valid sql ----------------------------------------------------

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -265,8 +265,8 @@ test_that("consistent result of full natural join", {
     full_join(tbl_left, tbl_right) %>% arrange(x, y, z, w)
   }
 
-  tbl_left <- data_frame(x = 1L:4L, y = 1L:4L, w = 1L:4L)
-  tbl_right <- data_frame(x = c(1L:3L, 5L), y = 1L:4L, z = 1L:4L)
+  tbl_left <- tibble(x = 1L:4L, y = 1L:4L, w = 1L:4L)
+  tbl_right <- tibble(x = c(1L:3L, 5L), y = 1L:4L, z = 1L:4L)
 
   # SQLite and MySQL do not support full joins
   tbls_left <- test_load(tbl_left, ignore = c("sqlite", "mysql", "MariaDB"))

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -8,14 +8,14 @@ test_that("select quotes correctly", {
   out <- memdb_frame(x = 1, y = 1) %>%
     select(x) %>%
     collect()
-  expect_equal(out, data_frame(x = 1))
+  expect_equal(out, tibble(x = 1))
 })
 
 test_that("select can rename", {
   out <- memdb_frame(x = 1, y = 2) %>%
     select(y = x) %>%
     collect()
-  expect_equal(out, data_frame(y = 1))
+  expect_equal(out, tibble(y = 1))
 })
 
 test_that("two selects equivalent to one", {


### PR DESCRIPTION
Replaces `data_frame()` for `tibble()`. See tidyverse/dplyr#4069. Completed for tidyverse developer day.