### PR TITLE
Better squashing of trivial subqueries

### DIFF
--- a/R/query-select.R
+++ b/R/query-select.R
@@ -63,10 +63,9 @@ sql_optimise.select_query <- function(x, con = NULL, ...) {
   outer <- select_query_clauses(x)
   inner <- select_query_clauses(from)
 
-  if (length(outer) == 0 || length(inner) == 0)
-    return(x)
+  can_squash <- length(outer) == 0 || length(inner) == 0 || min(outer) > max(inner)
 
-  if (min(outer) > max(inner)) {
+  if (can_squash) {
     from[as.character(outer)] <- x[as.character(outer)]
     from
   } else {

--- a/tests/testthat/test-query-select.R
+++ b/tests/testthat/test-query-select.R
@@ -50,3 +50,17 @@ test_that("filter and rename are correctly composed", {
   # It surprises me that this SQL works!
   expect_equal(collect(lf), tibble(x = 2))
 })
+
+test_that("trivial subqueries are collapsed", {
+  lf <- memdb_frame(a = 1:3) %>%
+    mutate(b = a + 1) %>%
+    distinct() %>%
+    arrange()
+
+  qry <- lf %>% sql_build()
+  expect_is(qry$from, "ident")
+  expect_true(qry$distinct)
+
+  # And check that it returns the correct value
+  expect_equal(collect(lf), tibble(a = 1:3, b = a + 1.0))
+})


### PR DESCRIPTION
Only found a contrived example, still might be useful.

## 692be52

``` r
library(tidyverse)
library(dbplyr)

lazy_frame(a = 1:3) %>%
  mutate(b = a + 1) %>%
  distinct() %>%
  arrange()
#> <SQL>
#> SELECT *
#> FROM (SELECT DISTINCT *
#> FROM (SELECT `a`, `a` + 1.0 AS `b`
#> FROM `df`) `dbplyr_001`) `dbplyr_002`
```

<sup>Created on 2019-04-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>

## With this PR

``` r
library(tidyverse)
library(dbplyr)

lazy_frame(a = 1:3) %>%
  mutate(b = a + 1) %>%
  distinct() %>%
  arrange()
#> <SQL>
#> SELECT DISTINCT `a`, `a` + 1.0 AS `b`
#> FROM `df`
```

<sup>Created on 2019-04-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>