### PR TITLE
fixing a typo ('dbQuoteIdentifer' -> 'dbQuoteIdentifier')

### DIFF
--- a/vignettes/backend-2.Rmd
+++ b/vignettes/backend-2.Rmd
@@ -35,7 +35,7 @@ A number of generics are no longer used so you can delete the corresponding meth
 
 -   `db_write_table()` calls `DBI::dbWriteTable()` instead of nine individual generics: `db_create_indexes()`, `db_begin()`, `db_rollback()`, `db_commit()`, `db_list_tables()`, `db_drop_table()`, `db_has_table()`, `db_create_table()`, and `db_data_types()`.
 
--   `sql_escape_ident()` and `sql_escape_string()` are no longer used in favour of calling `dbQuoteIdentifer()` and `dbQuoteString()` directly.
+-   `sql_escape_ident()` and `sql_escape_string()` are no longer used in favour of calling `dbQuoteIdentifier()` and `dbQuoteString()` directly.
 
 -   `db_query_rows()` was never actually used.
 


### PR DESCRIPTION
I only found this typo after copy/pasting things from https://dbplyr.tidyverse.org/articles/backend-2.html to sparklyr source code (because sparklyr needs to be up-to-date with all the changes from `dbplyr` edition 2). Let's get this typo corrected so that other backend authors won't need to go through the same trouble.

Signed-off-by: Yitao Li <yitao@rstudio.com>