### PR TITLE
add support for yday and quarter to PostgreSQL backend

### DIFF
--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -71,6 +71,18 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
           }
         }
       },
+      quarter = function(x, with_year = FALSE, fiscal_start = 1) {
+        if (fiscal_start != 1) {
+          stop("`fiscal_start` is not supported in PostgreSQL translation. Must be 1.", call. = FALSE)
+        }
+
+        if (with_year) {
+          sql_expr((EXTRACT(year %FROM% !!x) || '.' || EXTRACT(quarter %FROM% !!x)))
+        } else {
+          sql_expr(EXTRACT(quarter %FROM% !!x))
+        }
+      },
+
       wday = function(x, label = FALSE, abbr = TRUE, week_start = NULL) {
         if (!label) {
           # quiet R CMD check

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -86,7 +86,8 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
         } else {
           stop("Unrecognized arguments to `wday`", call. = FALSE)
         }
-      }
+      },
+      yday = function(x) sql_expr(EXTRACT(doy %FROM% !!x))
     ),
     sql_translator(.parent = base_agg,
       n = function() sql("COUNT(*)"),

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -56,3 +56,11 @@ test_that("postgres mimics two argument log", {
   expect_equal(trans(log(x, 10)), sql('LOG(`x`) / LOG(10.0)'))
   expect_equal(trans(log(x, 10L)), sql('LOG(`x`) / LOG(10)'))
 })
+
+test_that("custom lubridate functions translated correctly", {
+  trans <- function(x) {
+    translate_sql(!!enquo(x), con = simulate_postgres())
+  }
+
+  expect_equal(trans(yday('2019-03-18')), sql("EXTRACT(doy FROM '2019-03-18')"))
+})

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -62,5 +62,10 @@ test_that("custom lubridate functions translated correctly", {
     translate_sql(!!enquo(x), con = simulate_postgres())
   }
 
-  expect_equal(trans(yday('2019-03-18')), sql("EXTRACT(doy FROM '2019-03-18')"))
+  expect_equal(trans(yday(x)),                      sql("EXTRACT(doy FROM `x`)"))
+
+  expect_equal(trans(quarter(x)),                   sql("EXTRACT(quarter FROM `x`)"))
+  expect_equal(trans(quarter(x, with_year = TRUE)), sql("(EXTRACT(year FROM `x`) || '.' || EXTRACT(quarter FROM `x`))"))
+
+  expect_error(trans(quarter(x, fiscal_start = 2)))
 })


### PR DESCRIPTION
This adds support for the lubridate `yday()` function to the PostgreSQL backend.