### PR TITLE
arrange() and window_order() override previous order

### DIFF
--- a/R/verb-arrange.R
+++ b/R/verb-arrange.R
@@ -32,6 +32,10 @@ arrange.tbl_lazy <- function(.data, ..., .by_group = FALSE) {
   dots <- partial_eval_dots(dots, vars = op_vars(.data))
   names(dots) <- NULL
 
+  if (length(dots) > 0 && length(op_sort(.data$ops)) > 0) {
+    warn("Overriding previously set sort order")
+  }
+
   add_op_single(
     "arrange",
     .data,
@@ -42,7 +46,7 @@ arrange.tbl_lazy <- function(.data, ..., .by_group = FALSE) {
 
 #' @export
 op_sort.op_arrange <- function(op) {
-  c(op_sort(op$x), op$dots)
+  op$dots
 }
 
 #' @export

--- a/R/verb-window.R
+++ b/R/verb-window.R
@@ -25,6 +25,10 @@ window_order <- function(.data, ...) {
   dots <- partial_eval_dots(dots, vars = op_vars(.data))
   names(dots) <- NULL
 
+  if (length(dots) > 0 && length(op_sort(.data$ops)) > 0) {
+    warn("Overriding previously set sort order")
+  }
+
   add_op_order(.data, dots)
 }
 
@@ -41,7 +45,7 @@ add_op_order <- function(.data, dots = list()) {
 }
 #' @export
 op_sort.op_order <- function(op) {
-  c(op_sort(op$x), op$dots)
+  op$dots
 }
 
 #' @export

--- a/tests/testthat/sql/arrange-join.txt
+++ b/tests/testthat/sql/arrange-join.txt
@@ -1,0 +1,75 @@
+> lf <- lazy_frame(a = 1:3, b = 3:1)
+> rf <- lazy_frame(a = 1:3, c = 4:6)
+> # join
+> lf %>% arrange(a) %>% left_join(rf)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT `LHS`.`a` AS `a`, `LHS`.`b` AS `b`, `RHS`.`c` AS `c`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `LHS`
+LEFT JOIN `df` AS `RHS`
+ON (`LHS`.`a` = `RHS`.`a`)
+
+
+> lf %>% arrange(b) %>% left_join(rf)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT `LHS`.`a` AS `a`, `LHS`.`b` AS `b`, `RHS`.`c` AS `c`
+FROM (SELECT *
+FROM `df`
+ORDER BY `b`) `LHS`
+LEFT JOIN `df` AS `RHS`
+ON (`LHS`.`a` = `RHS`.`a`)
+
+
+> lf %>% left_join(rf) %>% arrange(a)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT *
+FROM (SELECT `LHS`.`a` AS `a`, `LHS`.`b` AS `b`, `RHS`.`c` AS `c`
+FROM `df` AS `LHS`
+LEFT JOIN `df` AS `RHS`
+ON (`LHS`.`a` = `RHS`.`a`)
+) `dbplyr_001`
+ORDER BY `a`
+
+> lf %>% left_join(rf) %>% arrange(b)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT *
+FROM (SELECT `LHS`.`a` AS `a`, `LHS`.`b` AS `b`, `RHS`.`c` AS `c`
+FROM `df` AS `LHS`
+LEFT JOIN `df` AS `RHS`
+ON (`LHS`.`a` = `RHS`.`a`)
+) `dbplyr_002`
+ORDER BY `b`
+
+> lf %>% left_join(rf %>% arrange(a))
+Message: Joining, by = "a"
+
+<SQL>
+SELECT `LHS`.`a` AS `a`, `LHS`.`b` AS `b`, `RHS`.`c` AS `c`
+FROM `df` AS `LHS`
+LEFT JOIN (SELECT *
+FROM `df`
+ORDER BY `a`) `RHS`
+ON (`LHS`.`a` = `RHS`.`a`)
+
+
+> lf %>% left_join(rf %>% arrange(c))
+Message: Joining, by = "a"
+
+<SQL>
+SELECT `LHS`.`a` AS `a`, `LHS`.`b` AS `b`, `RHS`.`c` AS `c`
+FROM `df` AS `LHS`
+LEFT JOIN (SELECT *
+FROM `df`
+ORDER BY `c`) `RHS`
+ON (`LHS`.`a` = `RHS`.`a`)
+
+

--- a/tests/testthat/sql/arrange-semi-join.txt
+++ b/tests/testthat/sql/arrange-semi-join.txt
@@ -1,0 +1,75 @@
+> lf <- lazy_frame(a = 1:3, b = 3:1)
+> rf <- lazy_frame(a = 1:3, c = 4:6)
+> # semi_join
+> lf %>% arrange(a) %>% semi_join(rf)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT * FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `LHS`
+WHERE EXISTS (
+  SELECT 1 FROM `df` AS `RHS`
+  WHERE (`LHS`.`a` = `RHS`.`a`)
+)
+
+> lf %>% arrange(b) %>% semi_join(rf)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT * FROM (SELECT *
+FROM `df`
+ORDER BY `b`) `LHS`
+WHERE EXISTS (
+  SELECT 1 FROM `df` AS `RHS`
+  WHERE (`LHS`.`a` = `RHS`.`a`)
+)
+
+> lf %>% semi_join(rf) %>% arrange(a)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT *
+FROM (SELECT * FROM `df` AS `LHS`
+WHERE EXISTS (
+  SELECT 1 FROM `df` AS `RHS`
+  WHERE (`LHS`.`a` = `RHS`.`a`)
+)) `dbplyr_001`
+ORDER BY `a`
+
+> lf %>% semi_join(rf) %>% arrange(b)
+Message: Joining, by = "a"
+
+<SQL>
+SELECT *
+FROM (SELECT * FROM `df` AS `LHS`
+WHERE EXISTS (
+  SELECT 1 FROM `df` AS `RHS`
+  WHERE (`LHS`.`a` = `RHS`.`a`)
+)) `dbplyr_002`
+ORDER BY `b`
+
+> lf %>% semi_join(rf %>% arrange(a))
+Message: Joining, by = "a"
+
+<SQL>
+SELECT * FROM `df` AS `LHS`
+WHERE EXISTS (
+  SELECT 1 FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `RHS`
+  WHERE (`LHS`.`a` = `RHS`.`a`)
+)
+
+> lf %>% semi_join(rf %>% arrange(c))
+Message: Joining, by = "a"
+
+<SQL>
+SELECT * FROM `df` AS `LHS`
+WHERE EXISTS (
+  SELECT 1 FROM (SELECT *
+FROM `df`
+ORDER BY `c`) `RHS`
+  WHERE (`LHS`.`a` = `RHS`.`a`)
+)
+

--- a/tests/testthat/sql/arrange-setop.txt
+++ b/tests/testthat/sql/arrange-setop.txt
@@ -1,0 +1,33 @@
+> lf <- lazy_frame(a = 1:3, b = 3:1)
+> rf <- lazy_frame(a = 1:3, c = 4:6)
+> # setop
+> lf %>% union_all(rf) %>% arrange(a)
+<SQL>
+SELECT *
+FROM ((SELECT `a`, `b`, NULL AS `c`
+FROM `df`)
+UNION ALL
+(SELECT `a`, NULL AS `b`, `c`
+FROM `df`)) `dbplyr_001`
+ORDER BY `a`
+
+> lf %>% arrange(a) %>% union_all(rf)
+<SQL>
+(SELECT `a`, `b`, NULL AS `c`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_002`)
+UNION ALL
+(SELECT `a`, NULL AS `b`, `c`
+FROM `df`)
+
+> lf %>% union_all(rf %>% arrange(a))
+<SQL>
+(SELECT `a`, `b`, NULL AS `c`
+FROM `df`)
+UNION ALL
+(SELECT `a`, NULL AS `b`, `c`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_003`)
+

--- a/tests/testthat/sql/arrange-single.txt
+++ b/tests/testthat/sql/arrange-single.txt
@@ -1,0 +1,75 @@
+> lf <- lazy_frame(a = 1:3, b = 3:1)
+> # head
+> lf %>% head(1) %>% arrange(a)
+<SQL>
+SELECT *
+FROM (SELECT *
+FROM `df`
+LIMIT 1) `dbplyr_001`
+ORDER BY `a`
+
+> lf %>% arrange(a) %>% head(1)
+<SQL>
+SELECT *
+FROM `df`
+ORDER BY `a`
+LIMIT 1
+
+> lf %>% arrange(a) %>% head(1) %>% arrange(b)
+<SQL>
+SELECT *
+FROM (SELECT *
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_002`
+LIMIT 1) `dbplyr_003`
+ORDER BY `b`
+
+> # mutate
+> lf %>% mutate(a = b) %>% arrange(a)
+<SQL>
+SELECT `b` AS `a`, `b`
+FROM `df`
+ORDER BY `a`
+
+> # complex mutate
+> lf %>% arrange(a) %>% mutate(a = b) %>% arrange(a)
+<SQL>
+SELECT `b` AS `a`, `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_004`
+ORDER BY `a`
+
+> lf %>% arrange(a) %>% mutate(a = 1) %>% arrange(b)
+<SQL>
+SELECT 1.0 AS `a`, `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_005`
+ORDER BY `b`
+
+> lf %>% arrange(a) %>% mutate(b = a) %>% arrange(b)
+<SQL>
+SELECT `a`, `a` AS `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_006`
+ORDER BY `b`
+
+> lf %>% arrange(a) %>% mutate(b = 1) %>% arrange(b)
+<SQL>
+SELECT `a`, 1.0 AS `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_007`
+ORDER BY `b`
+
+> lf %>% mutate(a = -a) %>% arrange(a) %>% mutate(a = -a)
+<SQL>
+SELECT -`a` AS `a`, `b`
+FROM (SELECT *
+FROM (SELECT -`a` AS `a`, `b`
+FROM `df`) `dbplyr_008`
+ORDER BY `a`) `dbplyr_009`
+

--- a/tests/testthat/sql/arrange-single.txt
+++ b/tests/testthat/sql/arrange-single.txt
@@ -16,6 +16,8 @@ ORDER BY `a`
 LIMIT 1
 
 > lf %>% arrange(a) %>% head(1) %>% arrange(b)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT *
 FROM (SELECT *
@@ -34,6 +36,8 @@ ORDER BY `a`
 
 > # complex mutate
 > lf %>% arrange(a) %>% mutate(a = b) %>% arrange(a)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT `b` AS `a`, `b`
 FROM (SELECT *
@@ -42,6 +46,8 @@ ORDER BY `a`) `dbplyr_004`
 ORDER BY `a`
 
 > lf %>% arrange(a) %>% mutate(a = 1) %>% arrange(b)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT 1.0 AS `a`, `b`
 FROM (SELECT *
@@ -50,6 +56,8 @@ ORDER BY `a`) `dbplyr_005`
 ORDER BY `b`
 
 > lf %>% arrange(a) %>% mutate(b = a) %>% arrange(b)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT `a`, `a` AS `b`
 FROM (SELECT *
@@ -58,6 +66,8 @@ ORDER BY `a`) `dbplyr_006`
 ORDER BY `b`
 
 > lf %>% arrange(a) %>% mutate(b = 1) %>% arrange(b)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT `a`, 1.0 AS `b`
 FROM (SELECT *

--- a/tests/testthat/sql/arrange.txt
+++ b/tests/testthat/sql/arrange.txt
@@ -1,0 +1,59 @@
+
+arrange renders correctly
+=========================
+
+> lf <- lazy_frame(a = 1:3, b = 3:1)
+> # basic
+> lf %>% arrange(a)
+<SQL>
+SELECT *
+FROM `df`
+ORDER BY `a`
+
+> # double arrange
+> lf %>% arrange(a) %>% arrange(b)
+<SQL>
+SELECT *
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_001`
+ORDER BY `b`
+
+> # remove ordered by
+> lf %>% arrange(a) %>% select(-a)
+<SQL>
+SELECT `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_002`
+
+> lf %>% arrange(a) %>% select(-a) %>% arrange(b)
+<SQL>
+SELECT `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_003`
+ORDER BY `b`
+
+> # un-arrange
+> lf %>% arrange(a) %>% arrange()
+<SQL>
+SELECT *
+FROM `df`
+ORDER BY `a`
+
+> lf %>% arrange(a) %>% select(-a) %>% arrange()
+<SQL>
+SELECT `b`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_004`
+
+> # use order
+> lf %>% arrange(a) %>% select(-a) %>% mutate(c = lag(b))
+<SQL>
+SELECT `b`, LAG(`b`, 1, NULL) OVER (ORDER BY `a`) AS `c`
+FROM (SELECT *
+FROM `df`
+ORDER BY `a`) `dbplyr_005`
+

--- a/tests/testthat/sql/arrange.txt
+++ b/tests/testthat/sql/arrange.txt
@@ -12,6 +12,8 @@ ORDER BY `a`
 
 > # double arrange
 > lf %>% arrange(a) %>% arrange(b)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT *
 FROM (SELECT *
@@ -28,6 +30,8 @@ FROM `df`
 ORDER BY `a`) `dbplyr_002`
 
 > lf %>% arrange(a) %>% select(-a) %>% arrange(b)
+Warning: Overriding previously set sort order
+
 <SQL>
 SELECT `b`
 FROM (SELECT *


### PR DESCRIPTION
with a warning.

This is a breaking change with two failure modes:

- For queries of the form `. %>% arrange(...) %>% ... %>% mutate(some_window_function())`, the order no longer propagates to the window function. This should lead to an error or at least a warning.
- Queries like `. %>% arrange(...) %>% arrange(...)` have a different order, with a warning.

The `ORDER BY` in subqueries is still emitted in any case. This will be fixed in future PRs.

Addresses part of #373.