### PR TITLE
typo in verb-slice.R

### DIFF
--- a/R/verb-slice.R
+++ b/R/verb-slice.R
@@ -49,7 +49,7 @@ NULL
 #' @importFrom dplyr slice
 #' @export
 slice.tbl_lazy <- function(.data, ...) {
-  abort("slice() is not suppoted on database backends")
+  abort("slice() is not supported on database backends")
 }
 
 #' @importFrom dplyr slice_head

--- a/tests/testthat/_snaps/verb-slice.md
+++ b/tests/testthat/_snaps/verb-slice.md
@@ -1,6 +1,6 @@
 # slice, head and tail aren't available
 
-    slice() is not suppoted on database backends
+    slice() is not supported on database backends
 
 ---
 


### PR DESCRIPTION
fixed typo in slice error message: suppoted -> supported