### PR TITLE
Fix explain() for Postgres data sources

### DIFF
--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -183,8 +183,9 @@ db_explain.PostgreSQLConnection <- function(con, sql, format = "text", ...) {
 
   exsql <- build_sql(
     "EXPLAIN ",
-    if (!is.null(format)) build_sql("(FORMAT ", sql(format), ") "),
-    sql
+    if (!is.null(format)) sql(paste0("(FORMAT ", format, ") ")),
+    sql,
+    con = con
   )
   expl <- dbGetQuery(con, exsql)
 

--- a/tests/testthat/sql/postgres-explain.sql
+++ b/tests/testthat/sql/postgres-explain.sql
@@ -1,0 +1,6 @@
+<SQL>
+SELECT "x", "x" + 1.0 AS "y"
+FROM "dbplyr_002"
+
+<PLAN>
+Seq Scan on dbplyr_002  (cost=0.00..1.04 rows=3 width=36)

--- a/tests/testthat/sql/postgres-explain.sql
+++ b/tests/testthat/sql/postgres-explain.sql
@@ -1,6 +1,6 @@
 <SQL>
 SELECT "x", "x" + 1.0 AS "y"
-FROM "dbplyr_002"
+FROM "dbplyr_001"
 
 <PLAN>
-Seq Scan on dbplyr_002  (cost=0.00..1.04 rows=3 width=36)
+Seq Scan on dbplyr_001  (cost=0.00..1.04 rows=3 width=36)

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -56,3 +56,17 @@ test_that("postgres mimics two argument log", {
   expect_equal(trans(log(x, 10)), sql('LOG(`x`) / LOG(10.0)'))
   expect_equal(trans(log(x, 10L)), sql('LOG(`x`) / LOG(10)'))
 })
+
+test_that("postgres can explain (#272)", {
+  skip_if_no_db("postgres")
+
+  df1 <- data.frame(x = 1:3)
+
+  expect_known_output(
+    src_test("postgres") %>%
+      copy_to(df1, unique_table_name()) %>%
+      mutate(y = x + 1) %>%
+      explain(),
+    "sql/postgres-explain.sql"
+  )
+})


### PR DESCRIPTION
What's a good place to add tests, also for other data sources?