### PR TITLE
Map str_flatten to Oracle's listagg

### DIFF
--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -49,8 +49,25 @@ sql_translate_env.Oracle <- function(con) {
       paste = sql_paste_infix(" ", "||", function(x) sql_expr(cast(!!x %as% text))),
       paste0 = sql_paste_infix("", "||", function(x) sql_expr(cast(!!x %as% text))),
     ),
-    base_odbc_agg,
-    base_odbc_win
+    sql_translator(.parent = base_odbc_agg,
+                   # str_flatten = function(x, collapse) sql_expr(listagg(!!x, !!collapse))
+                   str_flatten = function(x, collapse) {
+                     win_over_listagg(
+                       sql_expr(listagg(!!x, !!collapse)),
+                       partition = win_current_group(),
+                       order = win_current_order()
+                     )
+                   }
+    ),
+    sql_translator(.parent = base_odbc_win,
+                   str_flatten = function(x, collapse) {
+                     win_over_listagg(
+                       sql_expr(listagg(!!x, !!collapse)),
+                       partition = win_current_group(),
+                       order = win_current_order()
+                     )
+                   }
+    )
   )
 }
 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -50,7 +50,6 @@ sql_translate_env.Oracle <- function(con) {
       paste0 = sql_paste_infix("", "||", function(x) sql_expr(cast(!!x %as% text))),
     ),
     sql_translator(.parent = base_odbc_agg,
-                   # str_flatten = function(x, collapse) sql_expr(listagg(!!x, !!collapse))
                    str_flatten = function(x, collapse) {
                      win_over_listagg(
                        sql_expr(listagg(!!x, !!collapse)),

--- a/R/translate-sql-window.R
+++ b/R/translate-sql-window.R
@@ -70,6 +70,53 @@ win_over <- function(expr, partition = NULL, order = NULL, frame = NULL, con = s
   sql
 }
 
+#' @rdname win_over
+win_over_listagg <- function(expr, partition = NULL, order = NULL, con = sql_current_con()) {
+  if (length(partition) > 0) {
+    partition <- as.sql(partition)
+
+    partition <- build_sql(
+      "PARTITION BY ",
+      sql_vector(
+        escape(partition, con = con),
+        collapse = ", ",
+        parens = FALSE,
+        con = con
+      ),
+      con = con
+    )
+  }
+
+  if (length(order) > 0) {
+    order <- as.sql(order)
+
+    order <- build_sql(
+      "ORDER BY ",
+      sql_vector(
+        escape(order, con = con),
+        collapse = ", ",
+        parens = FALSE,
+        con = con
+      ),
+      con = con
+    )
+  }
+
+
+  sql <- build_sql(expr,
+            " WITHIN GROUP ",
+            sql_vector(order, parens = T, con = con),
+            " OVER ",
+            sql_vector(partition, parens = T, con = con),
+            con = con)
+
+
+  sql
+
+
+
+}
+
 rows <- function(from = -Inf, to = 0) {
   if (from >= to) stop("from must be less than to", call. = FALSE)
 

--- a/man/win_over.Rd
+++ b/man/win_over.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/translate-sql-window.R
 \name{win_over}
 \alias{win_over}
+\alias{win_over_listagg}
 \alias{win_rank}
 \alias{win_aggregate}
 \alias{win_aggregate_2}
@@ -14,6 +15,9 @@
 \title{Generate SQL expression for window functions}
 \usage{
 win_over(expr, partition = NULL, order = NULL, frame = NULL,
+  con = sql_current_con())
+
+win_over_listagg(expr, partition = NULL, order = NULL,
   con = sql_current_con())
 
 win_rank(f)


### PR DESCRIPTION
`str_flatten` is not currently supported for Oracle backends. I added a translation to `dbplyr` which uses Oracle's `listagg` equivalent to PostgreSQL's `string_agg` which powers `str_flatten` for PostgreSQL backends. Since the syntax is different I added a new `win_over` helper.