### PR TITLE
Added lubridate specifics for Oracle

### DIFF
--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -47,7 +47,7 @@ sql_translate_env.Oracle <- function(con) {
       as.double     = sql_cast("NUMBER"),
       #as.Date = sql_cast("DATE"),
       # Oracle date casting is NLS dependant, the following will work for the default YYYY-MM-DD
-      as.Date = function(x) sql_expr("DATE " !!x),
+      as.Date = function(x) build_sql("DATE ", x),
 
       # https://docs.oracle.com/cd/B19306_01/server.102/b14200/operators003.htm#i997789
       paste = sql_paste_infix(" ", "||", function(x) sql_expr(cast(!!x %as% text))),
@@ -61,10 +61,10 @@ sql_translate_env.Oracle <- function(con) {
 
       # https://modern-sql.com/feature/extract
       yday = function(x) sql_expr((TO_NUMBER(TO_CHAR(!!x, "DDD")))),
-      wday = function(x) build_sql("(MOD(1 + TRUNC(", !!x, ") - TRUNC(", !!x, ", 'IW'),7) +1 )"),
-      hour = function(x) build_sql("EXTRACT(HOUR FROM CASE(", !!x, " AS TIMESTAMP)"),
-      minute = function(x) build_sql("EXTRACT(MINUTE FROM CASE(", !!x, " AS TIMESTAMP)"),
-      second = function(x) build_sql("EXTRACT(SECOND FROM CASE(", !!x, " AS TIMESTAMP)")
+      wday = function(x) build_sql("(MOD(1 + TRUNC(", x, ") - TRUNC(", x, ", 'IW'),7) +1 )"),
+      hour = function(x) build_sql("EXTRACT(HOUR FROM CASE(", x, " AS TIMESTAMP)"),
+      minute = function(x) build_sql("EXTRACT(MINUTE FROM CASE(", x, " AS TIMESTAMP)"),
+      second = function(x) build_sql("EXTRACT(SECOND FROM CASE(", x, " AS TIMESTAMP)")
     ),
     base_odbc_agg,
     base_odbc_win

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -45,9 +45,26 @@ sql_translate_env.Oracle <- function(con) {
       as.integer64  = sql_cast("NUMBER(19)"),
       as.numeric    = sql_cast("NUMBER"),
       as.double     = sql_cast("NUMBER"),
+      #as.Date = sql_cast("DATE"),
+      # Oracle date casting is NLS dependant, the following will work for the default YYYY-MM-DD
+      as.Date = function(x) sql_expr("DATE " !!x),
+
       # https://docs.oracle.com/cd/B19306_01/server.102/b14200/operators003.htm#i997789
       paste = sql_paste_infix(" ", "||", function(x) sql_expr(cast(!!x %as% text))),
       paste0 = sql_paste_infix("", "||", function(x) sql_expr(cast(!!x %as% text))),
+
+      # lubridate ---------------------------------------------------------------
+      # https://en.wikibooks.org/wiki/SQL_Dialects_Reference/Functions_and_expressions/Date_and_time_functions
+
+      today = function() sql_expr(TRUNC(SYSDATE)),
+      now = function() sql_expr(CURRENT_TIMESTAMP),
+
+      # https://modern-sql.com/feature/extract
+      yday = function(x) sql_expr((TO_NUMBER(TO_CHAR(!!x, "DDD")))),
+      wday = function(x) build_sql("(MOD(1 + TRUNC(", !!x, ") - TRUNC(", !!x, ", 'IW'),7) +1 )"),
+      hour = function(x) build_sql("EXTRACT(HOUR FROM CASE(", !!x, " AS TIMESTAMP)"),
+      minute = function(x) build_sql("EXTRACT(MINUTE FROM CASE(", !!x, " AS TIMESTAMP)"),
+      second = function(x) build_sql("EXTRACT(SECOND FROM CASE(", !!x, " AS TIMESTAMP)")
     ),
     base_odbc_agg,
     base_odbc_win


### PR DESCRIPTION
I've supplied the basic changes needed to fully support oracle with the lubridate functions currently supported across all languages. 

Main differences are:

- Forced cast to timestamp for dates to get hour/minute/second - this shouldn't introduce much if any overhead to queries where it already is a timestamp.
- Today is based on sysdate as CURRENT_DATE has a time in oracle (note this will be the current date of the system the database is running on, *not* the date of the NLS settings of the database, this can be changed if it is different to the other SQL variants)
- I've implemented as.Date via an explicit call to Date rather than via a cast - there's 2 reasons for this. The first is that the database optimiser can't identify casts as dates at run time so it might not e.g. identify it should filter on a partition before a join, rather than after. Secondly, the cast to date is NLS setting dependant in Oracle databases; at least in my experience most users will not actually be aware of what this is so the conversion will fail. The method implemented will work for YYYY-MM-DD formats and as as.Date tries YYYY-MM-DD by default this is consistent with the base R method. I do still have the code for the full(ish) version of as.Date/as_date that includes the format argument specific to an Oracle translation however did not include it as the base backend does not support this argument.
- I've also included support for yday and wday as they were listed explicitly in the backend so assumed they would be supported soon and Oracle has a very easy to_char function to extract them.
