### PR TITLE
make explain work with redshift

### DIFF
--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -199,7 +199,6 @@ db_explain.PostgreSQLConnection <- function(con, sql, format = "text", ...) {
     sql,
     con = con
   )
-  print(exsql)
   expl <- dbGetQuery(con, exsql)
 
   paste(expl[[1]], collapse = "\n")

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -189,7 +189,9 @@ db_query_fields.PostgreSQLConnection <- function(con, sql, ...) {
 # http://www.postgresql.org/docs/9.3/static/sql-explain.html
 #' @export
 db_explain.PostgreSQLConnection <- function(con, sql, format = "text", ...) {
-  format <- match.arg(format, c("text", "json", "yaml", "xml"))
+  if (!is.null(format)){
+    format <- match.arg(format, c("text", "json", "yaml", "xml"))
+  }
 
   exsql <- build_sql(
     "EXPLAIN ",
@@ -197,6 +199,7 @@ db_explain.PostgreSQLConnection <- function(con, sql, format = "text", ...) {
     sql,
     con = con
   )
+  print(exsql)
   expl <- dbGetQuery(con, exsql)
 
   paste(expl[[1]], collapse = "\n")

--- a/R/explain.R
+++ b/R/explain.R
@@ -11,7 +11,7 @@ explain.tbl_sql <- function(x, ...) {
   show_query(x)
   cat_line()
   cat_line("<PLAN>")
-  cat_line(remote_query_plan(x))
+  cat_line(remote_query_plan(x, ...))
 
   invisible(x)
 }

--- a/R/remote.R
+++ b/R/remote.R
@@ -48,6 +48,6 @@ remote_query <- function(x) {
 
 #' @export
 #' @rdname remote_name
-remote_query_plan <- function(x) {
-  db_explain(remote_con(x), db_sql_render(remote_con(x), x$ops))
+remote_query_plan <- function(x, ...) {
+  db_explain(remote_con(x), db_sql_render(remote_con(x), x$ops), ...)
 }


### PR DESCRIPTION
Redshift EXPLAIN does not accept a `(FORMAT ***)` statement following it, in contrast to PostgresSQL. This PR allows the user to pass `format = NULL` explicitly to allow `explain()` to work with `redshift`.

I am unable to provide a reproducible example, since I don't have a public instance of a redshift cluster I can connect to.