### PR TITLE
Fix typos in NEWS, vignettes, documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
+Language: en-gb
 LazyData: yes
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Breaking changes
 
 * ``Error: `con` must not be NULL``: If you see this error, it probably means 
-  that you have probably forgotten to pass `con` down to a dbplyr function. 
+  that you have forgotten to pass `con` down to a dbplyr function. 
   Previously, dbplyr defaulted to using `simulate_dbi()` which introduced
   subtle escaping bugs. (It's also possible I have forgotten to pass it 
   somewhere that the dbplyr tests don't pick up, so if you can't figure it 
@@ -23,7 +23,7 @@
 * Overall, dplyr generates many fewer subqueries:
 
   * Joins and semi-joins no longer add an unneeded subquery (#236). This is
-    faciliated by the new `bare_identifier_ok` argument to `sql_render()`;
+    facilitated by the new `bare_identifier_ok` argument to `sql_render()`;
     the previous argument was called `root` and confused me.
   
   * Many sequences of `select()`, `rename()`, `mutate()`, and `transmute()` can
@@ -31,12 +31,12 @@
     (#213).
 
 * New `vignette("sql")` describes some advantages of dbplyr over SQL (#205) and 
-  gives some advice about writing how to write literal SQL inside of dplyr, 
-  when you you need to (#196).
+  gives some advice about writing literal SQL inside of dplyr, when you need 
+  to (#196).
 
 * New `vignette("reprex")` gives some hints on creating reprexes that work 
-  anywhere (#117). This is supposrted by a new `tbl_memdb()` that 
-  matches the existing `tbl_lazy()`.
+  anywhere (#117). This is supported by a new `tbl_memdb()` that matches the 
+  existing `tbl_lazy()`.
 
 * All `..._join()` functions gain an `sql_on` argument that allows specifying
   arbitrary join predicates in SQL code (#146, @krlmlr).
@@ -45,7 +45,8 @@
 
 * New translations for some lubridate functions: `today()`, `now()`, 
   `year()`, `month()`, `day()`, `hour()`, `minute()`,
-  `second()`, `quarter()`, ``yday()` (@colearendt, @derekmorr). Also added new translation for `as.POSIXct()`.
+  `second()`, `quarter()`, `yday()` (@colearendt, @derekmorr). Also added new 
+  translation for `as.POSIXct()`.
 
 * New translations for stringr functions: `str_c()`, `str_sub()`, 
   `str_length()`, `str_to_upper()`, `str_to_lower()`, and `str_to_title()`
@@ -87,7 +88,9 @@
 
 ### SQL simulation
 
-SQL simulation makes it possible to see what dbplyr will translate SQL to, without having an active database connection, and is used for testing and generating reprexes. 
+SQL simulation makes it possible to see what dbplyr will translate SQL to,
+without having an active database connection, and is used for testing and
+generating reprexes.
 
 * SQL simulation has been overhauled. It now works reliably, is better 
   documented, and always uses ANSI escaping (i.e. `` ` `` for field 
@@ -505,7 +508,7 @@ SQL simulation makes it possible to see what dbplyr will translate SQL to, witho
 
 * New `as.sql()` safely coerces an input to SQL.
 
-* More tranlators for `as.character()`, `as.integer()` and `as.double()` 
+* More translators for `as.character()`, `as.integer()` and `as.double()` 
   (#2775).
 
 * New `ident_q()` makes it possible to specifier identifiers that do not
@@ -599,7 +602,7 @@ SQL simulation makes it possible to see what dbplyr will translate SQL to, witho
 * `common_by()` gets a better error message for unexpected inputs (#2091)
 
 * `copy_to()` no longer checks that the table doesn't exist before creation,
-  intead preferring to fall back on the database for error messages. This
+  instead preferring to fall back on the database for error messages. This
   should reduce both false positives and false negative (#1470)
 
 * `copy_to()` now succeeds for MySQL if a character column contains `NA` 

--- a/R/build-sql.R
+++ b/R/build-sql.R
@@ -7,13 +7,13 @@
 #' attack, but should make it unlikely that you produce invalid sql.
 #'
 #' This function should be used only when generating `SELECT` clauses,
-#' other high level queries, or for other syntax that has no R equivalnt.
+#' other high level queries, or for other syntax that has no R equivalent.
 #' For individual function translations, prefer [sql_expr()].
 #'
 #' @param ... input to convert to SQL. Use [sql()] to preserve
 #'   user input as is (dangerous), and [ident()] to label user
 #'   input as sql identifiers (safe)
-#' @param .env the environment in which to evalute the arguments. Should not
+#' @param .env the environment in which to evaluate the arguments. Should not
 #'   be needed in typical use.
 #' @param con database connection; used to select correct quoting characters.
 #' @keywords internal

--- a/R/data-lahman.R
+++ b/R/data-lahman.R
@@ -5,10 +5,10 @@
 #' \url{http://www.seanlahman.com/baseball-archive/statistics/}, and
 #' made easily available in R through the \pkg{Lahman} package by
 #' Michael Friendly, Dennis Murphy and Martin Monkman. See the documentation
-#' for that package for documentation of the inidividual tables.
+#' for that package for documentation of the individual tables.
 #'
 #' @param ... Other arguments passed to `src` on first
-#'   load. For mysql and postgresql, the defaults assume you have a local
+#'   load. For MySQL and PostgreSQL, the defaults assume you have a local
 #'   server with `lahman` database already created.
 #'   For `lahman_srcs()`, character vector of names giving srcs to generate.
 #' @param quiet if `TRUE`, suppress messages about databases failing to

--- a/R/data-nycflights13.R
+++ b/R/data-nycflights13.R
@@ -10,7 +10,7 @@ NULL
 
 #' @export
 #' @rdname nycflights13
-#' @param path location of sqlite database file
+#' @param path location of SQLite database file
 nycflights13_sqlite <- function(path = NULL) {
   cache_computation("nycflights_sqlite", {
     path <- db_location(path, "nycflights13.sqlite")

--- a/R/partial-eval.R
+++ b/R/partial-eval.R
@@ -3,7 +3,7 @@
 #' This function partially evaluates an expression, using information from
 #' the tbl to determine whether names refer to local expressions
 #' or remote variables. This simplifies SQL translation because expressions
-#' don't need to carry around their environment - all revelant information
+#' don't need to carry around their environment - all relevant information
 #' is incorporated into the expression.
 #'
 #' @section Symbol substitution:

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ deparse_all <- function(x) {
   purrr::map_chr(x, expr_text, width = 500L)
 }
 
-#' Provides comma-separated string out ot the parameters
+#' Provides comma-separated string out of the parameters
 #' @export
 #' @keywords internal
 #' @param ... Arguments to be constructed into the string

--- a/R/verb-arrange.R
+++ b/R/verb-arrange.R
@@ -3,7 +3,7 @@
 #' Order rows of database tables by an expression involving its variables.
 #'
 #' @section Missing values:
-#' Compared to its sorting behavior on local data, the [arrange()] method for
+#' Compared to its sorting behaviour on local data, the [arrange()] method for
 #' most database tables sorts NA at the beginning unless wrapped with [desc()].
 #' Users can override this behaviour by explicitly sorting on `is.na(x)`.
 #'

--- a/man/arrange.tbl_lazy.Rd
+++ b/man/arrange.tbl_lazy.Rd
@@ -24,7 +24,7 @@ Order rows of database tables by an expression involving its variables.
 }
 \section{Missing values}{
 
-Compared to its sorting behavior on local data, the \code{\link[=arrange]{arrange()}} method for
+Compared to its sorting behaviour on local data, the \code{\link[=arrange]{arrange()}} method for
 most database tables sorts NA at the beginning unless wrapped with \code{\link[=desc]{desc()}}.
 Users can override this behaviour by explicitly sorting on \code{is.na(x)}.
 }

--- a/man/build_sql.Rd
+++ b/man/build_sql.Rd
@@ -11,7 +11,7 @@ build_sql(..., .env = parent.frame(), con = sql_current_con())
 user input as is (dangerous), and \code{\link[=ident]{ident()}} to label user
 input as sql identifiers (safe)}
 
-\item{.env}{the environment in which to evalute the arguments. Should not
+\item{.env}{the environment in which to evaluate the arguments. Should not
 be needed in typical use.}
 
 \item{con}{database connection; used to select correct quoting characters.}
@@ -25,7 +25,7 @@ attack, but should make it unlikely that you produce invalid sql.
 }
 \details{
 This function should be used only when generating \code{SELECT} clauses,
-other high level queries, or for other syntax that has no R equivalnt.
+other high level queries, or for other syntax that has no R equivalent.
 For individual function translations, prefer \code{\link[=sql_expr]{sql_expr()}}.
 }
 \examples{

--- a/man/lahman.Rd
+++ b/man/lahman.Rd
@@ -27,7 +27,7 @@ lahman_srcs(..., quiet = NULL)
 }
 \arguments{
 \item{...}{Other arguments passed to \code{src} on first
-load. For mysql and postgresql, the defaults assume you have a local
+load. For MySQL and PostgreSQL, the defaults assume you have a local
 server with \code{lahman} database already created.
 For \code{lahman_srcs()}, character vector of names giving srcs to generate.}
 
@@ -42,7 +42,7 @@ data source, provided by Sean Lahman at
 \url{http://www.seanlahman.com/baseball-archive/statistics/}, and
 made easily available in R through the \pkg{Lahman} package by
 Michael Friendly, Dennis Murphy and Martin Monkman. See the documentation
-for that package for documentation of the inidividual tables.
+for that package for documentation of the individual tables.
 }
 \examples{
 # Connect to a local sqlite database, if already created

--- a/man/named_commas.Rd
+++ b/man/named_commas.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{named_commas}
 \alias{named_commas}
-\title{Provides comma-separated string out ot the parameters}
+\title{Provides comma-separated string out of the parameters}
 \usage{
 named_commas(...)
 }
@@ -10,6 +10,6 @@ named_commas(...)
 \item{...}{Arguments to be constructed into the string}
 }
 \description{
-Provides comma-separated string out ot the parameters
+Provides comma-separated string out of the parameters
 }
 \keyword{internal}

--- a/man/nycflights13.Rd
+++ b/man/nycflights13.Rd
@@ -17,7 +17,7 @@ has_nycflights13(type = c("sqlite", "postgresql"), ...)
 copy_nycflights13(src, ...)
 }
 \arguments{
-\item{path}{location of sqlite database file}
+\item{path}{location of SQLite database file}
 
 \item{dbname, ...}{Arguments passed on to \code{\link[=src_postgres]{src_postgres()}}}
 }

--- a/man/partial_eval.Rd
+++ b/man/partial_eval.Rd
@@ -17,7 +17,7 @@ partial_eval(call, vars = character(), env = caller_env())
 This function partially evaluates an expression, using information from
 the tbl to determine whether names refer to local expressions
 or remote variables. This simplifies SQL translation because expressions
-don't need to carry around their environment - all revelant information
+don't need to carry around their environment - all relevant information
 is incorporated into the expression.
 }
 \section{Symbol substitution}{

--- a/vignettes/dbplyr.Rmd
+++ b/vignettes/dbplyr.Rmd
@@ -21,7 +21,7 @@ As well as working with local in-memory data stored in data frames, dplyr also w
   
 (If your data fits in memory there is no advantage to putting it in a database: it will only be slower and more frustrating.)
 
-This vignette focusses on the first scenario because it's the most common. If you're using R to do data analysis inside a company, most of the data you need probably already lives in a database (it's just a matter of figuring out which one!). However, you will learn how to load data in to a local database in order to demonstrate dplyr's database tools. At  the end, I'll also give you a few pointers if you do need to set up your own database.
+This vignette focuses on the first scenario because it's the most common. If you're using R to do data analysis inside a company, most of the data you need probably already lives in a database (it's just a matter of figuring out which one!). However, you will learn how to load data in to a local database in order to demonstrate dplyr's database tools. At  the end, I'll also give you a few pointers if you do need to set up your own database.
 
 ## Getting started
 
@@ -144,7 +144,7 @@ tailnum_delay_db <- flights_db %>%
   filter(n > 100)
 ```
 
-Suprisingly, this sequence of operations never touches the database. It's not until you ask for the data (e.g. by printing `tailnum_delay`) that dplyr generates the SQL and requests the results from the database. Even then it tries to do as little work as possible and only pulls down a few rows.
+Surprisingly, this sequence of operations never touches the database. It's not until you ask for the data (e.g. by printing `tailnum_delay`) that dplyr generates the SQL and requests the results from the database. Even then it tries to do as little work as possible and only pulls down a few rows.
 
 ```{r}
 tailnum_delay_db

--- a/vignettes/notes/_postgres-setup.Rmd
+++ b/vignettes/notes/_postgres-setup.Rmd
@@ -3,11 +3,11 @@
 %\VignetteIndexEntry{PostgreSQL setup}
 -->
 
-# Setting up Postgresql
+# Setting up PostgreSQL
 
 ## Install
 
-First install postgresql, create a data directory, and create a default database.
+First install PostgreSQL, create a data directory, and create a default database.
 
 ```
 brew install postgresql

--- a/vignettes/sql.Rmd
+++ b/vignettes/sql.Rmd
@@ -36,7 +36,7 @@ mf %>%
   show_query()
 ```
 
-In general, it's much easier to work iterately in dbplyr. You can easily give intermediate queries names, and reuse them in multiple places. Or if you have a common operation that you want to do to many queries, you can easily wrap it up in a function. It's also easy to chain `count()` to the end of any query to check the results are about what you expect.
+In general, it's much easier to work iteratively in dbplyr. You can easily give intermediate queries names, and reuse them in multiple places. Or if you have a common operation that you want to do to many queries, you can easily wrap it up in a function. It's also easy to chain `count()` to the end of any query to check the results are about what you expect.
 
 ## What happens when dbplyr fails?
 
@@ -44,7 +44,7 @@ dbplyr aims to translate the most common R functions to their SQL equivalents, a
 
 ### Prefix functions
 
-Any function that dbplyr doens't know about will be left as is:
+Any function that dbplyr doesn't know about will be left as is:
 
 ```{r}
 mf %>% 

--- a/vignettes/translation-function.Rmd
+++ b/vignettes/translation-function.Rmd
@@ -113,7 +113,7 @@ Note that, by default, `translate()` assumes that the call is inside a `mutate()
 translate_sql(mean(x, na.rm = TRUE), window = FALSE)
 ```
 
-### Conditional evauation
+### Conditional evaluation
 
 `if` and `switch()` are translate to `CASE WHEN`:
 
@@ -167,7 +167,7 @@ Things get a little trickier with window functions, because SQL's window functio
   to the window function, describing which rows (relative to the current row)
   should be included. The frame clause provides two offsets which determine
   the start and end of frame. There are three special values: -Inf means
-  to include all preceeding rows (in SQL, "unbounded preceding"), 0 means the
+  to include all preceding rows (in SQL, "unbounded preceding"), 0 means the
   current row ("current row"), and Inf means all following rows ("unbounded
   following)". The complete set of options is comprehensive, but fairly 
   confusing, and is summarised visually below.

--- a/vignettes/translation-verb.Rmd
+++ b/vignettes/translation-verb.Rmd
@@ -8,7 +8,7 @@ vignette: >
 ---
 
 
-There are two parts to dbplyr SQL translation: translating dplyr verbs, and translating expressions within those verbs. This vignette describes how entire verbs are translated; `vignette("translate-function")` descibes how individual expressions within those verbs are translated.
+There are two parts to dbplyr SQL translation: translating dplyr verbs, and translating expressions within those verbs. This vignette describes how entire verbs are translated; `vignette("translate-function")` describes how individual expressions within those verbs are translated.
 
 All dplyr verbs generate a `SELECT` statement. To demonstrate we'll make a temporary database with a couple of tables
 


### PR DESCRIPTION
This fixes some typos. I renamed "mysql", "postgresql" and "sqlite" to "MySQL", "PostgreSQL" and "SQLite" where appropriate. I hope that's okay. 

While reviewing, I was wondering whether [this line](https://github.com/tidyverse/dbplyr/blob/2f17ed749e4f634c64cf1f99f1a9634f7d4378a5/vignettes/dbplyr.Rmd#L200) in the comparison of PostgreSQL with SQLite is still appropriate in its current wording, given that SQLite now supports window functions.