### PR TITLE
Radically improved across() implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dbplyr (development version)
 
+* `across()` implementation has been rewritten to support more inputs:
+  it now translates formulas (#525), works with SQL functions that don't have
+  R translations (#534), and work with `NULL` (#554)
+
 * `pull()` no longer `select()`s the result when there's already only 
   one variable (#562).
 

--- a/tests/testthat/_snaps/partial-eval.md
+++ b/tests/testthat/_snaps/partial-eval.md
@@ -1,7 +1,7 @@
-# across() translated to individual components
+# across() translates character vectors
 
     Code
-      lf %>% summarise(across(everything(), "log"))
+      lf %>% summarise(across(a:b, "log"))
     Output
       <SQL>
       SELECT LN(`a`) AS `a`, LN(`b`) AS `b`
@@ -10,25 +10,7 @@
 ---
 
     Code
-      lf %>% summarise(across(everything(), log))
-    Output
-      <SQL>
-      SELECT LN(`a`) AS `a`, LN(`b`) AS `b`
-      FROM `df`
-
----
-
-    Code
-      lf %>% summarise(across(everything(), list(log)))
-    Output
-      <SQL>
-      SELECT LN(`a`) AS `a`, LN(`b`) AS `b`
-      FROM `df`
-
----
-
-    Code
-      lf %>% summarise(across(everything(), "log", base = 2))
+      lf %>% summarise(across(a:b, "log", base = 2))
     Output
       <SQL>
       SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
@@ -37,18 +19,103 @@
 ---
 
     Code
-      lf %>% summarise(across(everything(), c("log", "exp")))
+      lf %>% summarise(across(a, c("log", "exp")))
     Output
       <SQL>
-      SELECT LN(`a`) AS `a_log`, EXP(`a`) AS `a_exp`, LN(`b`) AS `b_log`, EXP(`b`) AS `b_exp`
+      SELECT LN(`a`) AS `a_log`, EXP(`a`) AS `a_exp`
+      FROM `df`
+
+# across() translates functions
+
+    Code
+      lf %>% summarise(across(a:b, log))
+    Output
+      <SQL>
+      SELECT LN(`a`) AS `a`, LN(`b`) AS `b`
       FROM `df`
 
 ---
 
     Code
-      lf %>% summarise(across(everything(), c("log", "exp"), .names = "{.fn}_{.col}"))
+      lf %>% summarise(across(a:b, log, base = 2))
     Output
       <SQL>
-      SELECT LN(`a`) AS `log_a`, EXP(`a`) AS `exp_a`, LN(`b`) AS `log_b`, EXP(`b`) AS `exp_b`
+      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      FROM `df`
+
+---
+
+    Code
+      lf %>% summarise(across(a:b, list(log, exp)))
+    Output
+      <SQL>
+      SELECT LN(`a`) AS `a_log`, EXP(`a`) AS `a_exp`, LN(`b`) AS `b_log`, EXP(`b`) AS `b_exp`
+      FROM `df`
+
+# untranslatable functions are preserved
+
+    Code
+      lf %>% summarise(across(a:b, SQL_LOG))
+    Output
+      <SQL>
+      SELECT SQL_LOG(`a`) AS `a`, SQL_LOG(`b`) AS `b`
+      FROM `df`
+
+# across() translates formulas
+
+    Code
+      lf %>% summarise(across(a:b, ~log(.x, 2)))
+    Output
+      <SQL>
+      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      FROM `df`
+
+---
+
+    Code
+      lf %>% summarise(across(a:b, list(~log(.x, 2))))
+    Output
+      <SQL>
+      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      FROM `df`
+
+# across() translates NULL
+
+    Code
+      lf %>% mutate(across(a:b))
+    Output
+      <SQL>
+      SELECT `a`, `b`
+      FROM `df`
+
+# old _at functions continue to work
+
+    Code
+      lf %>% dplyr::summarise_at(dplyr::vars(a:b), "sum")
+    Warning <simpleWarning>
+      Missing values are always removed in SQL.
+      Use `SUM(x, na.rm = TRUE)` to silence this warning
+      This warning is displayed only once per session.
+    Output
+      <SQL>
+      SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
+      FROM `df`
+
+---
+
+    Code
+      lf %>% dplyr::summarise_at(dplyr::vars(a:b), sum)
+    Output
+      <SQL>
+      SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
+      FROM `df`
+
+---
+
+    Code
+      lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~sum(.))
+    Output
+      <SQL>
+      SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
       FROM `df`
 

--- a/tests/testthat/test-partial-eval.R
+++ b/tests/testthat/test-partial-eval.R
@@ -17,11 +17,6 @@ test_that("can look up inlined function", {
     partial_eval(expr((!!mean)(x)), vars = "x"),
     expr(mean(x))
   )
-
-  expect_equal(
-    partial_eval(expr((!!as_function("mean"))(x)), vars = "x"),
-    expr(mean(x))
-  )
 })
 
 test_that("respects tidy evaluation pronouns", {
@@ -43,16 +38,57 @@ test_that("fails with multi-classes", {
 })
 
 # across() ----------------------------------------------------------------
+# test partial_eval_across() indirectly via SQL generation
 
-test_that("across() translated to individual components", {
-  # test partial_eval_across() indirectly via SQL generation
+test_that("across() translates character vectors", {
   lf <- lazy_frame(a = 1, b = 2)
-  expect_snapshot(lf %>% summarise(across(everything(), "log")))
-  expect_snapshot(lf %>% summarise(across(everything(), log)))
-  expect_snapshot(lf %>% summarise(across(everything(), list(log))))
+  expect_snapshot(lf %>% summarise(across(a:b, "log")))
+  expect_snapshot(lf %>% summarise(across(a:b, "log", base = 2)))
 
-  expect_snapshot(lf %>% summarise(across(everything(), "log", base = 2)))
+  expect_snapshot(lf %>% summarise(across(a, c("log", "exp"))))
 
-  expect_snapshot(lf %>% summarise(across(everything(), c("log", "exp"))))
-  expect_snapshot(lf %>% summarise(across(everything(), c("log", "exp"), .names = "{.fn}_{.col}")))
+  out <- lf %>% summarise(across(a:b, c(x = "log", y = "exp")))
+  expect_equal(colnames(out), c("a_x", "a_y", "b_x", "b_y"))
+})
+
+test_that("across() translates functions", {
+  lf <- lazy_frame(a = 1, b = 2)
+  expect_snapshot(lf %>% summarise(across(a:b, log)))
+  expect_snapshot(lf %>% summarise(across(a:b, log, base = 2)))
+
+  expect_snapshot(lf %>% summarise(across(a:b, list(log, exp))))
+
+  out <- lf %>% summarise(across(a:b, list(x = log, y = exp)))
+  expect_equal(colnames(out), c("a_x", "a_y", "b_x", "b_y"))
+})
+
+test_that("untranslatable functions are preserved", {
+  lf <- lazy_frame(a = 1, b = 2)
+  expect_snapshot(lf %>% summarise(across(a:b, SQL_LOG)))
+})
+
+test_that("across() translates formulas", {
+  lf <- lazy_frame(a = 1, b = 2)
+  expect_snapshot(lf %>% summarise(across(a:b, ~ log(.x, 2))))
+  expect_snapshot(lf %>% summarise(across(a:b, list(~ log(.x, 2)))))
+})
+
+test_that("across() translates NULL", {
+  lf <- lazy_frame(a = 1, b = 2)
+  expect_snapshot(lf %>% mutate(across(a:b)))
+})
+
+test_that("can control names", {
+  lf <- lazy_frame(a = 1, b = 2)
+  out <- lf %>% summarise(across(a:b, c("log", "exp"), .names = "{.fn}_{.col}"))
+  expect_equal(colnames(out), c("log_a", "exp_a", "log_b", "exp_b"))
+})
+
+test_that("old _at functions continue to work", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  lf <- lazy_frame(a = 1, b = 2)
+
+  expect_snapshot(lf %>% dplyr::summarise_at(dplyr::vars(a:b), "sum"))
+  expect_snapshot(lf %>% dplyr::summarise_at(dplyr::vars(a:b), sum))
+  expect_snapshot(lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~ sum(.)))
 })


### PR DESCRIPTION
Now handles `across()` using NSE approach that's more in keeping with the keeping with the rest of dbplyr's translation, so that functions without native translation are passed along. It also gains support for `.fns = NULL` and for translating functions.

Fixes #525. Fixes #534. Fixes #554.