### PR TITLE
postgres backend: str_detect, str_replace and str_replace_all

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `str_detect()`, `str_replace()` and `str_replace_all()` are now correct for postgres backends (@shosaco, #362).
+
 # dbplyr 1.4.2
 
 * Fix bug when partially evaluating unquoting quosure containing a single 

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -52,11 +52,12 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
       str_locate  = function(string, pattern) {
         sql_expr(strpos(!!string, !!pattern))
       },
-      str_detect  = function(string, pattern) {
-        sql_expr(strpos(!!string, !!pattern) > 0L)
+      str_detect = sql_infix("~"),
+      str_replace = function(string, pattern, replacement){
+        sql_expr(regexp_replace(!!string, !!pattern, !!replacement))
       },
       str_replace_all = function(string, pattern, replacement){
-        sql_expr(regexp_replace(!!string, !!pattern, !!replacement))
+        sql_expr(regexp_replace(!!string, !!pattern, !!replacement, 'g'))
       },
 
       # lubridate functions

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -23,7 +23,9 @@ test_that("custom stringr functions translated correctly", {
   trans <- function(x) {
     translate_sql(!!enquo(x), con = simulate_postgres())
   }
-  expect_equal(trans(str_replace_all(x, y, z)), sql("REGEXP_REPLACE(`x`, `y`, `z`)"))
+  expect_equal(trans(str_detect(x, y)), sql("`x` ~ `y`"))
+  expect_equal(trans(str_replace(x, y, z)), sql("REGEXP_REPLACE(`x`, `y`, `z`)"))
+  expect_equal(trans(str_replace_all(x, y, z)), sql("REGEXP_REPLACE(`x`, `y`, `z`, 'g')"))
 })
 
 test_that("two variable aggregates are translated correctly", {
@@ -83,3 +85,4 @@ test_that("postgres can explain (#272)", {
     NA
   ))
 })
+


### PR DESCRIPTION
corrected str_detect so it is possible to use regular expressions, introduced str_replace and corrected str_replace_all with 'g' parameter

fixes #362 