### PR TITLE
Use TOP 100 PERCENT as stop-gap to allow subqueries with ORDER BY

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Window functions are now translated correctly for Hive (#293, @cderv).
 
+* Use `TOP 100 PERCENT` as stop-gap to allow subqueries with `ORDER BY` (#277).
+
 # dbplyr 1.4.0
 
 ## Breaking changes

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -4,7 +4,8 @@
                                              order_by = NULL,
                                              limit = NULL,
                                              distinct = FALSE,
-                                             ...) {
+                                             ...,
+                                             bare_identifier_ok = FALSE) {
   out <- vector("list", 7)
   names(out) <- c("select", "from", "where", "group_by",
                   "having", "order_by","limit")
@@ -21,7 +22,7 @@
       # e.g: SELECT TOP 100 * FROM my_table
       assert_that(is.numeric(limit), length(limit) == 1L, limit > 0)
       build_sql("TOP(", as.integer(limit), ") ", con = con)
-    } else if (!is.null(order_by)) {
+    } else if (!is.null(order_by) && bare_identifier_ok) {
       # Stop-gap measure so that a wider range of queries is supported (#276).
       # MS SQL doesn't allow ORDER BY in subqueries,
       # unless also TOP (or FOR XML) is specified.

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -100,8 +100,12 @@ sql_render.select_query <- function(query, con, ..., bare_identifier_ok = FALSE)
   )
 
   sql_select(
-    con, query$select, from, where = query$where, group_by = query$group_by,
-    having = query$having, order_by = query$order_by, limit = query$limit,
+    con, query$select, from,
+    where = query$where,
+    group_by = query$group_by,
+    having = query$having,
+    order_by = query$order_by,
+    limit = query$limit,
     distinct = query$distinct,
     ...,
     bare_identifier_ok = bare_identifier_ok

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -103,7 +103,8 @@ sql_render.select_query <- function(query, con, ..., bare_identifier_ok = FALSE)
     con, query$select, from, where = query$where, group_by = query$group_by,
     having = query$having, order_by = query$order_by, limit = query$limit,
     distinct = query$distinct,
-    ...
+    ...,
+    bare_identifier_ok = bare_identifier_ok
   )
 }
 

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -166,7 +166,6 @@ test_that("ORDER BY in subqueries uses TOP 100 PERCENT (#175)", {
 
   expect_equal(
     mf %>% mutate(x = -x) %>% arrange(x) %>% mutate(x = -x) %>% sql_render(),
-    sql("SELECT -`x` AS `x`\nFROM (SELECT TOP 100 PERCENT *\nFROM (SELECT TOP 100 PERCENT -`
-x[1]: x` AS `x`\nFROM `df`) `dbplyr_001`\nORDER BY `x`) `dbplyr_002`")
+    sql("SELECT -`x` AS `x`\nFROM (SELECT TOP 100 PERCENT *\nFROM (SELECT TOP 100 PERCENT -`x` AS `x`\nFROM `df`) `dbplyr_001`\nORDER BY `x`) `dbplyr_002`")
   )
 })

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -166,6 +166,7 @@ test_that("ORDER BY in subqueries uses TOP 100 PERCENT (#175)", {
 
   expect_equal(
     mf %>% mutate(x = -x) %>% arrange(x) %>% mutate(x = -x) %>% sql_render(),
-    sql("SELECT -`x` AS `x`\nFROM (SELECT TOP 100 PERCENT -`x` AS `x`\nFROM `df`\nORDER BY `x`) `dbplyr_001`")
+    sql("SELECT -`x` AS `x`\nFROM (SELECT TOP 100 PERCENT *\nFROM (SELECT TOP 100 PERCENT -`
+x[1]: x` AS `x`\nFROM `df`) `dbplyr_001`\nORDER BY `x`) `dbplyr_002`")
   )
 })

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -160,3 +160,12 @@ FROM `df`")
     sql("SELECT `x`, CASE\nWHEN (((`x`) IS NULL)) THEN (1.0)\nWHEN (NOT(((`x`) IS NULL))) THEN (2.0)\nELSE (3.0)\nEND AS `z`\nFROM `df`")
   )
 })
+
+test_that("ORDER BY in subqueries uses TOP 100 PERCENT (#175)", {
+  mf <- lazy_frame(x = 1:3, con = simulate_mssql())
+
+  expect_equal(
+    mf %>% mutate(x = -x) %>% arrange(x) %>% mutate(x = -x) %>% sql_render(),
+    sql("SELECT -`x` AS `x`\nFROM (SELECT TOP 100 PERCENT -`x` AS `x`\nFROM `df`\nORDER BY `x`) `dbplyr_001`")
+  )
+})


### PR DESCRIPTION
for MSSQL.

Closes #275.