### PR TITLE
mention `dplyr::sql_translate_env()` -> `dbplyr::sql_translation()` (?)

### DIFF
--- a/vignettes/backend-2.Rmd
+++ b/vignettes/backend-2.Rmd
@@ -83,6 +83,7 @@ A number of other generics have been renamed:
 -   `dplyr::sql_semi_join()` -\> `dbplyr::sql_query_semi_join()`
 -   `dplyr::sql_set_op()` -\> `dbplyr::sql_query_set_op()`
 -   `dplyr::sql_subquery()` -\> `dbplyr::sql_query_wrap()`
+-   `dplyr::sql_translate_env()` -\> `dbplyr::sql_translation()`
 -   `dplyr::db_desc()` -\> `dbplyr::db_connection_describe()`
 
 If you have methods for any of these generics, you'll need to rename.


### PR DESCRIPTION
It looks like `dbplyr::sql_translation()` is supposed to replace `dplyr::sql_translate_env()` eventually (or at least that's what I'm empirically observing so far while attempting to fully transition `spark_connection`s of `sparklyr` to the `dbplyr` edition 2 API)

Signed-off-by: Yitao Li <yitao@rstudio.com>