### PR TITLE
Hive translations for window functions were no more working

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* Window functions are now translated correctly for Hive (#293, @cderv).
+
 # dbplyr 1.4.0
 
 ## Breaking changes

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -18,7 +18,7 @@ sql_translate_env.Hive <- function(con) {
       quantile = sql_quantile("PERCENTILE"),
       median = sql_median("PERCENTILE")
     ),
-    sql_translator(.parent = base_odbc_agg,
+    sql_translator(.parent = base_odbc_win,
       var = win_aggregate("VARIANCE"),
       quantile = sql_quantile("PERCENTILE", window = TRUE),
       median = sql_median("PERCENTILE", window = TRUE)


### PR DESCRIPTION
This comes from a question on [community.rstudio.com](https://community.rstudio.com/t/error-using-dbplyr-1-4-with-row-number/29779/5)

In dbplyr 1.3.0
```r
library(dplyr)
library(dbplyr)
tab <- tbl_lazy(iris, src = simulate_hive())
query <- tab %>%
  group_by(Species) %>%
  filter(row_number() == 1L)
query %>% show_query()
<SQL> SELECT `Sepal.Length`, `Sepal.Width`, `Petal.Length`, `Petal.Width`, `Species`
FROM (SELECT `Sepal.Length`, `Sepal.Width`, `Petal.Length`, `Petal.Width`, `Species`, row_number() OVER (PARTITION BY `Species`) AS `zzz1`
FROM `df`) `ohjggmqvbj`
WHERE (`zzz1` = 1)
```
With 1.4.0
```r
tab <- tbl_lazy(iris, src = simulate_hive())
query <- tab %>%
  group_by(Species) %>%
  filter(row_number() == 1L)
query %>% show_query()
<SQL>
SELECT *
FROM `df`
WHERE (row_number() = 1)
```

A `git bisect` points to this commit: f4fcfdc9f73d56bbf2d93eb705b57709ccae52e5. This comes from a small typo - odbc window function were no more used. 

This PR changes that and now it is working as before
```r
tab <- tbl_lazy(iris, src = simulate_hive())
query <- tab %>%
  group_by(Species) %>%
  filter(row_number() == 1L)
query %>% show_query()
<SQL>
SELECT `Sepal.Length`, `Sepal.Width`, `Petal.Length`, `Petal.Width`, `Species`
FROM (SELECT `Sepal.Length`, `Sepal.Width`, `Petal.Length`, `Petal.Width`, `Species`, ROW_NUMBER() OVER (PARTITION BY `Species`) AS `zzz1`
FROM `df`) `dbplyr_001`
WHERE (`zzz1` = 1)
```

I can add tests later if you want. There are not so many tests for hive curently, and nothing about window function