### PR TITLE
Fix copy_to() for MSSQL databases

### DIFF
--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -144,7 +144,14 @@ mssql_temp_name <- function(name, temporary){
                             analyze = TRUE, ...) {
   NextMethod(
     table = mssql_temp_name(table, temporary),
-    temporary = FALSE
+    values = values,
+    overwrite = overwrite,
+    types = types,
+    temporary = FALSE,
+    unique_indexes = unique_indexes,
+    indexes = indexes,
+    analyze = analyze,
+    ...
   )
 }
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -161,7 +161,6 @@ mssql_temp_name <- function(name, temporary){
   name <- mssql_temp_name(name, temporary)
 
   tt_sql <- build_sql(
-    #"SELECT ", escape(ident(vars), collapse = ", ", con = con), " ",
     "SELECT * ",
     "INTO ", as.sql(name), " ",
     "FROM (", sql, ") AS temp",

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -160,6 +160,7 @@ mssql_temp_name <- function(name, temporary){
                                                  temporary = TRUE, ...){
   name <- mssql_temp_name(name, temporary)
 
+  # Different syntax for MSSQL: https://stackoverflow.com/q/16683758/946850
   tt_sql <- build_sql(
     "SELECT * ",
     "INTO ", as.sql(name), " ",

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -144,14 +144,9 @@ mssql_temp_name <- function(name, temporary){
                             analyze = TRUE, ...) {
   NextMethod(
     table = mssql_temp_name(table, temporary),
-    values = values,
-    overwrite = overwrite,
     types = types,
-    temporary = FALSE,
-    unique_indexes = unique_indexes,
-    indexes = indexes,
-    analyze = analyze,
-    ...
+    values = values,
+    temporary = FALSE
   )
 }
 
@@ -176,11 +171,9 @@ mssql_temp_name <- function(name, temporary){
 `db_write_table.Microsoft SQL Server`  <- function(con, table, types, values, temporary = TRUE, ...) {
   NextMethod(
     table = mssql_temp_name(table, temporary),
-    values = values,
-    overwrite = overwrite,
     types = types,
-    temporary = FALSE,
-    ...
+    values = values,
+    temporary = FALSE
   )
 }
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -158,17 +158,29 @@ mssql_temp_name <- function(name, temporary){
 #' @export
 `db_save_query.Microsoft SQL Server` <- function(con, sql, name,
                                                  temporary = TRUE, ...){
-  NextMethod(
-    name = mssql_temp_name(name, temporary),
-    temporary = FALSE
+  name <- mssql_temp_name(name, temporary)
+
+  tt_sql <- build_sql(
+    #"SELECT ", escape(ident(vars), collapse = ", ", con = con), " ",
+    "SELECT * ",
+    "INTO ", as.sql(name), " ",
+    "FROM (", sql, ") AS temp",
+    con = con
   )
+  dbExecute(con, tt_sql)
+  name
+
 }
 
 #' @export
 `db_write_table.Microsoft SQL Server`  <- function(con, table, types, values, temporary = TRUE, ...) {
   NextMethod(
     table = mssql_temp_name(table, temporary),
-    temporary = FALSE
+    values = values,
+    overwrite = overwrite,
+    types = types,
+    temporary = FALSE,
+    ...
   )
 }
 


### PR DESCRIPTION
A regression.

The partial `NextMethod()` calls didn't work for me, only when the full list of arguments is specified.