### PR TITLE
support argument `.groups` in `summarise()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@
 * Redshift translation of `lag()` and `lead()` lose the `default` parameter 
   since its not supported (@hdplsa, #548).
 
+* `summarise()` now supports argument `.groups` (@mgirlich, #584).
+
 # dbplyr 2.0.0
 
 ## dplyr 1.0.0 compatibility

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -207,7 +207,7 @@ dbplyr_pivot_wider_spec <- function(data,
   pivot_exprs <- set_names(pivot_exprs, out_nms_repaired)
 
   data_grouped %>%
-    summarise(!!!pivot_exprs) %>%
+    summarise(!!!pivot_exprs, .groups = "drop") %>%
     group_by(!!!syms(group_vars(data)))
 }
 

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -110,8 +110,6 @@ sql_build.op_summarise <- function(op, con, ...) {
 
   .groups <- op$args$.groups
   verbose <- summarise_verbose(.groups, op$args$env_caller)
-  # we cannot automatically infer "keep" as for local frames
-  # -> use `drop_last` as it was historically
   .groups <- .groups %||% "drop_last"
 
   if (verbose && n > 1) {

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -6,6 +6,19 @@
 #'
 #' @inheritParams arrange.tbl_lazy
 #' @inheritParams dplyr::summarise
+#' @param .groups \Sexpr[results=rd]{lifecycle::badge("experimental")} Grouping structure of the result.
+#'
+#'   * "drop_last": dropping the last level of grouping. This was the
+#'   only supported option before version 1.0.0.
+#'   * "drop": All levels of grouping are dropped.
+#'   * "keep": Same grouping structure as `.data`.
+#'   * "rowwise": This is not possible for lazy data frames.
+#'
+#'   When `.groups` is not specified, it defaults to "drop_last".
+#'
+#'   In addition, a message informs you of that choice, unless the result is ungrouped,
+#'   the option "dplyr.summarise.inform" is set to `FALSE`,
+#'   or when `summarise()` is called from a function in a package.
 #' @inherit arrange.tbl_lazy return
 #' @importFrom dplyr summarise
 #' @export

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -65,15 +65,21 @@ check_summarise_vars <- function(dots) {
 }
 
 check_groups <- function(.groups) {
-  if (!is_null(.groups) && !.groups %in% c("drop_last", "drop", "keep")) {
-    abort(c(
-      paste0(
-        "`.groups` can't be ", as_label(.groups),
-        if (.groups == "rowwise") " for lazy tables"
-      ),
-      i = 'Possible values are NULL (default), "drop_last", "drop", and "keep"'
-    ))
+  if (is_null(.groups)) {
+    return()
   }
+
+  if (.groups %in% c("drop_last", "drop", "keep")) {
+    return()
+  }
+
+  abort(c(
+    paste0(
+      "`.groups` can't be ", as_label(.groups),
+      if (.groups == "rowwise") " in dbplyr"
+    ),
+    i = 'Possible values are NULL (default), "drop_last", "drop", and "keep"'
+  ))
 }
 
 #' @export

--- a/man/summarise.tbl_lazy.Rd
+++ b/man/summarise.tbl_lazy.Rd
@@ -4,13 +4,28 @@
 \alias{summarise.tbl_lazy}
 \title{Summarise each group to one row}
 \usage{
-\method{summarise}{tbl_lazy}(.data, ...)
+\method{summarise}{tbl_lazy}(.data, ..., .groups = NULL)
 }
 \arguments{
 \item{.data}{A lazy data frame backed by a database query.}
 
 \item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Variables, or functions or
 variables. Use \code{\link[dplyr:desc]{desc()}} to sort a variable in descending order.}
+
+\item{.groups}{\Sexpr[results=rd]{lifecycle::badge("experimental")} Grouping structure of the result.
+\itemize{
+\item "drop_last": dropping the last level of grouping. This was the
+only supported option before version 1.0.0.
+\item "drop": All levels of grouping are dropped.
+\item "keep": Same grouping structure as \code{.data}.
+\item "rowwise": This is not possible for lazy data frames.
+}
+
+When \code{.groups} is not specified, it defaults to "drop_last".
+
+In addition, a message informs you of that choice, unless the result is ungrouped,
+the option "dplyr.summarise.inform" is set to \code{FALSE},
+or when \code{summarise()} is called from a function in a package.}
 }
 \value{
 Another \code{tbl_lazy}. Use \code{\link[=show_query]{show_query()}} to see the generated

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -1,3 +1,20 @@
+# summarise(.groups=)
+
+    Code
+      df %>% summarise()
+    Message <message>
+      `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
+    Output
+      <SQL>
+      SELECT `x`, `y`
+      FROM `df`
+      GROUP BY `x`, `y`
+
+---
+
+    `.groups` can't be "rowwise" for lazy tables
+    i Possible values are NULL (default), "drop_last", "drop", and "keep"
+
 # quoting for rendering summarized grouped table
 
     Code

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -1,12 +1,12 @@
 # summarise(.groups=)
 
     Code
-      df %>% summarise()
+      eval_bare(expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>%
+        remote_query()), env(global_env()))
     Message <message>
       `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
     Output
-      <SQL>
-      SELECT `x`, `y`
+      <SQL> SELECT `x`, `y`
       FROM `df`
       GROUP BY `x`, `y`
 

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -12,7 +12,7 @@
 
 ---
 
-    `.groups` can't be "rowwise" for lazy tables
+    `.groups` can't be "rowwise" in dbplyr
     i Possible values are NULL (default), "drop_last", "drop", and "keep"
 
 # quoting for rendering summarized grouped table

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -1,7 +1,7 @@
 # summarise(.groups=)
 
     Code
-      eval_bare(expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>%
+      eval_bare(expr(lazy_frame(x = 1, y = 2) %>% dplyr::group_by(x, y) %>% dplyr::summarise() %>%
         remote_query()), env(global_env()))
     Message <message>
       `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -27,7 +27,21 @@ test_that("can't refer to freshly created variables", {
 test_that("summarise(.groups=)", {
   df <- lazy_frame(x = 1, y = 2) %>% group_by(x, y)
 
-  expect_snapshot(df %>% summarise())
+  # should produce a message when called directly by user
+  expect_message(eval_bare(
+    expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>% remote_query()),
+    env(global_env())
+  ))
+  expect_snapshot(eval_bare(
+    expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>% remote_query()),
+    env(global_env())
+  ))
+
+  # should be silent when called in another package
+  expect_silent(eval_bare(
+    expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>% remote_query()),
+    asNamespace("testthat")
+  ))
 
   expect_equal(df %>% summarise() %>% group_vars(), "x")
   expect_equal(df %>% summarise(.groups = "drop_last") %>% group_vars(), "x")

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -27,19 +27,20 @@ test_that("can't refer to freshly created variables", {
 test_that("summarise(.groups=)", {
   df <- lazy_frame(x = 1, y = 2) %>% group_by(x, y)
 
+  # the `dplyr::` prefix is needed for `check()`
   # should produce a message when called directly by user
   expect_message(eval_bare(
-    expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>% remote_query()),
+    expr(lazy_frame(x = 1, y = 2) %>% dplyr::group_by(x, y) %>% dplyr::summarise() %>% remote_query()),
     env(global_env())
   ))
   expect_snapshot(eval_bare(
-    expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>% remote_query()),
+    expr(lazy_frame(x = 1, y = 2) %>% dplyr::group_by(x, y) %>% dplyr::summarise() %>% remote_query()),
     env(global_env())
   ))
 
   # should be silent when called in another package
   expect_silent(eval_bare(
-    expr(lazy_frame(x = 1, y = 2) %>% group_by(x, y) %>% summarise() %>% remote_query()),
+    expr(lazy_frame(x = 1, y = 2) %>% dplyr::group_by(x, y) %>% dplyr::summarise() %>% remote_query()),
     asNamespace("testthat")
   ))
 

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -24,6 +24,19 @@ test_that("can't refer to freshly created variables", {
   )
 })
 
+test_that("summarise(.groups=)", {
+  df <- lazy_frame(x = 1, y = 2) %>% group_by(x, y)
+
+  expect_snapshot(df %>% summarise())
+
+  expect_equal(df %>% summarise() %>% group_vars(), "x")
+  expect_equal(df %>% summarise(.groups = "drop_last") %>% group_vars(), "x")
+  expect_equal(df %>% summarise(.groups = "drop") %>% group_vars(), character())
+  expect_equal(df %>% summarise(.groups = "keep") %>% group_vars(), c("x", "y"))
+
+  expect_snapshot_error(df %>% summarise(.groups = "rowwise"))
+})
+
 # sql-render --------------------------------------------------------------
 
 test_that("quoting for rendering summarized grouped table", {


### PR DESCRIPTION
closes #584 

I am not sure about the environment check in `summarise_verbose()`.