### PR TITLE
embed compat lazyeval, use tidyselect::vars_pull()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,6 +76,7 @@ Collate:
     'backend-sqlite.R'
     'backend-teradata.R'
     'build-sql.R'
+    'compat-lazyeval.R'
     'data-cache.R'
     'data-lahman.R'
     'data-nycflights13.R'

--- a/R/compat-lazyeval.R
+++ b/R/compat-lazyeval.R
@@ -1,0 +1,100 @@
+# nocov start - compat-lazyeval (last updated: rlang 0.3.0)
+
+# This file serves as a reference for compatibility functions for lazyeval.
+# Please find the most recent version in rlang's repository.
+
+
+warn_underscored <- function() {
+  return(NULL)
+  warn(paste(
+    "The underscored versions are deprecated in favour of",
+    "tidy evaluation idioms. Please see the documentation",
+    "for `quo()` in rlang"
+  ))
+}
+warn_text_se <- function() {
+  return(NULL)
+  warn("Text parsing is deprecated, please supply an expression or formula")
+}
+
+compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
+  if (warn) warn_underscored()
+
+  if (missing(lazy)) {
+    return(quo())
+  }
+  if (is_quosure(lazy)) {
+    return(lazy)
+  }
+  if (is_formula(lazy)) {
+    return(as_quosure(lazy, env))
+  }
+
+  out <- switch(typeof(lazy),
+    symbol = ,
+    language = new_quosure(lazy, env),
+    character = {
+      if (warn) warn_text_se()
+      parse_quo(lazy[[1]], env)
+    },
+    logical = ,
+    integer = ,
+    double = {
+      if (length(lazy) > 1) {
+        warn("Truncating vector to length 1")
+        lazy <- lazy[[1]]
+      }
+      new_quosure(lazy, env)
+    },
+    list =
+      if (inherits(lazy, "lazy")) {
+        lazy = new_quosure(lazy$expr, lazy$env)
+      }
+  )
+
+  if (is_null(out)) {
+    abort(sprintf("Can't convert a %s to a quosure", typeof(lazy)))
+  } else {
+    out
+  }
+}
+
+compat_lazy_dots <- function(dots, env, ..., .named = FALSE) {
+  if (missing(dots)) {
+    dots <- list()
+  }
+  if (inherits(dots, c("lazy", "formula"))) {
+    dots <- list(dots)
+  } else {
+    dots <- unclass(dots)
+  }
+  dots <- c(dots, list(...))
+
+  warn <- TRUE
+  for (i in seq_along(dots)) {
+    dots[[i]] <- compat_lazy(dots[[i]], env, warn)
+    warn <- FALSE
+  }
+
+  named <- have_name(dots)
+  if (.named && any(!named)) {
+    nms <- vapply(dots[!named], function(x) expr_text(get_expr(x)), character(1))
+    names(dots)[!named] <- nms
+  }
+
+  names(dots) <- names2(dots)
+  dots
+}
+
+compat_as_lazy <- function(quo) {
+  structure(class = "lazy", list(
+    expr = get_expr(quo),
+    env = get_env(quo)
+  ))
+}
+compat_as_lazy_dots <- function(...) {
+  structure(class = "lazy_dots", lapply(quos(...), compat_as_lazy))
+}
+
+
+# nocov end

--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -84,47 +84,47 @@ group_vars.tbl_lazy <- function(x) {
 # nocov start
 #' @export
 filter_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   filter(.data, !!!dots)
 }
 #' @export
 arrange_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   arrange(.data, !!!dots)
 }
 #' @export
 select_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   select(.data, !!!dots)
 }
 #' @export
 rename_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   rename(.data, !!!dots)
 }
 #' @export
 summarise_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   summarise(.data, !!!dots)
 }
 #' @export
 mutate_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   mutate(.data, !!!dots)
 }
 #' @export
 group_by_.tbl_lazy <- function(.data, ..., .dots = list(), add = FALSE) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   group_by(.data, !!!dots, add = add)
 }
 #' @export
 distinct_.tbl_lazy <- function(.data, ..., .dots = list(), .keep_all = FALSE) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   distinct(.data, !!! dots, .keep_all = .keep_all)
 }
 #' @export
 do_.tbl_sql <- function(.data, ..., .dots = list(), .chunk_size = 1e4L) {
-  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
+  dots <- compat_lazy_dots(.dots, caller_env(), ...)
   do(.data, !!! dots, .chunk_size = .chunk_size)
 }
 # nocov end

--- a/R/verb-pull.R
+++ b/R/verb-pull.R
@@ -1,7 +1,7 @@
 #' @export
 pull.tbl_sql <- function(.data, var = -1) {
   expr <- enquo(var)
-  var <- dplyr:::find_var(expr, tbl_vars(.data))
+  var <- tidyselect::vars_pull(tbl_vars(.data), !!expr)
 
   .data <- ungroup(.data)
   .data <- select(.data, !! sym(var))


### PR DESCRIPTION
Because this came up as part of dplyr 0.8.4 rev dev checks https://github.com/tidyverse/dplyr/issues/4579

````
# dbplyr

<details>

* Version: 1.4.2
* Source code: https://github.com/cran/dbplyr
* URL: https://dbplyr.tidyverse.org/, https://github.com/tidyverse/dbplyr
* BugReports: https://github.com/tidyverse/dbplyr/issues
* Date/Publication: 2019-06-17 20:00:04 UTC
* Number of recursive dependencies: 61

Run `revdep_details(,"dbplyr")` for more info

</details>

## Newly broken

*   checking dependencies in R code ... NOTE
    ```
    Unexported objects imported by ':::' calls:
      ‘dplyr:::compat_lazy_dots’ ‘dplyr:::find_var’
      See the note in ?`:::` about the use of this operator.
    ```
````

This:
 - includes and uses `compat-lazyeval.R` instead of using the same functions from `dplyr:::`
 - uses `tidyselect::vars_pull()` instead of `dplyr:::find_var()`

