### PR TITLE
add str_like() function

### DIFF
--- a/R/backend-.R
+++ b/R/backend-.R
@@ -237,6 +237,7 @@ base_scalar <- sql_translator(
   str_glue = sql_not_supported("str_glue()"),
   str_glue_data = sql_not_supported("str_glue_data()"),
   str_interp = sql_not_supported("str_interp()"),
+  str_like = sql_not_supported("str_like()"),
   str_locate = sql_not_supported("str_locate()"),
   str_locate_all = sql_not_supported("str_locate_all()"),
   str_match = sql_not_supported("str_match()"),

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -40,6 +40,15 @@ sql_translate_env.Hive <- function(con) {
 
       str_replace_all = function(string, pattern, replacement) {
         sql_expr(regexp_replace(!!string, !!pattern, !!replacement))
+      },
+
+      str_like = function(string, pattern, ignore_case = TRUE) {
+        if (isTRUE(ignore_case)) {
+          sql_expr(!!string %LIKE% !!pattern)
+        } else {
+          warn("in Hive LIKE is case insensitive")
+          sql_expr(!!string %LIKE% !!pattern)
+        }
       }
     ),
     sql_translator(.parent = base_odbc_agg,

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -146,6 +146,14 @@ simulate_mssql <- function(version = "15.0") {
       # no built in function: https://stackoverflow.com/questions/230138
       str_to_title = sql_not_supported("str_to_title()"),
       str_sub = sql_str_sub("SUBSTRING", "LEN"),
+      str_like = function(string, pattern, ignore_case = TRUE) {
+        if (isTRUE(ignore_case)) {
+          sql_expr(!!string %LIKE% !!pattern)
+        } else {
+          warn("in SQL Server LIKE is case insensitive")
+          sql_expr(!!string %LIKE% !!pattern)
+        }
+      },
 
       # lubridate ---------------------------------------------------------------
       # https://en.wikibooks.org/wiki/SQL_Dialects_Reference/Functions_and_expressions/Date_and_time_functions

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -61,6 +61,13 @@ sql_translate_env.MariaDBConnection <- function(con) {
       # but available in MariaDB. A few more details at:
       # https://www.oreilly.com/library/view/mysql-cookbook/0596001452/ch04s11.html
       str_detect = sql_infix("REGEXP"),
+      str_like = function(string, pattern, ignore_case = TRUE) {
+        if (isTRUE(ignore_case)) {
+          sql_expr(!!string %LIKE% !!pattern)
+        } else {
+          sql_expr(!!string %LIKE BINARY% !!pattern)
+        }
+      },
       str_locate = function(string, pattern) {
         sql_expr(REGEXP_INSTR(!!string, !!pattern))
       },

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -85,6 +85,13 @@ sql_translate_env.PostgreSQLConnection <- function(con) {
           sql_expr(!!string ~ !!pattern)
         }
       },
+      str_like = function(string, pattern, ignore_case = TRUE) {
+        if (isTRUE(ignore_case)) {
+          sql_expr(!!string %LIKE% !!pattern)
+        } else {
+          sql_expr(!!string %ILIKE% !!pattern)
+        }
+      },
       str_replace = function(string, pattern, replacement){
         sql_expr(regexp_replace(!!string, !!pattern, !!replacement))
       },

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -47,6 +47,15 @@ sql_translate_env.RedshiftConnection <- function(con) {
       str_replace = sql_not_supported("str_replace"),
       str_replace_all = function(string, pattern, replacement) {
         sql_expr(REGEXP_REPLACE(!!string, !!pattern, !!replacement))
+      },
+
+      # https://docs.aws.amazon.com/redshift/latest/dg/r_patternmatching_condition_like.html
+      str_like = function(string, pattern, ignore_case = TRUE) {
+        if (isTRUE(ignore_case)) {
+          sql_expr(!!string %ILIKE% !!pattern)
+        } else {
+          sql_expr(!!string %LIKE% !!pattern)
+        }
       }
     ),
     sql_translator(.parent = postgres$aggregate),

--- a/tests/testthat/test-backend-hive.R
+++ b/tests/testthat/test-backend-hive.R
@@ -5,7 +5,9 @@ test_that("custom scalar & string functions translated correctly", {
   expect_equal(translate_sql(bitwShiftR(x, 2L)),                sql("SHIFTRIGHT(`x`, 2)"))
   expect_equal(translate_sql(cot(x)),                           sql("1.0 / TAN(`x`)"))
   expect_equal(translate_sql(str_replace_all(x, "old", "new")), sql("REGEXP_REPLACE(`x`, 'old', 'new')"))
+  expect_equal(translate_sql(str_like(x, y)),                   sql("`x` LIKE `y`"))
   expect_equal(translate_sql(median(x, na.rm = TRUE)),          sql("PERCENTILE(`x`, 0.5) OVER ()"))
+  expect_warning(translate_sql(str_like(x, y, FALSE)), "in Hive LIKE is case insensitive")
 })
 
 test_that("generates custom sql", {

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -24,6 +24,8 @@ test_that("custom stringr functions translated correctly", {
   local_con(simulate_mssql())
 
   expect_equal(translate_sql(str_length(x)),     sql("LEN(`x`)"))
+  expect_equal(translate_sql(str_like(x, y)),    sql("`x` LIKE `y`"))
+  expect_warning(translate_sql(str_like(x, y, FALSE)), "in SQL Server LIKE is case insensitive")
 })
 
 test_that("custom aggregators translated correctly", {

--- a/tests/testthat/test-backend-mysql.R
+++ b/tests/testthat/test-backend-mysql.R
@@ -13,6 +13,17 @@ test_that("generates custom sql", {
   expect_snapshot(left_join(lf, lf, by = "x", na_matches = "na"))
 })
 
+test_that("custom stringr functions translated correctly", {
+  local_con(simulate_mysql())
+
+  expect_equal(translate_sql(str_c(x, y)), sql("CONCAT_WS('', `x`, `y`)"))
+  expect_equal(translate_sql(str_detect(x, y)), sql("`x` REGEXP `y`"))
+  expect_equal(translate_sql(str_like(x, y)), sql("`x` LIKE `y`"))
+  expect_equal(translate_sql(str_like(x, y, FALSE)), sql("`x` LIKE BINARY `y`"))
+  expect_equal(translate_sql(str_locate(x, y)), sql("REGEXP_INSTR(`x`, `y`)"))
+  expect_equal(translate_sql(str_replace_all(x, y, z)), sql("REGEXP_REPLACE(`x`, `y`, `z`)"))
+})
+
 # live database -----------------------------------------------------------
 
 test_that("logicals converted to integer correctly", {

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -22,6 +22,8 @@ test_that("custom stringr functions translated correctly", {
   expect_equal(translate_sql(str_squish(x)), sql("LTRIM(RTRIM(REGEXP_REPLACE(`x`, '\\s+', ' ', 'g')))"))
   expect_equal(translate_sql(str_remove(x, y)), sql("REGEXP_REPLACE(`x`, `y`, '')"))
   expect_equal(translate_sql(str_remove_all(x, y)), sql("REGEXP_REPLACE(`x`, `y`, '', 'g')"))
+  expect_equal(translate_sql(str_like(x, y)), sql("`x` LIKE `y`"))
+  expect_equal(translate_sql(str_like(x, y, ignore_case = FALSE)), sql("`x` ILIKE `y`"))
 })
 
 test_that("two variable aggregates are translated correctly", {

--- a/tests/testthat/test-backend-redshift.R
+++ b/tests/testthat/test-backend-redshift.R
@@ -15,6 +15,9 @@ test_that("string translations", {
   expect_equal(translate_sql(paste("x", "y")), sql("'x' || ' ' || 'y'"))
   expect_equal(translate_sql(paste0("x", "y")), sql("'x' || 'y'"))
   expect_equal(translate_sql(str_c("x", "y")), sql("'x' || 'y'"))
+
+  expect_equal(translate_sql(str_like(x, y)), sql("`x` ILIKE `y`"))
+  expect_equal(translate_sql(str_like(x, y, FALSE)), sql("`x` LIKE `y`"))
 })
 
 test_that("numeric translations", {


### PR DESCRIPTION
closes #509 

Made the decision that for Hive and MSSQL it would provide a warning when trying to be case sensitive and just continue on insensitively

``` r
library(dbplyr)
library(stringr)

lf <- lazy_frame(x = c("abc", "def"), con = simulate_postgres())

lf %>% 
  filter(str_like(x, "a%")) 
#> <SQL>
#> SELECT *
#> FROM `df`
#> WHERE (`x` LIKE 'a%')
```