### PR TITLE
Indentation

### DIFF
--- a/R/backend-access.R
+++ b/R/backend-access.R
@@ -41,15 +41,16 @@ sql_query_select.ACCESS <- function(con, select, from,
                               where = NULL,  group_by = NULL,
                               having = NULL, order_by = NULL,
                               limit = NULL,  distinct = FALSE, ...,
-                              subquery = FALSE) {
+                              subquery = FALSE,
+                              level = 0) {
 
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, top = limit),
-    from      = sql_clause_from(con, from),
-    where     = sql_clause_where(con, where),
-    group_by  = sql_clause_group_by(con, group_by),
-    having    = sql_clause_having(con, having),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit)
+    select    = sql_clause_select(con, select, distinct, top = limit, level = level),
+    from      = sql_clause_from(con, from, level = level),
+    where     = sql_clause_where(con, where, level = level),
+    group_by  = sql_clause_group_by(con, group_by, level = level),
+    having    = sql_clause_having(con, having, level = level),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level)
   )
 }
 

--- a/R/backend-access.R
+++ b/R/backend-access.R
@@ -42,15 +42,15 @@ sql_query_select.ACCESS <- function(con, select, from,
                               having = NULL, order_by = NULL,
                               limit = NULL,  distinct = FALSE, ...,
                               subquery = FALSE,
-                              level = 0) {
+                              lvl = 0) {
 
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, top = limit, level = level),
-    from      = sql_clause_from(con, from, level = level),
-    where     = sql_clause_where(con, where, level = level),
-    group_by  = sql_clause_group_by(con, group_by, level = level),
-    having    = sql_clause_having(con, having, level = level),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level)
+    select    = sql_clause_select(con, select, distinct, top = limit, lvl = lvl),
+    from      = sql_clause_from(con, from, lvl = lvl),
+    where     = sql_clause_where(con, where, lvl = lvl),
+    group_by  = sql_clause_group_by(con, group_by, lvl = lvl),
+    having    = sql_clause_having(con, having, lvl = lvl),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, lvl = lvl)
   )
 }
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -76,14 +76,14 @@ simulate_mssql <- function(version = "15.0") {
                                              distinct = FALSE,
                                              ...,
                                              subquery = FALSE,
-                                             level = 0) {
+                                             lvl = 0) {
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, top = limit, level = level),
-    from      = sql_clause_from(con, from, level = level),
-    where     = sql_clause_where(con, where, level = level),
-    group_by  = sql_clause_group_by(con, group_by, level = level),
-    having    = sql_clause_having(con, having, level = level),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level)
+    select    = sql_clause_select(con, select, distinct, top = limit, lvl = lvl),
+    from      = sql_clause_from(con, from, lvl = lvl),
+    where     = sql_clause_where(con, where, lvl = lvl),
+    group_by  = sql_clause_group_by(con, group_by, lvl = lvl),
+    having    = sql_clause_having(con, having, lvl = lvl),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, lvl = lvl)
   )
 }
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -75,14 +75,15 @@ simulate_mssql <- function(version = "15.0") {
                                              limit = NULL,
                                              distinct = FALSE,
                                              ...,
-                                             subquery = FALSE) {
+                                             subquery = FALSE,
+                                             level = 0) {
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, top = limit),
-    from      = sql_clause_from(con, from),
-    where     = sql_clause_where(con, where),
-    group_by  = sql_clause_group_by(con, group_by),
-    having    = sql_clause_having(con, having),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit)
+    select    = sql_clause_select(con, select, distinct, top = limit, level = level),
+    from      = sql_clause_from(con, from, level = level),
+    where     = sql_clause_where(con, where, level = level),
+    group_by  = sql_clause_group_by(con, group_by, level = level),
+    having    = sql_clause_having(con, having, level = level),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level)
   )
 }
 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -110,9 +110,9 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
-    build_sql("(", from, ") ", if (!is.null(name)) ident(name), con = con)
+    build_sql(ident_subquery(from, con), " ", if (!is.null(name)) ident(name), con = con)
   } else {
-    build_sql("(", from, ") ", ident(name %||% unique_subquery_name()), con = con)
+    build_sql(ident_subquery(from, con), " ", ident(name %||% unique_subquery_name()), con = con)
   }
 }
 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -107,10 +107,10 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 }
 
 #' @export
-sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...) {
+sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
-    build_sql(ident_subquery(from, con, level), " ", if (!is.null(name)) ident(name), con = con)
+    build_sql("(", from, ") ", if (!is.null(name)) ident(name), con = con)
   } else {
     build_sql(ident_subquery(from, con, level), " ", ident(name %||% unique_subquery_name()), con = con)
   }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -110,9 +110,9 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
-    build_sql(ident_subquery(from, con), " ", if (!is.null(name)) ident(name), con = con)
+    build_sql(ident_subquery(from, con, level), " ", if (!is.null(name)) ident(name), con = con)
   } else {
-    build_sql(ident_subquery(from, con), " ", ident(name %||% unique_subquery_name()), con = con)
+    build_sql(ident_subquery(from, con, level), " ", ident(name %||% unique_subquery_name()), con = con)
   }
 }
 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -52,8 +52,7 @@ sql_query_select.Oracle <- function(con, select, from, where = NULL,
     order_by  = sql_clause_order_by(con, order_by, subquery, limit, lvl = lvl),
     # Requires Oracle 12c, released in 2013
     limit =   if (!is.null(limit)) {
-      # TODO respect lvl here
-      build_sql("FETCH FIRST ", as.integer(limit), " ROWS ONLY", con = con)
+      build_sql_line("FETCH FIRST ", as.integer(limit), " ROWS ONLY", con = con, lvl = lvl)
     }
   )
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -40,17 +40,19 @@ sql_query_select.Oracle <- function(con, select, from, where = NULL,
                              limit = NULL,
                              distinct = FALSE,
                              ...,
-                             subquery = FALSE) {
+                             subquery = FALSE,
+                             level = 0) {
 
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct),
-    from      = sql_clause_from(con, from),
-    where     = sql_clause_where(con, where),
-    group_by  = sql_clause_group_by(con, group_by),
-    having    = sql_clause_having(con, having),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit),
+    select    = sql_clause_select(con, select, distinct, level = level),
+    from      = sql_clause_from(con, from, level = level),
+    where     = sql_clause_where(con, where, level = level),
+    group_by  = sql_clause_group_by(con, group_by, level = level),
+    having    = sql_clause_having(con, having, level = level),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level),
     # Requires Oracle 12c, released in 2013
     limit =   if (!is.null(limit)) {
+      # TODO respect level here
       build_sql("FETCH FIRST ", as.integer(limit), " ROWS ONLY", con = con)
     }
   )

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -52,7 +52,8 @@ sql_query_select.Oracle <- function(con, select, from, where = NULL,
     order_by  = sql_clause_order_by(con, order_by, subquery, limit, lvl = lvl),
     # Requires Oracle 12c, released in 2013
     limit =   if (!is.null(limit)) {
-      build_sql_line("FETCH FIRST ", as.integer(limit), " ROWS ONLY", con = con, lvl = lvl)
+      sql <- build_sql("FETCH FIRST ", as.integer(limit), " ROWS ONLY", con = con)
+      indent_lvl(sql, lvl)
     }
   )
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -41,18 +41,18 @@ sql_query_select.Oracle <- function(con, select, from, where = NULL,
                              distinct = FALSE,
                              ...,
                              subquery = FALSE,
-                             level = 0) {
+                             lvl = 0) {
 
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, level = level),
-    from      = sql_clause_from(con, from, level = level),
-    where     = sql_clause_where(con, where, level = level),
-    group_by  = sql_clause_group_by(con, group_by, level = level),
-    having    = sql_clause_having(con, having, level = level),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level),
+    select    = sql_clause_select(con, select, distinct, lvl = lvl),
+    from      = sql_clause_from(con, from, lvl = lvl),
+    where     = sql_clause_where(con, where, lvl = lvl),
+    group_by  = sql_clause_group_by(con, group_by, lvl = lvl),
+    having    = sql_clause_having(con, having, lvl = lvl),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, lvl = lvl),
     # Requires Oracle 12c, released in 2013
     limit =   if (!is.null(limit)) {
-      # TODO respect level here
+      # TODO respect lvl here
       build_sql("FETCH FIRST ", as.integer(limit), " ROWS ONLY", con = con)
     }
   )
@@ -107,12 +107,12 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 }
 
 #' @export
-sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
+sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
     build_sql("(", from, ") ", if (!is.null(name)) ident(name), con = con)
   } else {
-    build_sql(ident_subquery(from, con, level), " ", ident(name %||% unique_subquery_name()), con = con)
+    build_sql(ident_subquery(from, con, lvl), " ", ident(name %||% unique_subquery_name()), con = con)
   }
 }
 

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -45,9 +45,10 @@ sql_query_explain.SQLiteConnection <- function(con, sql, ...) {
 #' @export
 sql_query_set_op.SQLiteConnection <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   # SQLite does not allow parentheses
+  method <- paste0(method, if (all) " ALL")
   build_sql(
     x,
-    "\n", sql_clause_kw(method, if (all) " ALL", lvl = lvl), "\n",
+    "\n", indent_lvl(sql_kw(method), lvl = lvl), "\n",
     y,
     con = con
   )
@@ -148,7 +149,7 @@ sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by 
   if (type == "full") {
     join_sql <- build_sql(
       sql_query_join(con, x, y, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl + 1),
-      sql_clause_kw("UNION", lvl = lvl + 1), "\n",
+      indent_lvl(sql_kw("UNION"), lvl = lvl + 1), "\n",
       sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl + 1),
       con = con
     )

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -43,11 +43,12 @@ sql_query_explain.SQLiteConnection <- function(con, sql, ...) {
 }
 
 #' @export
-sql_query_set_op.SQLiteConnection <- function(con, x, y, method, ..., all = FALSE) {
+sql_query_set_op.SQLiteConnection <- function(con, x, y, method, ..., all = FALSE, level = 0) {
   # SQLite does not allow parentheses
   build_sql(
+    # TODO extract into function?
     x,
-    "\n", sql(method), if (all) sql(" ALL"), "\n",
+    "\n", !!get_clause_indent(level), sql(method), if (all) sql(" ALL"), "\n",
     y,
     con = con
   )

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -162,6 +162,7 @@ sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by 
       level = level
     )
   } else if (type == "right") {
+    # TODO remove superfluous line break
     sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., level = level)
   } else {
     NextMethod()

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -43,12 +43,12 @@ sql_query_explain.SQLiteConnection <- function(con, sql, ...) {
 }
 
 #' @export
-sql_query_set_op.SQLiteConnection <- function(con, x, y, method, ..., all = FALSE, level = 0) {
+sql_query_set_op.SQLiteConnection <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   # SQLite does not allow parentheses
   build_sql(
     # TODO extract into function?
     x,
-    "\n", !!get_clause_indent(level), sql(method), if (all) sql(" ALL"), "\n",
+    "\n", !!get_clause_indent(lvl), sql(method), if (all) sql(" ALL"), "\n",
     y,
     con = con
   )
@@ -119,15 +119,15 @@ sql_escape_logical.SQLiteConnection <- function(con, x){
 }
 
 #' @export
-sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
+sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
   if (is.ident(from)) {
     setNames(from, name)
   } else {
 
     if (is.null(name)) {
-      build_sql(ident_subquery(from, con, level), con = con)
+      build_sql(ident_subquery(from, con, lvl), con = con)
     } else {
-      build_sql(ident_subquery(from, con, level), " AS ", ident(name), con = con)
+      build_sql(ident_subquery(from, con, lvl), " AS ", ident(name), con = con)
     }
   }
 }
@@ -139,7 +139,7 @@ sql_expr_matches.SQLiteConnection <- function(con, x, y) {
 }
 
 #' @export
-sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by = NULL, na_matches = FALSE, ..., level = 0) {
+sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by = NULL, na_matches = FALSE, ..., lvl = 0) {
   # workaround as SQLite doesn't support FULL OUTER JOIN and RIGHT JOIN
   # see: https://www.sqlite.org/omitted.html
 
@@ -148,9 +148,9 @@ sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by 
 
   if (type == "full") {
     join_sql <- build_sql(
-      sql_query_join(con, x, y, vars, type = "left", by = by, na_matches = na_matches, ..., level = level + 1),
-      !!get_clause_indent(level + 1), "UNION\n",
-      sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., level = level + 1),
+      sql_query_join(con, x, y, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl + 1),
+      !!get_clause_indent(lvl + 1), "UNION\n",
+      sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl + 1),
       con = con
     )
 
@@ -158,13 +158,13 @@ sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by 
       con,
       select = ident(vars$alias),
       # TODO this should probably be `dbplyr_sql_subquery`
-      from = sql_subquery(con, join_sql, level = level),
+      from = sql_subquery(con, join_sql, lvl = lvl),
       subquery = TRUE,
-      level = level
+      lvl = lvl
     )
   } else if (type == "right") {
     # TODO remove superfluous line break
-    sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., level = level)
+    sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl)
   } else {
     NextMethod()
   }

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -124,9 +124,9 @@ sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_na
   } else {
 
     if (is.null(name)) {
-      build_sql(ident_subquery(from, con), con = con)
+      build_sql(ident_subquery(from, con, level), con = con)
     } else {
-      build_sql(ident_subquery(from, con), " AS ", ident(name), con = con)
+      build_sql(ident_subquery(from, con, level), " AS ", ident(name), con = con)
     }
   }
 }

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -46,9 +46,8 @@ sql_query_explain.SQLiteConnection <- function(con, sql, ...) {
 sql_query_set_op.SQLiteConnection <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   # SQLite does not allow parentheses
   build_sql(
-    # TODO extract into function?
     x,
-    "\n", !!get_clause_indent(lvl), sql(method), if (all) sql(" ALL"), "\n",
+    "\n", sql_clause_kw(method, if (all) " ALL", lvl = lvl), "\n",
     y,
     con = con
   )
@@ -149,7 +148,7 @@ sql_query_join.SQLiteConnection <- function(con, x, y, vars, type = "inner", by 
   if (type == "full") {
     join_sql <- build_sql(
       sql_query_join(con, x, y, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl + 1),
-      !!get_clause_indent(lvl + 1), "UNION\n",
+      sql_clause_kw("UNION", lvl = lvl + 1), "\n",
       sql_query_join(con, y, x, vars, type = "left", by = by, na_matches = na_matches, ..., lvl = lvl + 1),
       con = con
     )

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -118,7 +118,7 @@ sql_escape_logical.SQLiteConnection <- function(con, x){
 }
 
 #' @export
-sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_name(), ...) {
+sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
   if (is.ident(from)) {
     setNames(from, name)
   } else {

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -122,10 +122,11 @@ sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_na
   if (is.ident(from)) {
     setNames(from, name)
   } else {
+
     if (is.null(name)) {
-      build_sql("(", from, ")", con = con)
+      build_sql(ident_subquery(from, con), con = con)
     } else {
-      build_sql("(", from, ") AS ", ident(name), con = con)
+      build_sql(ident_subquery(from, con), " AS ", ident(name), con = con)
     }
   }
 }

--- a/R/backend-teradata.R
+++ b/R/backend-teradata.R
@@ -36,15 +36,16 @@ sql_query_select.Teradata <- function(con, select, from, where = NULL,
                                              limit = NULL,
                                              distinct = FALSE,
                                              ...,
-                                             subquery = FALSE) {
+                                             subquery = FALSE,
+                                             level = 0) {
 
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, top = limit),
-    from      = sql_clause_from(con, from),
-    where     = sql_clause_where(con, where),
-    group_by  = sql_clause_group_by(con, group_by),
-    having    = sql_clause_having(con, having),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit)
+    select    = sql_clause_select(con, select, distinct, top = limit, level = level),
+    from      = sql_clause_from(con, from, level = level),
+    where     = sql_clause_where(con, where, level = level),
+    group_by  = sql_clause_group_by(con, group_by, level = level),
+    having    = sql_clause_having(con, having, level = level),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level)
   )
 }
 

--- a/R/backend-teradata.R
+++ b/R/backend-teradata.R
@@ -37,15 +37,15 @@ sql_query_select.Teradata <- function(con, select, from, where = NULL,
                                              distinct = FALSE,
                                              ...,
                                              subquery = FALSE,
-                                             level = 0) {
+                                             lvl = 0) {
 
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct, top = limit, level = level),
-    from      = sql_clause_from(con, from, level = level),
-    where     = sql_clause_where(con, where, level = level),
-    group_by  = sql_clause_group_by(con, group_by, level = level),
-    having    = sql_clause_having(con, having, level = level),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level)
+    select    = sql_clause_select(con, select, distinct, top = limit, lvl = lvl),
+    from      = sql_clause_from(con, from, lvl = lvl),
+    where     = sql_clause_where(con, where, lvl = lvl),
+    group_by  = sql_clause_group_by(con, group_by, lvl = lvl),
+    having    = sql_clause_having(con, having, lvl = lvl),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, lvl = lvl)
   )
 }
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -284,7 +284,7 @@ sql_query_join.DBIConnection <- function(con, x, y, vars, type = "inner", by = N
     stop("Unknown join type:", type, call. = FALSE)
   )
 
-  select <- sql_join_vars(con, vars, lvl = lvl)
+  select <- sql_join_vars(con, vars)
   on <- sql_join_tbls(con, by, na_matches = na_matches)
 
   # Wrap with SELECT since callers assume a valid query is returned

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -292,6 +292,7 @@ sql_query_join.DBIConnection <- function(con, x, y, vars, type = "inner", by = N
     sql_clause_select(con, select, level = level), "\n",
     sql_clause_from(con, x, level = level), "\n",
     !!get_clause_indent(level), JOIN, " ", y, "\n",
+    # TODO probably this can be done via `sql_clause_generic()`
     if (!is.null(on)) build_sql(!!get_clause_indent(level), "ON ", on, "\n", con = con) else NULL,
     con = con
   )

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -171,11 +171,11 @@ sql_query_save.DBIConnection <- function(con, sql, name, temporary = TRUE, ...) 
 }
 #' @export
 #' @rdname db-sql
-sql_query_wrap <- function(con, from, name = unique_subquery_name(), ...) {
+sql_query_wrap <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
   UseMethod("sql_query_wrap")
 }
 #' @export
-sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(), ...) {
+sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
   if (is.ident(from)) {
     setNames(from, name)
   } else if (is.schema(from)) {
@@ -207,7 +207,8 @@ sql_query_select <- function(con, select, from, where = NULL,
                              limit = NULL,
                              distinct = FALSE,
                              ...,
-                             subquery = FALSE) {
+                             subquery = FALSE,
+                             level = 0) {
   UseMethod("sql_query_select")
 }
 
@@ -218,15 +219,16 @@ sql_query_select.DBIConnection <- function(con, select, from, where = NULL,
                                limit = NULL,
                                distinct = FALSE,
                                ...,
-                               subquery = FALSE) {
+                               subquery = FALSE,
+                               level = 0) {
   sql_select_clauses(con,
-    select    = sql_clause_select(con, select, distinct),
-    from      = sql_clause_from(con, from),
-    where     = sql_clause_where(con, where),
-    group_by  = sql_clause_group_by(con, group_by),
-    having    = sql_clause_having(con, having),
-    order_by  = sql_clause_order_by(con, order_by, subquery, limit),
-    limit     = sql_clause_limit(con, limit)
+    select    = sql_clause_select(con, select, distinct, level = level),
+    from      = sql_clause_from(con, from, level = level),
+    where     = sql_clause_where(con, where, level = level),
+    group_by  = sql_clause_group_by(con, group_by, level = level),
+    having    = sql_clause_having(con, having, level = level),
+    order_by  = sql_clause_order_by(con, order_by, subquery, limit, level = level),
+    limit     = sql_clause_limit(con, limit, level = level)
   )
 }
 dbplyr_query_select <- function(con, ...) {
@@ -417,6 +419,6 @@ dbplyr_sql_subquery <- function(con, ...) {
 }
 #' @export
 #' @importFrom dplyr sql_subquery
-sql_subquery.DBIConnection <- function(con, from, name = unique_subquery_name(), ...) {
-  sql_query_wrap(con, from = from, name = name, ...)
+sql_subquery.DBIConnection <- function(con, from, name = unique_subquery_name(), ..., level = 0) {
+  sql_query_wrap(con, from = from, name = name, ..., level = level)
 }

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -181,7 +181,13 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
   } else if (is.schema(from)) {
     setNames(as.sql(from, con), name)
   } else {
-    build_sql("(", from, ") ", ident(name %||% unique_subquery_name()), con = con)
+    ident_name <- ident(name %||% unique_subquery_name())
+    # TODO allow better control via option
+    if (getOption("dbplyr_break_subquery", FALSE)) {
+      build_sql("(\n", from, "\n) ", ident_name, con = con)
+    } else {
+      build_sql("(", from, ") ", ident_name, con = con)
+    }
   }
 }
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -348,15 +348,17 @@ sql_semi_join.DBIConnection <- function(con, x, y, anti = FALSE, by = NULL, ...,
 
 #' @rdname db-sql
 #' @export
-sql_query_set_op <- function(con, x, y, method, ..., all = FALSE) {
+sql_query_set_op <- function(con, x, y, method, ..., all = FALSE, level = 0) {
   UseMethod("sql_query_set_op")
 }
 #' @export
-sql_query_set_op.DBIConnection <- function(con, x, y, method, ..., all = FALSE) {
+sql_query_set_op.DBIConnection <- function(con, x, y, method, ..., all = FALSE, level) {
   build_sql(
-    "(", x, ")",
-    "\n", sql(method), if (all) sql(" ALL"), "\n",
-    "(", y, ")",
+    # TODO extract into function
+    # TODO legacy mode doesn't work
+    !!get_clause_indent(level), "(\n", x, "\n", !!get_clause_indent(level), ")",
+    "\n", !!get_clause_indent(level), sql(method), if (all) sql(" ALL"), "\n",
+    !!get_clause_indent(level), "(\n", y, "\n", !!get_clause_indent(level), ")",
     con = con
   )
 }

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -188,7 +188,7 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
 
 ident_subquery <- function(from, con, lvl) {
   multi_line <- grepl(x = from, pattern = "\\r\\n|\\r|\\n")
-  if (!is_legacy_strategy() && multi_line) {
+  if (multi_line) {
     build_sql("(\n", from, "\n", get_clause_indent(lvl), ")", con = con)
   } else {
     build_sql("(", from, ")", con = con)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -188,7 +188,7 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
 
 ident_subquery <- function(from, con, lvl) {
   multi_line <- grepl(x = from, pattern = "\\r\\n|\\r|\\n")
-  if (getOption("dbplyr_break_subquery", FALSE) && multi_line) {
+  if (!is_legacy_strategy() && multi_line) {
     build_sql("(\n", from, "\n", get_clause_indent(lvl), ")", con = con)
   } else {
     build_sql("(", from, ")", con = con)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -182,12 +182,16 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
     setNames(as.sql(from, con), name)
   } else {
     ident_name <- ident(name %||% unique_subquery_name())
-    # TODO allow better control via option
-    if (getOption("dbplyr_break_subquery", FALSE)) {
-      build_sql("(\n", from, "\n) ", ident_name, con = con)
-    } else {
-      build_sql("(", from, ") ", ident_name, con = con)
-    }
+    build_sql(ident_subquery(from, con), " ", ident_name, con = con)
+  }
+}
+
+ident_subquery <- function(from, con) {
+  # TODO allow better control via option
+  if (getOption("dbplyr_break_subquery", FALSE)) {
+    build_sql("(\n", from, "\n)", con = con)
+  } else {
+    build_sql("(", from, ")", con = con)
   }
 }
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -182,14 +182,14 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
     setNames(as.sql(from, con), name)
   } else {
     ident_name <- ident(name %||% unique_subquery_name())
-    build_sql(ident_subquery(from, con), " ", ident_name, con = con)
+    build_sql(ident_subquery(from, con, level), " ", ident_name, con = con)
   }
 }
 
-ident_subquery <- function(from, con) {
+ident_subquery <- function(from, con, level) {
   # TODO allow better control via option
   if (getOption("dbplyr_break_subquery", FALSE)) {
-    build_sql("(\n", from, "\n)", con = con)
+    build_sql("(\n", from, "\n", !!lvl_indent(level), ")", con = con)
   } else {
     build_sql("(", from, ")", con = con)
   }

--- a/R/escape.R
+++ b/R/escape.R
@@ -31,7 +31,7 @@
 #' escape_ansi("X")
 #' escape_ansi(escape_ansi("X"))
 #' escape_ansi(escape_ansi(escape_ansi("X")))
-escape <- function(x, parens = NA, collapse = " ", con = NULL, align_as = FALSE) {
+escape <- function(x, parens = NA, collapse = " ", con = NULL) {
   if (is.null(con)) {
     stop("`con` must not be NULL", call. = FALSE)
   }
@@ -46,39 +46,39 @@ escape_ansi <- function(x, parens = NA, collapse = "") {
 }
 
 #' @export
-escape.ident <- function(x, parens = FALSE, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.ident <- function(x, parens = FALSE, collapse = ", ", con = NULL) {
   y <- sql_escape_ident(con, x)
-  sql_vector(names_to_as(y, names2(x), con = con, align_as = align_as), parens, collapse, con = con)
+  sql_vector(names_to_as(y, names2(x), con = con), parens, collapse, con = con)
 }
 
 #' @export
-escape.logical <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.logical <- function(x, parens = NA, collapse = ", ", con = NULL) {
   sql_vector(sql_escape_logical(con, x), parens, collapse, con = con)
 }
 
 #' @export
-escape.factor <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.factor <- function(x, parens = NA, collapse = ", ", con = NULL) {
   x <- as.character(x)
   escape.character(x, parens = parens, collapse = collapse, con = con)
 }
 
 #' @export
-escape.Date <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.Date <- function(x, parens = NA, collapse = ", ", con = NULL) {
   sql_vector(sql_escape_date(con, x), parens, collapse, con = con)
 }
 
 #' @export
-escape.POSIXt <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.POSIXt <- function(x, parens = NA, collapse = ", ", con = NULL) {
   sql_vector(sql_escape_datetime(con, x), parens, collapse, con = con)
 }
 
 #' @export
-escape.character <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.character <- function(x, parens = NA, collapse = ", ", con = NULL) {
   sql_vector(sql_escape_string(con, x), parens, collapse, con = con)
 }
 
 #' @export
-escape.double <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.double <- function(x, parens = NA, collapse = ", ", con = NULL) {
   out <- ifelse(is.wholenumber(x), sprintf("%.1f", x), as.character(x))
 
   # Special values
@@ -91,47 +91,47 @@ escape.double <- function(x, parens = NA, collapse = ", ", con = NULL, align_as 
 }
 
 #' @export
-escape.integer <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.integer <- function(x, parens = NA, collapse = ", ", con = NULL) {
   x[is.na(x)] <- "NULL"
   sql_vector(x, parens, collapse, con = con)
 }
 
 #' @export
-escape.integer64 <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.integer64 <- function(x, parens = NA, collapse = ", ", con = NULL) {
   x <- as.character(x)
   x[is.na(x)] <- "NULL"
   sql_vector(x, parens, collapse, con = con)
 }
 
 #' @export
-escape.blob <- function(x, parens = NA, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.blob <- function(x, parens = NA, collapse = ", ", con = NULL) {
   pieces <- vapply(x, sql_escape_raw, character(1), con = con)
   sql_vector(pieces, isTRUE(parens) || length(pieces) > 1, collapse, con = con)
 }
 
 #' @export
-escape.NULL <- function(x, parens = NA, collapse = " ", con = NULL, align_as = FALSE) {
+escape.NULL <- function(x, parens = NA, collapse = " ", con = NULL) {
   sql("NULL")
 }
 
 #' @export
-escape.sql <- function(x, parens = NULL, collapse = NULL, con = NULL, align_as = FALSE) {
-  sql_vector(x, isTRUE(parens), collapse, con = con, align_as = align_as)
+escape.sql <- function(x, parens = NULL, collapse = NULL, con = NULL) {
+  sql_vector(x, isTRUE(parens), collapse, con = con)
 }
 
 #' @export
-escape.list <- function(x, parens = TRUE, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.list <- function(x, parens = TRUE, collapse = ", ", con = NULL) {
   pieces <- vapply(x, escape, character(1), con = con)
   sql_vector(pieces, parens, collapse, con = con)
 }
 
 #' @export
-escape.data.frame <- function(x, parens = TRUE, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.data.frame <- function(x, parens = TRUE, collapse = ", ", con = NULL) {
   error_embed("a data.frame", "df$x")
 }
 
 #' @export
-escape.reactivevalues <- function(x, parens = TRUE, collapse = ", ", con = NULL, align_as = FALSE) {
+escape.reactivevalues <- function(x, parens = TRUE, collapse = ", ", con = NULL) {
   error_embed("shiny inputs", "inputs$x")
 }
 
@@ -145,7 +145,7 @@ error_embed <- function(type, expr) {
 
 #' @export
 #' @rdname escape
-sql_vector <- function(x, parens = NA, collapse = " ", con = NULL, align_as = FALSE) {
+sql_vector <- function(x, parens = NA, collapse = " ", con = NULL) {
   if (is.null(con)) {
     stop("`con` must not be NULL", call. = FALSE)
   }
@@ -162,23 +162,19 @@ sql_vector <- function(x, parens = NA, collapse = " ", con = NULL, align_as = FA
     parens <- length(x) > 1L
   }
 
-  x <- names_to_as(x, con = con, align_as = align_as)
+  x <- names_to_as(x, con = con)
   x <- paste(x, collapse = collapse)
   if (parens) x <- paste0("(", x, ")")
   sql(x)
 }
 
-names_to_as <- function(x, names = names2(x), con = NULL, align_as = FALSE) {
+names_to_as <- function(x, names = names2(x), con = NULL) {
   if (length(x) == 0) {
     return(character())
   }
 
   names_esc <- sql_escape_ident(con, names)
   as <- ifelse(names == "" | names_esc == x, "", paste0(" AS ", names_esc))
-  if (is_true(align_as)) {
-    n <- max(nchar(x))
-    x <- paste0(x, rep_char(n - nchar(x), " "))
-  }
 
   paste0(x, as)
 }

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -33,12 +33,14 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, leve
   from_x <- dbplyr_sql_subquery(
     con,
     sql_render(query$x, con, ..., subquery = TRUE, level = level + 1),
-    name = "LHS"
+    name = "LHS",
+    level = level
   )
   from_y <- dbplyr_sql_subquery(
     con,
     sql_render(query$y, con, ..., subquery = TRUE, level = level + 1),
-    name = "RHS"
+    name = "RHS",
+    level = level
   )
 
   dbplyr_query_join(con, from_x, from_y,

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -53,7 +53,7 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, leve
 # SQL generation ----------------------------------------------------------
 
 
-sql_join_vars <- function(con, vars) {
+sql_join_vars <- function(con, vars, level = 0) {
   sql_vector(
     mapply(
       FUN = sql_join_var,
@@ -65,7 +65,7 @@ sql_join_vars <- function(con, vars) {
       USE.NAMES = TRUE
     ),
     parens = FALSE,
-    collapse = ", ",
+    collapse = get_field_separator(compare, sep = ",", level),
     con = con
   )
 }
@@ -88,7 +88,7 @@ sql_join_var <- function(con, alias, x, y, all_x, all_y) {
   }
 }
 
-sql_join_tbls <- function(con, by, na_matches = "never") {
+sql_join_tbls <- function(con, by, na_matches = "never", level = 0) {
   na_matches <- arg_match(na_matches, c("na", "never"))
 
   on <- NULL
@@ -104,8 +104,11 @@ sql_join_tbls <- function(con, by, na_matches = "never") {
       compare <- paste0(lhs, " = ", rhs)
     }
 
-    on <- sql_vector(compare, collapse = " AND ", parens = TRUE, con = con)
+    # TODO line break after "(" and before ")" and indent before ")"
+    coll <- get_field_separator(compare, sep = " AND", level)
+    on <- sql_vector(compare, collapse = coll, parens = TRUE, con = con)
   } else if (length(by$on) > 0) {
+    # TODO needs indent
     on <- build_sql("(", by$on, ")", con = con)
   }
 

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -55,7 +55,7 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl 
 # SQL generation ----------------------------------------------------------
 
 
-sql_join_vars <- function(con, vars, lvl = 0) {
+sql_join_vars <- function(con, vars) {
   join_vars_list <- mapply(
     FUN = sql_join_var,
     alias = vars$alias,

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -29,18 +29,18 @@ print.join_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   from_x <- dbplyr_sql_subquery(
     con,
-    sql_render(query$x, con, ..., subquery = TRUE, level = level + 1),
+    sql_render(query$x, con, ..., subquery = TRUE, lvl = lvl + 1),
     name = "LHS",
-    level = level
+    lvl = lvl
   )
   from_y <- dbplyr_sql_subquery(
     con,
-    sql_render(query$y, con, ..., subquery = TRUE, level = level + 1),
+    sql_render(query$y, con, ..., subquery = TRUE, lvl = lvl + 1),
     name = "RHS",
-    level = level
+    lvl = lvl
   )
 
   dbplyr_query_join(con, from_x, from_y,
@@ -48,14 +48,14 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, leve
     type = query$type,
     by = query$by,
     na_matches = query$na_matches,
-    level = level
+    lvl = lvl
   )
 }
 
 # SQL generation ----------------------------------------------------------
 
 
-sql_join_vars <- function(con, vars, level = 0) {
+sql_join_vars <- function(con, vars, lvl = 0) {
   join_vars_list <- mapply(
     FUN = sql_join_var,
     alias = vars$alias,
@@ -87,7 +87,7 @@ sql_join_var <- function(con, alias, x, y, all_x, all_y) {
   }
 }
 
-sql_join_tbls <- function(con, by, na_matches = "never", level = 0) {
+sql_join_tbls <- function(con, by, na_matches = "never", lvl = 0) {
   na_matches <- arg_match(na_matches, c("na", "never"))
 
   on <- NULL
@@ -104,7 +104,7 @@ sql_join_tbls <- function(con, by, na_matches = "never", level = 0) {
     }
 
     # TODO line break after "(" and before ")" and indent before ")"
-    coll <- get_field_separator(compare, sep = " AND", level)
+    coll <- get_field_separator(compare, sep = " AND", lvl)
     on <- sql_vector(compare, collapse = coll, parens = TRUE, con = con)
   } else if (length(by$on) > 0) {
     # TODO needs indent

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -56,20 +56,17 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, leve
 
 
 sql_join_vars <- function(con, vars, level = 0) {
-  sql_vector(
-    mapply(
-      FUN = sql_join_var,
-      alias = vars$alias,
-      x = vars$x,
-      y = vars$y,
-      MoreArgs = list(con = con, all_x = vars$all_x, all_y = vars$all_y),
-      SIMPLIFY = FALSE,
-      USE.NAMES = TRUE
-    ),
-    parens = FALSE,
-    collapse = get_field_separator(compare, sep = ",", level),
-    con = con
+  join_vars_list <- mapply(
+    FUN = sql_join_var,
+    alias = vars$alias,
+    x = vars$x,
+    y = vars$y,
+    MoreArgs = list(con = con, all_x = vars$all_x, all_y = vars$all_y),
+    SIMPLIFY = FALSE,
+    USE.NAMES = TRUE
   )
+
+  sql(unlist(join_vars_list))
 }
 
 sql_join_var <- function(con, alias, x, y, all_x, all_y) {

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -29,15 +29,15 @@ print.join_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE) {
+sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
   from_x <- dbplyr_sql_subquery(
     con,
-    sql_render(query$x, con, ..., subquery = TRUE),
+    sql_render(query$x, con, ..., subquery = TRUE, level = level + 1),
     name = "LHS"
   )
   from_y <- dbplyr_sql_subquery(
     con,
-    sql_render(query$y, con, ..., subquery = TRUE),
+    sql_render(query$y, con, ..., subquery = TRUE, level = level + 1),
     name = "RHS"
   )
 
@@ -45,7 +45,8 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE) {
     vars = query$vars,
     type = query$type,
     by = query$by,
-    na_matches = query$na_matches
+    na_matches = query$na_matches,
+    level = level
   )
 }
 

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -87,7 +87,7 @@ sql_join_var <- function(con, alias, x, y, all_x, all_y) {
   }
 }
 
-sql_join_tbls <- function(con, by, na_matches = "never", lvl = 0) {
+sql_join_tbls <- function(con, by, na_matches = "never") {
   na_matches <- arg_match(na_matches, c("na", "never"))
 
   on <- NULL
@@ -103,15 +103,10 @@ sql_join_tbls <- function(con, by, na_matches = "never", lvl = 0) {
       compare <- paste0(lhs, " = ", rhs)
     }
 
-    # TODO line break after "(" and before ")" and indent before ")"
-    coll <- get_field_separator(compare, sep = " AND", lvl)
-    on <- sql_vector(compare, collapse = coll, parens = TRUE, con = con)
+    sql(compare)
   } else if (length(by$on) > 0) {
-    # TODO needs indent
-    on <- build_sql("(", by$on, ")", con = con)
+    by$on
   }
-
-  on
 }
 
 sql_table_prefix <- function(con, var, table = NULL) {

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -100,9 +100,9 @@ select_query_clauses <- function(x, subquery = FALSE) {
 }
 
 #' @export
-sql_render.select_query <- function(query, con, ..., subquery = FALSE) {
+sql_render.select_query <- function(query, con, ..., subquery = FALSE, level = 0) {
   from <- dbplyr_sql_subquery(con,
-    sql_render(query$from, con, ..., subquery = TRUE),
+    sql_render(query$from, con, ..., subquery = TRUE, level = level + 1),
     name = NULL
   )
 
@@ -115,7 +115,8 @@ sql_render.select_query <- function(query, con, ..., subquery = FALSE) {
     limit = query$limit,
     distinct = query$distinct,
     ...,
-    subquery = subquery
+    subquery = subquery,
+    level = level
   )
 }
 

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -100,11 +100,11 @@ select_query_clauses <- function(x, subquery = FALSE) {
 }
 
 #' @export
-sql_render.select_query <- function(query, con, ..., subquery = FALSE, level = 0) {
+sql_render.select_query <- function(query, con, ..., subquery = FALSE, lvl = 0) {
   from <- dbplyr_sql_subquery(con,
-    sql_render(query$from, con, ..., subquery = TRUE, level = level + 1),
+    sql_render(query$from, con, ..., subquery = TRUE, lvl = lvl + 1),
     name = NULL,
-    level = level
+    lvl = lvl
   )
 
   dbplyr_query_select(
@@ -117,7 +117,7 @@ sql_render.select_query <- function(query, con, ..., subquery = FALSE, level = 0
     distinct = query$distinct,
     ...,
     subquery = subquery,
-    level = level
+    lvl = lvl
   )
 }
 

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -103,7 +103,8 @@ select_query_clauses <- function(x, subquery = FALSE) {
 sql_render.select_query <- function(query, con, ..., subquery = FALSE, level = 0) {
   from <- dbplyr_sql_subquery(con,
     sql_render(query$from, con, ..., subquery = TRUE, level = level + 1),
-    name = NULL
+    name = NULL,
+    level = level
   )
 
   dbplyr_query_select(

--- a/R/query-semi-join.R
+++ b/R/query-semi-join.R
@@ -28,17 +28,17 @@ print.semi_join_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.semi_join_query <- function(query, con = NULL, ..., subquery = FALSE) {
+sql_render.semi_join_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
   from_x <- dbplyr_sql_subquery(
     con,
-    sql_render(query$x, con, ..., subquery = TRUE),
+    sql_render(query$x, con, ..., subquery = TRUE, level = level + 1),
     name = "LHS"
   )
   from_y <- dbplyr_sql_subquery(
     con,
-    sql_render(query$y, con, ..., subquery = TRUE),
+    sql_render(query$y, con, ..., subquery = TRUE, level = level + 1),
     name = "RHS"
   )
 
-  dbplyr_query_semi_join(con, from_x, from_y, anti = query$anti, by = query$by)
+  dbplyr_query_semi_join(con, from_x, from_y, anti = query$anti, by = query$by, level = level)
 }

--- a/R/query-semi-join.R
+++ b/R/query-semi-join.R
@@ -28,19 +28,19 @@ print.semi_join_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.semi_join_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render.semi_join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   from_x <- dbplyr_sql_subquery(
     con,
-    sql_render(query$x, con, ..., subquery = TRUE, level = level + 1),
+    sql_render(query$x, con, ..., subquery = TRUE, lvl = lvl + 1),
     name = "LHS",
-    level = level
+    lvl = lvl
   )
   from_y <- dbplyr_sql_subquery(
     con,
-    sql_render(query$y, con, ..., subquery = TRUE, level = level + 1),
+    sql_render(query$y, con, ..., subquery = TRUE, lvl = lvl + 1),
     name = "RHS",
-    level = level
+    lvl = lvl
   )
 
-  dbplyr_query_semi_join(con, from_x, from_y, anti = query$anti, by = query$by, level = level)
+  dbplyr_query_semi_join(con, from_x, from_y, anti = query$anti, by = query$by, lvl = lvl)
 }

--- a/R/query-semi-join.R
+++ b/R/query-semi-join.R
@@ -32,12 +32,14 @@ sql_render.semi_join_query <- function(query, con = NULL, ..., subquery = FALSE,
   from_x <- dbplyr_sql_subquery(
     con,
     sql_render(query$x, con, ..., subquery = TRUE, level = level + 1),
-    name = "LHS"
+    name = "LHS",
+    level = level
   )
   from_y <- dbplyr_sql_subquery(
     con,
     sql_render(query$y, con, ..., subquery = TRUE, level = level + 1),
-    name = "RHS"
+    name = "RHS",
+    level = level
   )
 
   dbplyr_query_semi_join(con, from_x, from_y, anti = query$anti, by = query$by, level = level)

--- a/R/query-set-op.R
+++ b/R/query-set-op.R
@@ -24,16 +24,16 @@ print.set_op_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.set_op_query <- function(query, con = NULL, ..., subquery = FALSE) {
-  from_x <- sql_render(query$x, con, ..., subquery = FALSE)
-  from_y <- sql_render(query$y, con, ..., subquery = FALSE)
+sql_render.set_op_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+  from_x <- sql_render(query$x, con, ..., subquery = FALSE, , level = level)
+  from_y <- sql_render(query$y, con, ..., subquery = FALSE, , level = level)
 
   if (dbplyr_edition(con) >= 2) {
-    sql_query_set_op(con, from_x, from_y, method = query$type, all = query$all)
+    sql_query_set_op(con, from_x, from_y, method = query$type, all = query$all, level = level)
   } else {
     if (isTRUE(query$all)) {
       abort("`all` argument not supported by this backend")
     }
-    dbplyr_query_set_op(con, from_x, from_y, method = query$type)
+    dbplyr_query_set_op(con, from_x, from_y, method = query$type, level = level)
   }
 }

--- a/R/query-set-op.R
+++ b/R/query-set-op.R
@@ -24,18 +24,18 @@ print.set_op_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.set_op_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render.set_op_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   # TODO improve this hack a little
-  sub_level <- level + !inherits(con, "SQLiteConnection")
-  from_x <- sql_render(query$x, con, ..., subquery = FALSE, level = sub_level)
-  from_y <- sql_render(query$y, con, ..., subquery = FALSE, level = sub_level)
+  sub_lvl <- lvl + !inherits(con, "SQLiteConnection")
+  from_x <- sql_render(query$x, con, ..., subquery = FALSE, lvl = sub_lvl)
+  from_y <- sql_render(query$y, con, ..., subquery = FALSE, lvl = sub_lvl)
 
   if (dbplyr_edition(con) >= 2) {
-    sql_query_set_op(con, from_x, from_y, method = query$type, all = query$all, level = level)
+    sql_query_set_op(con, from_x, from_y, method = query$type, all = query$all, lvl = lvl)
   } else {
     if (isTRUE(query$all)) {
       abort("`all` argument not supported by this backend")
     }
-    dbplyr_query_set_op(con, from_x, from_y, method = query$type, level = level)
+    dbplyr_query_set_op(con, from_x, from_y, method = query$type, lvl = lvl)
   }
 }

--- a/R/query-set-op.R
+++ b/R/query-set-op.R
@@ -25,8 +25,10 @@ print.set_op_query <- function(x, ...) {
 
 #' @export
 sql_render.set_op_query <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
-  from_x <- sql_render(query$x, con, ..., subquery = FALSE, , level = level)
-  from_y <- sql_render(query$y, con, ..., subquery = FALSE, , level = level)
+  # TODO improve this hack a little
+  sub_level <- level + !inherits(con, "SQLiteConnection")
+  from_x <- sql_render(query$x, con, ..., subquery = FALSE, level = sub_level)
+  from_y <- sql_render(query$y, con, ..., subquery = FALSE, level = sub_level)
 
   if (dbplyr_edition(con) >= 2) {
     sql_query_set_op(con, from_x, from_y, method = query$type, all = query$all, level = level)

--- a/R/schema.R
+++ b/R/schema.R
@@ -59,8 +59,8 @@ ident_q <- function(...) {
 }
 
 #' @export
-escape.ident_q <- function(x, parens = FALSE, collapse = ", ", con = NULL) {
-  sql_vector(names_to_as(x, names2(x), con = con), parens, collapse, con = con)
+escape.ident_q <- function(x, parens = FALSE, collapse = ", ", con = NULL, align_as = FALSE) {
+  sql_vector(names_to_as(x, names2(x), con = con, align_as = align_as), parens, collapse, con = con)
 }
 
 #' @export

--- a/R/schema.R
+++ b/R/schema.R
@@ -59,8 +59,8 @@ ident_q <- function(...) {
 }
 
 #' @export
-escape.ident_q <- function(x, parens = FALSE, collapse = ", ", con = NULL, align_as = FALSE) {
-  sql_vector(names_to_as(x, names2(x), con = con, align_as = align_as), parens, collapse, con = con)
+escape.ident_q <- function(x, parens = FALSE, collapse = ", ", con = NULL) {
+  sql_vector(names_to_as(x, names2(x), con = con), parens, collapse, con = con)
 }
 
 #' @export

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -48,33 +48,33 @@ sql_build.ident <- function(op, con = NULL, ...) {
 #' @param subquery Is this SQL going to be used in a subquery?
 #'   This is important because you can place a bare table name in a subquery
 #'   and  ORDER BY does not work in subqueries.
-sql_render <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   UseMethod("sql_render")
 }
 
 #' @export
-sql_render.tbl_lazy <- function(query, con = query$src$con, ..., subquery = FALSE, level = 0) {
-  sql_render(query$ops, con = con, ..., subquery = subquery, level = level)
+sql_render.tbl_lazy <- function(query, con = query$src$con, ..., subquery = FALSE, lvl = 0) {
+  sql_render(query$ops, con = con, ..., subquery = subquery, lvl = lvl)
 }
 
 #' @export
-sql_render.op <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render.op <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   qry <- sql_build(query, con = con, ...)
   qry <- sql_optimise(qry, con = con, ..., subquery = subquery)
-  sql_render(qry, con = con, ..., subquery = subquery, level = level)
+  sql_render(qry, con = con, ..., subquery = subquery, lvl = lvl)
 }
 
 #' @export
-sql_render.sql <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render.sql <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   query
 }
 
 #' @export
-sql_render.ident <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
+sql_render.ident <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
   if (subquery) {
     query
   } else {
-    dbplyr_query_select(con, sql("*"), query, level = level)
+    dbplyr_query_select(con, sql("*"), query, lvl = lvl)
   }
 }
 

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -48,33 +48,33 @@ sql_build.ident <- function(op, con = NULL, ...) {
 #' @param subquery Is this SQL going to be used in a subquery?
 #'   This is important because you can place a bare table name in a subquery
 #'   and  ORDER BY does not work in subqueries.
-sql_render <- function(query, con = NULL, ..., subquery = FALSE) {
+sql_render <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
   UseMethod("sql_render")
 }
 
 #' @export
-sql_render.tbl_lazy <- function(query, con = query$src$con, ..., subquery = FALSE) {
-  sql_render(query$ops, con = con, ..., subquery = subquery)
+sql_render.tbl_lazy <- function(query, con = query$src$con, ..., subquery = FALSE, level = 0) {
+  sql_render(query$ops, con = con, ..., subquery = subquery, level = level)
 }
 
 #' @export
-sql_render.op <- function(query, con = NULL, ..., subquery = FALSE) {
+sql_render.op <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
   qry <- sql_build(query, con = con, ...)
   qry <- sql_optimise(qry, con = con, ..., subquery = subquery)
-  sql_render(qry, con = con, ..., subquery = subquery)
+  sql_render(qry, con = con, ..., subquery = subquery, level = level)
 }
 
 #' @export
-sql_render.sql <- function(query, con = NULL, ..., subquery = FALSE) {
+sql_render.sql <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
   query
 }
 
 #' @export
-sql_render.ident <- function(query, con = NULL, ..., subquery = FALSE) {
+sql_render.ident <- function(query, con = NULL, ..., subquery = FALSE, level = 0) {
   if (subquery) {
     query
   } else {
-    dbplyr_query_select(con, sql("*"), query)
+    dbplyr_query_select(con, sql("*"), query, level = level)
   }
 }
 

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -19,7 +19,7 @@ sql_select_clauses <- function(con,
   escape(unname(out), collapse = "\n", parens = FALSE, con = con)
 }
 
-sql_clause_select <- function(con, select, distinct = FALSE, top = NULL, level = 0) {
+sql_clause_select <- function(con, select, distinct = FALSE, top = NULL, lvl = 0) {
   assert_that(is.character(select))
   if (is_empty(select)) {
     abort("Query contains no columns")
@@ -32,44 +32,44 @@ sql_clause_select <- function(con, select, distinct = FALSE, top = NULL, level =
     con = con
   )
 
-  sql_clause_generic(con, clause, select, level = level)
+  sql_clause_generic(con, clause, select, lvl = lvl)
 }
 
-sql_clause_from  <- function(con, from, level = 0) {
-  sql_clause_generic(con, "FROM", from, level = level)
+sql_clause_from  <- function(con, from, lvl = 0) {
+  sql_clause_generic(con, "FROM", from, lvl = lvl)
 }
 
-sql_clause_where <- function(con, where, level = 0) {
+sql_clause_where <- function(con, where, lvl = 0) {
   if (length(where) == 0L) {
     return()
   }
 
   assert_that(is.character(where))
   where_paren <- escape(where, parens = TRUE, con = con)
-  sql_clause_generic(con, "WHERE", where_paren, level = level, sep = " AND")
+  sql_clause_generic(con, "WHERE", where_paren, lvl = lvl, sep = " AND")
 }
 
-sql_clause_group_by <- function(con, group_by, level = 0) {
-  sql_clause_generic(con, "GROUP BY", group_by, level = level)
+sql_clause_group_by <- function(con, group_by, lvl = 0) {
+  sql_clause_generic(con, "GROUP BY", group_by, lvl = lvl)
 }
 
-sql_clause_having <- function(con, having, level = 0) {
-  sql_clause_generic(con, "HAVING", having, level = level)
+sql_clause_having <- function(con, having, lvl = 0) {
+  sql_clause_generic(con, "HAVING", having, lvl = lvl)
 }
 
-sql_clause_order_by <- function(con, order_by, subquery = FALSE, limit = NULL, level = 0) {
+sql_clause_order_by <- function(con, order_by, subquery = FALSE, limit = NULL, lvl = 0) {
   if (subquery && length(order_by) > 0 && is.null(limit)) {
     warn_drop_order_by()
     NULL
   } else {
-    sql_clause_generic(con, "ORDER BY", order_by, level = level)
+    sql_clause_generic(con, "ORDER BY", order_by, lvl = lvl)
   }
 }
 
-sql_clause_limit <- function(con, limit, level = 0){
+sql_clause_limit <- function(con, limit, lvl = 0){
   if (!is.null(limit) && !identical(limit, Inf)) {
     build_sql(
-      !!get_clause_indent(level), "LIMIT ", sql(format(limit, scientific = FALSE)),
+      !!get_clause_indent(lvl), "LIMIT ", sql(format(limit, scientific = FALSE)),
       con = con
     )
   }
@@ -77,15 +77,15 @@ sql_clause_limit <- function(con, limit, level = 0){
 
 # helpers -----------------------------------------------------------------
 
-sql_clause_generic <- function(con, clause, fields, level = 0, sep = ",") {
+sql_clause_generic <- function(con, clause, fields, lvl = 0, sep = ",") {
   if (length(fields) == 0L) {
     return()
   }
 
   assert_that(is.character(fields))
   build_sql(
-    !!get_clause_indent(level), sql(clause), !!get_clause_separator(fields, level),
-    escape(fields, collapse = get_field_separator(fields, sep = sep, level), con = con),
+    !!get_clause_indent(lvl), sql(clause), !!get_clause_separator(fields, lvl),
+    escape(fields, collapse = get_field_separator(fields, sep = sep, lvl), con = con),
     con = con
   )
 }
@@ -94,25 +94,25 @@ lvl_indent <- function(times, char = "  ") {
   paste(rep.int(char, times), collapse = "")
 }
 
-get_clause_indent <- function(level) {
+get_clause_indent <- function(lvl) {
   if (getOption("dbplyr_break_subquery", FALSE)) {
-    lvl_indent(level)
+    lvl_indent(lvl)
   } else {
     ""
   }
 }
 
-get_clause_separator <- function(fields, level) {
+get_clause_separator <- function(fields, lvl) {
   if (break_after_clause(fields)) {
-    field_collapse <- paste0("\n", lvl_indent(level + 1))
+    field_collapse <- paste0("\n", lvl_indent(lvl + 1))
   } else {
     field_collapse <- " "
   }
 }
 
-get_field_separator <- function(fields, sep, level) {
+get_field_separator <- function(fields, sep, lvl) {
   if (break_between_fields(fields)) {
-    paste0(sep, "\n", lvl_indent(level + 1))
+    paste0(sep, "\n", lvl_indent(lvl + 1))
   } else {
     paste0(sep, " ")
   }

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -97,14 +97,11 @@ sql_clause_kw <- function(..., lvl) {
 }
 
 build_sql_wrap <- function(..., .env = parent.frame(), con = sql_current_con(), lvl = 0) {
-  sql(
-    paste0(
-      "(", if (getOption("dbplyr_break_subquery", FALSE)) "\n",
-      build_sql(..., con = con, .env = .env),
-      if (getOption("dbplyr_break_subquery", FALSE)) paste0("\n", get_clause_indent(lvl)),
-      ")"
-    )
-  )
+  if (getOption("dbplyr_break_subquery", FALSE)) {
+    build_sql("(\n", ..., "\n", !!get_clause_indent(lvl), ")", con = con, .env = .env)
+  } else {
+    build_sql("(", ..., ")", con = con, .env = .env)
+  }
 }
 
 lvl_indent <- function(times, char = "  ") {

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -111,15 +111,9 @@ sql_kw <- function(kw) {
 #' cols <- ident("mpg", "cyl", "gear")
 #' conds <- sql("`mpg` > 0", "`cyl` = 6")
 #'
-#' cat(paste0("SELECT", field_minimal(cols, ",", con = con)))
-#' cat(paste0("SELECT", field_minimal(conds, " AND", con = con)))
-#'
-#' cat(paste0("SELECT", field_align(cols, ",", lvl = 0, kw = "SELECT", con = con)))
-#' cat(paste0("SELECT", field_align(conds, " AND", lvl = 0, kw = "SELECT", con = con)))
-#'
-#' cat(paste0("SELECT", field_indent(cols, ",", lvl = 0, con = con, parens = FALSE)))
-#' cat(paste0("SELECT", field_indent(cols, ",", lvl = 0, con = con, parens = TRUE)))
-#' cat(paste0("SELECT", field_indent(conds, " AND", lvl = 0, con = con)))
+#' cat(paste0("SELECT", format_fields(cols, ",", lvl = 0, kw = "SELECT", con = con, parens = FALSE)))
+#' cat(paste0("SELECT", format_fields(cols, ",", lvl = 0, kw = "SELECT", con = con, parens = TRUE)))
+#' cat(paste0("SELECT", format_fields(conds, " AND", lvl = 0, kw = "SELECT", con = con)))
 format_fields <- function(x, field_sep, lvl, kw, con, parens = FALSE, nchar_max = 80) {
   # check length without starting a new line
   fields_same_line <- escape(x, collapse = paste0(field_sep, " "), con = con)

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -19,56 +19,54 @@ sql_select_clauses <- function(con,
   escape(unname(out), collapse = "\n", parens = FALSE, con = con)
 }
 
-sql_clause_select <- function(con, select, distinct = FALSE, top = NULL) {
+sql_clause_select <- function(con, select, distinct = FALSE, top = NULL, level = 0) {
   assert_that(is.character(select))
   if (is_empty(select)) {
     abort("Query contains no columns")
   }
 
-  build_sql(
-    "SELECT ",
-    if (distinct) sql("DISTINCT "),
-    if (!is.null(top)) build_sql("TOP ", as.integer(top), " ", con = con),
-    escape(select, collapse = ", ", con = con),
+  clause <- build_sql(
+    "SELECT",
+    if (distinct) sql(" DISTINCT"),
+    if (!is.null(top)) build_sql(" TOP ", as.integer(top), con = con),
     con = con
   )
+
+  sql_clause_generic(con, clause, select, level = level)
 }
 
-sql_clause_from  <- function(con, from) {
-  sql_clause_generic(con, "FROM", from)
+sql_clause_from  <- function(con, from, level = 0) {
+  sql_clause_generic(con, "FROM", from, level = level)
 }
 
-sql_clause_where <- function(con, where) {
+sql_clause_where <- function(con, where, level = 0) {
   if (length(where) == 0L) {
     return()
   }
 
   assert_that(is.character(where))
   where_paren <- escape(where, parens = TRUE, con = con)
-  build_sql(
-    "WHERE ", sql_vector(where_paren, collapse = " AND ", con = con),
-    con = con
-  )
+  sql_clause_generic(con, "WHERE", where_paren, level = level, sep = " AND")
 }
 
-sql_clause_group_by <- function(con, group_by) {
-  sql_clause_generic(con, "GROUP BY", group_by)
+sql_clause_group_by <- function(con, group_by, level = 0) {
+  sql_clause_generic(con, "GROUP BY", group_by, level = level)
 }
 
-sql_clause_having <- function(con, having) {
-  sql_clause_generic(con, "HAVING", having)
+sql_clause_having <- function(con, having, level = 0) {
+  sql_clause_generic(con, "HAVING", having, level = level)
 }
 
-sql_clause_order_by <- function(con, order_by, subquery = FALSE, limit = NULL) {
+sql_clause_order_by <- function(con, order_by, subquery = FALSE, limit = NULL, level = 0) {
   if (subquery && length(order_by) > 0 && is.null(limit)) {
     warn_drop_order_by()
     NULL
   } else {
-    sql_clause_generic(con, "ORDER BY", order_by)
+    sql_clause_generic(con, "ORDER BY", order_by, level = level)
   }
 }
 
-sql_clause_limit <- function(con, limit){
+sql_clause_limit <- function(con, limit, level = 0){
   if (!is.null(limit) && !identical(limit, Inf)) {
     build_sql(
       "LIMIT ", sql(format(limit, scientific = FALSE)),
@@ -79,15 +77,53 @@ sql_clause_limit <- function(con, limit){
 
 # helpers -----------------------------------------------------------------
 
-sql_clause_generic <- function(con, clause, fields) {
+sql_clause_generic <- function(con, clause, fields, level = 0, sep = ",") {
   if (length(fields) == 0L) {
     return()
   }
 
   assert_that(is.character(fields))
   build_sql(
-    sql(clause), " ",
-    escape(fields, collapse = ", ", con = con),
+    !!get_clause_indent(level), sql(clause), !!get_clause_separator(fields, level),
+    escape(fields, collapse = get_field_separator(fields, sep = sep, level), con = con),
     con = con
   )
+}
+
+lvl_indent <- function(times, char = "  ") {
+  paste(rep.int(char, times), collapse = "")
+}
+
+get_clause_indent <- function(level) {
+  if (getOption("dbplyr_break_subquery", FALSE)) {
+    lvl_indent(level)
+  } else {
+    ""
+  }
+}
+
+get_clause_separator <- function(fields, level) {
+  if (break_after_clause(fields)) {
+    field_collapse <- paste0("\n", lvl_indent(level + 1))
+  } else {
+    field_collapse <- " "
+  }
+}
+
+get_field_separator <- function(fields, sep, level) {
+  if (break_between_fields(fields)) {
+    paste0(sep, "\n", lvl_indent(level + 1))
+  } else {
+    paste0(sep, " ")
+  }
+}
+
+break_after_clause <- function(fields) {
+  # TODO add option to always break or not break at all
+  getOption("dbplyr_indent_fields", FALSE) && length(fields) > 1
+}
+
+break_between_fields <- function(fields) {
+  # TODO improve option to control
+  getOption("dbplyr_indent_fields", FALSE)
 }

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -144,7 +144,7 @@ field_align <- function(x, field_sep, lvl, kw, con, parens) {
   kw_indent <- rep_char(nchar(kw) + (parens == TRUE), " ")
   collapse <- paste0(field_sep, "\n", " ", lvl_indent(lvl), kw_indent)
   # TODO should this really look like this??
-  paste0(" ", if (parens) "(", escape(x, collapse = collapse, con = con, align_as = should_align_as()), if (parens) ")")
+  paste0(" ", if (parens) "(", escape(x, collapse = collapse, con = con), if (parens) ")")
 }
 
 field_indent <- function(x, field_sep, lvl, con, parens) {
@@ -156,7 +156,7 @@ field_indent <- function(x, field_sep, lvl, con, parens) {
   collapse <- paste0(field_sep, "\n", indent)
   paste0(
     if (parens) " (", "\n",
-    indent, escape(x, collapse = collapse, con = con, align_as = should_align_as()),
+    indent, escape(x, collapse = collapse, con = con),
     if (parens) paste0("\n", indent_lvl(")", lvl))
   )
 }
@@ -191,8 +191,4 @@ get_indent_strategy <- function() {
 
 is_legacy_strategy <- function() {
   get_indent_strategy() == "legacy"
-}
-
-should_align_as <- function() {
-  getOption("dbplyr_indent_align_as", FALSE)
 }

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -120,7 +120,7 @@ sql_kw <- function(kw) {
 #' cat(paste0("SELECT", field_indent(cols, ",", lvl = 0, con = con, parens = FALSE)))
 #' cat(paste0("SELECT", field_indent(cols, ",", lvl = 0, con = con, parens = TRUE)))
 #' cat(paste0("SELECT", field_indent(conds, " AND", lvl = 0, con = con)))
-format_fields <- function(x, field_sep, lvl, kw, con, parens = FALSE) {
+format_fields <- function(x, field_sep, lvl, kw, con, parens = FALSE, nchar_max = 80) {
   # check length without starting a new line
   fields_same_line <- escape(x, collapse = paste0(field_sep, " "), con = con)
   if (parens) {
@@ -128,10 +128,9 @@ format_fields <- function(x, field_sep, lvl, kw, con, parens = FALSE) {
   } else {
     fields_same_line <- paste0(" ", fields_same_line)
   }
-  nchar_same_line <- nchar(kw) + nchar(fields_same_line)
-  max_length <- 80L
+  nchar_same_line <- nchar(lvl_indent(lvl)) + nchar(kw) + nchar(fields_same_line)
 
-  if (length(x) == 1 || nchar_same_line <= max_length) {
+  if (length(x) == 1 || nchar_same_line <= nchar_max) {
     return(sql(fields_same_line))
   }
 

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -26,9 +26,9 @@ sql_clause_select <- function(con, select, distinct = FALSE, top = NULL, lvl = 0
   }
 
   clause <- build_sql(
-    "SELECT",
-    if (distinct) sql(" DISTINCT"),
-    if (!is.null(top)) build_sql(" TOP ", as.integer(top), con = con),
+    sql_kw("SELECT"),
+    if (distinct) sql_kw(" DISTINCT"),
+    if (!is.null(top)) build_sql(sql_kw(" TOP "), as.integer(top), con = con),
     con = con
   )
 
@@ -68,11 +68,12 @@ sql_clause_order_by <- function(con, order_by, subquery = FALSE, limit = NULL, l
 
 sql_clause_limit <- function(con, limit, lvl = 0){
   if (!is.null(limit) && !identical(limit, Inf)) {
-    build_sql_line(
-      "LIMIT ", sql(format(limit, scientific = FALSE)),
-      con = con,
-      lvl = lvl
+    sql <- build_sql(
+      sql_kw("LIMIT"), " ", sql(format(limit, scientific = FALSE)),
+      con = con
     )
+
+    indent_lvl(sql, lvl)
   }
 }
 
@@ -84,54 +85,98 @@ sql_clause_generic <- function(con, clause, fields, lvl = 0, sep = ",") {
   }
 
   assert_that(is.character(fields))
-  build_sql_line(
-    sql(clause), !!get_clause_separator(fields, lvl),
-    escape(fields, collapse = get_field_separator(fields, sep = sep, lvl), con = con),
-    con = con,
-    lvl = lvl
+  sql <- build_sql(
+    sql_kw(clause),
+    format_fields(fields, sep, lvl = lvl, kw = clause, con = con, strategy = "indent"),
+    con = con
+  )
+
+  indent_lvl(sql, lvl)
+}
+
+sql_kw <- function(kw) {
+  sql(kw)
+}
+
+#' @noRd
+#' @examples
+#' con <- simulate_dbi()
+#' cols <- ident("mpg", "cyl", "gear")
+#' conds <- sql("`mpg` > 0", "`cyl` = 6")
+#'
+#' cat(paste0("SELECT", field_minimal(cols, ",", con = con)))
+#' cat(paste0("SELECT", field_minimal(conds, " AND", con = con)))
+#'
+#' cat(paste0("SELECT", field_align(cols, ",", lvl = 0, kw = "SELECT", con = con)))
+#' cat(paste0("SELECT", field_align(conds, " AND", lvl = 0, kw = "SELECT", con = con)))
+#'
+#' cat(paste0("SELECT", field_indent(cols, ",", lvl = 0, con = con, parens = FALSE)))
+#' cat(paste0("SELECT", field_indent(cols, ",", lvl = 0, con = con, parens = TRUE)))
+#' cat(paste0("SELECT", field_indent(conds, " AND", lvl = 0, con = con)))
+format_fields <- function(x, field_sep, lvl, kw, con, parens = FALSE, strategy = c("minimal", "align", "indent")) {
+  strategy <- match.arg(strategy)
+  field_string <- switch(strategy,
+    minimal = field_minimal(x, field_sep, con = con, parens = parens),
+    align = field_align(x, field_sep, kw = kw, lvl = lvl, con = con, parens = parens),
+    indent = field_indent(x, field_sep, lvl = lvl, con = con, parens = parens)
+  )
+  sql(field_string)
+}
+
+field_minimal <- function(x, field_sep, con, parens) {
+  paste0(" ", if (parens) "(", escape(x, collapse = paste0(" ", field_sep), con = con), if (parens) ")")
+}
+
+field_align <- function(x, field_sep, lvl, kw, con, parens) {
+  if (length(x) == 1) {
+    return(paste0(if (parens) "(" else " ", escape(x, con = con), if (parens) ")"))
+  }
+
+  kw_indent <- rep_char(nchar(kw) + (parens == TRUE), " ")
+  collapse <- paste0(field_sep, "\n", " ", lvl_indent(lvl), kw_indent)
+  # TODO should this really look like this??
+  paste0(" ", if (parens) "(", escape(x, collapse = collapse, con = con), if (parens) ")")
+}
+
+field_indent <- function(x, field_sep, lvl, con, parens) {
+  if (length(x) == 1) {
+    return(paste0(if (parens) "(" else " ", escape(x, con = con), if (parens) ")"))
+  }
+
+  indent <- lvl_indent(lvl + 1)
+  collapse <- paste0(field_sep, "\n", indent)
+  paste0(
+    if (parens) "(", "\n",
+    indent, escape(x, collapse = collapse, con = con),
+    if (parens) paste0("\n", indent_lvl(")", lvl))
   )
 }
 
 sql_clause_kw <- function(..., lvl) {
-  sql(paste0(get_clause_indent(lvl), ...))
+  sql_kw(paste0(get_clause_indent(lvl), ...))
 }
 
-build_sql_wrap <- function(..., .env = parent.frame(), con = sql_current_con(), lvl = 0) {
-  inner_sql <- build_sql(..., con = con, .env = .env)
-
-  multi_line <- grepl(x = inner_sql, pattern = "\\r\\n|\\r|\\n")
-  if (getOption("dbplyr_break_subquery", FALSE) && multi_line) {
-    build_sql("(\n", inner_sql, "\n", !!get_clause_indent(lvl), ")", con = con)
-  } else {
-    build_sql("(", inner_sql, ")", con = con)
-  }
-}
-
-lvl_indent <- function(times, char = "  ") {
+rep_char <- function(times, char) {
   paste(rep.int(char, times), collapse = "")
 }
 
-build_sql_line <- function(..., .env = parent.frame(), con = sql_current_con(), lvl = 0) {
-  build_sql(
-    !!get_clause_indent(lvl), ...,
-    .env = .env,
-    con = con
-  )
+lvl_indent <- function(times, char = "  ") {
+  rep_char(times, char)
+}
+
+indent_lvl <- function(x, lvl) {
+  if (getOption("dbplyr_break_subquery", FALSE)) {
+    sql(paste0(lvl_indent(lvl), x))
+  } else {
+    x
+  }
 }
 
 get_clause_indent <- function(lvl) {
   if (getOption("dbplyr_break_subquery", FALSE)) {
-    lvl_indent(lvl)
+    sql(lvl_indent(lvl))
   } else {
-    ""
-  }
-}
-
-get_clause_separator <- function(fields, lvl) {
-  if (break_after_clause(fields)) {
-    field_collapse <- paste0("\n", lvl_indent(lvl + 1))
-  } else {
-    field_collapse <- " "
+    sql("")
   }
 }
 

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -69,7 +69,7 @@ sql_clause_order_by <- function(con, order_by, subquery = FALSE, limit = NULL, l
 sql_clause_limit <- function(con, limit, level = 0){
   if (!is.null(limit) && !identical(limit, Inf)) {
     build_sql(
-      "LIMIT ", sql(format(limit, scientific = FALSE)),
+      !!get_clause_indent(level), "LIMIT ", sql(format(limit, scientific = FALSE)),
       con = con
     )
   }

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -97,10 +97,13 @@ sql_clause_kw <- function(..., lvl) {
 }
 
 build_sql_wrap <- function(..., .env = parent.frame(), con = sql_current_con(), lvl = 0) {
-  if (getOption("dbplyr_break_subquery", FALSE)) {
-    build_sql("(\n", ..., "\n", !!get_clause_indent(lvl), ")", con = con, .env = .env)
+  inner_sql <- build_sql(..., con = con, .env = .env)
+
+  multi_line <- grepl(x = inner_sql, pattern = "\\r\\n|\\r|\\n")
+  if (getOption("dbplyr_break_subquery", FALSE) && multi_line) {
+    build_sql("(\n", inner_sql, "\n", !!get_clause_indent(lvl), ")", con = con)
   } else {
-    build_sql("(", ..., ")", con = con, .env = .env)
+    build_sql("(", inner_sql, ")", con = con)
   }
 }
 

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -144,7 +144,7 @@ field_align <- function(x, field_sep, lvl, kw, con, parens) {
   kw_indent <- rep_char(nchar(kw) + (parens == TRUE), " ")
   collapse <- paste0(field_sep, "\n", " ", lvl_indent(lvl), kw_indent)
   # TODO should this really look like this??
-  paste0(" ", if (parens) "(", escape(x, collapse = collapse, con = con), if (parens) ")")
+  paste0(" ", if (parens) "(", escape(x, collapse = collapse, con = con, align_as = should_align_as()), if (parens) ")")
 }
 
 field_indent <- function(x, field_sep, lvl, con, parens) {
@@ -156,7 +156,7 @@ field_indent <- function(x, field_sep, lvl, con, parens) {
   collapse <- paste0(field_sep, "\n", indent)
   paste0(
     if (parens) " (", "\n",
-    indent, escape(x, collapse = collapse, con = con),
+    indent, escape(x, collapse = collapse, con = con, align_as = should_align_as()),
     if (parens) paste0("\n", indent_lvl(")", lvl))
   )
 }
@@ -191,4 +191,8 @@ get_indent_strategy <- function() {
 
 is_legacy_strategy <- function() {
   get_indent_strategy() == "legacy"
+}
+
+should_align_as <- function() {
+  getOption("dbplyr_indent_align_as", FALSE)
 }

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -166,7 +166,7 @@ sql_clause_kw <- function(..., lvl) {
 }
 
 rep_char <- function(times, char) {
-  paste(rep.int(char, times), collapse = "")
+  strrep(char, times)
 }
 
 lvl_indent <- function(times, char = "  ") {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,13 +23,6 @@
   }
 
   base_scalar$`%>%` <- magrittr::`%>%`
-
-  op <- options()
-  op.dbplyr <- list(
-    dbplyr_indent_strategy = "indent"
-  )
-  toset <- !(names(op.dbplyr) %in% names(op))
-  if (any(toset)) options(op.dbplyr[toset])
 }
 
 # Silence R CMD check note:

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,6 +23,14 @@
   }
 
   base_scalar$`%>%` <- magrittr::`%>%`
+
+  op <- options()
+  op.dbplyr <- list(
+    dbplyr_indent_fields = TRUE,
+    dbplyr_break_subquery = TRUE
+  )
+  toset <- !(names(op.dbplyr) %in% names(op))
+  if (any(toset)) options(op.dbplyr[toset])
 }
 
 # Silence R CMD check note:

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,8 +26,7 @@
 
   op <- options()
   op.dbplyr <- list(
-    dbplyr_indent_fields = TRUE,
-    dbplyr_break_subquery = TRUE
+    dbplyr_indent_strategy = "indent"
   )
   toset <- !(names(op.dbplyr) %in% names(op))
   if (any(toset)) options(op.dbplyr[toset])

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -31,7 +31,7 @@ sql_query_fields(con, sql, ...)
 
 sql_query_save(con, sql, name, temporary = TRUE, ...)
 
-sql_query_wrap(con, from, name = unique_subquery_name(), ...)
+sql_query_wrap(con, from, name = unique_subquery_name(), ..., lvl = 0)
 
 sql_query_rows(con, sql, ...)
 
@@ -46,7 +46,8 @@ sql_query_select(
   limit = NULL,
   distinct = FALSE,
   ...,
-  subquery = FALSE
+  subquery = FALSE,
+  lvl = 0
 )
 
 sql_query_join(
@@ -57,12 +58,13 @@ sql_query_join(
   type = "inner",
   by = NULL,
   na_matches = FALSE,
-  ...
+  ...,
+  lvl = 0
 )
 
-sql_query_semi_join(con, x, y, anti = FALSE, by = NULL, ...)
+sql_query_semi_join(con, x, y, anti = FALSE, by = NULL, ..., lvl = 0)
 
-sql_query_set_op(con, x, y, method, ..., all = FALSE)
+sql_query_set_op(con, x, y, method, ..., all = FALSE, lvl = 0)
 }
 \description{
 SQL translation:

--- a/man/sql_build.Rd
+++ b/man/sql_build.Rd
@@ -38,7 +38,7 @@ set_op_query(x, y, type = type, all = FALSE)
 
 sql_build(op, con = NULL, ...)
 
-sql_render(query, con = NULL, ..., subquery = FALSE, level = 0)
+sql_render(query, con = NULL, ..., subquery = FALSE, lvl = 0)
 
 sql_optimise(x, con = NULL, ..., subquery = FALSE)
 }

--- a/man/sql_build.Rd
+++ b/man/sql_build.Rd
@@ -38,7 +38,7 @@ set_op_query(x, y, type = type, all = FALSE)
 
 sql_build(op, con = NULL, ...)
 
-sql_render(query, con = NULL, ..., subquery = FALSE)
+sql_render(query, con = NULL, ..., subquery = FALSE, level = 0)
 
 sql_optimise(x, con = NULL, ..., subquery = FALSE)
 }

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -102,22 +102,24 @@
 # handles ORDER BY in subqueries
 
     Code
-      sql_query_select(simulate_mssql(), "x", "y", order_by = "z", subquery = TRUE)
+      sql_query_select(simulate_mssql(), ident("x"), ident("y"), order_by = "z",
+      subquery = TRUE)
     Warning <warning>
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
-      <SQL> SELECT 'x'
-      FROM 'y'
+      <SQL> SELECT `x`
+      FROM `y`
 
 # custom limit translation
 
     Code
-      sql_query_select(simulate_mssql(), "x", "y", order_by = "z", limit = 10)
+      sql_query_select(simulate_mssql(), ident("x"), ident("y"), order_by = ident("z"),
+      limit = 10)
     Output
-      <SQL> SELECT TOP 10 'x'
-      FROM 'y'
-      ORDER BY 'z'
+      <SQL> SELECT TOP 10 `x`
+      FROM `y`
+      ORDER BY `z`
 
 # custom escapes translated correctly
 

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -34,7 +34,9 @@
       mf %>% mutate(z = ifelse(x == 1L, 1L, 2L))
     Output
       <SQL>
-      SELECT `x`, IIF(`x` = 1, 1, 2) AS `z`
+      SELECT
+        `x`,
+        IIF(`x` = 1, 1, 2) AS `z`
       FROM `df`
 
 ---
@@ -43,7 +45,9 @@
       mf %>% mutate(z = case_when(x == 1L ~ 1L))
     Output
       <SQL>
-      SELECT `x`, CASE
+      SELECT
+        `x`,
+        CASE
       WHEN (`x` = 1) THEN (1)
       END AS `z`
       FROM `df`
@@ -54,7 +58,9 @@
       mf %>% mutate(z = !is.na(x))
     Output
       <SQL>
-      SELECT `x`, CAST(IIF(~((`x`) IS NULL), 1, 0) AS BIT) AS `z`
+      SELECT
+        `x`,
+        CAST(IIF(~((`x`) IS NULL), 1, 0) AS BIT) AS `z`
       FROM `df`
 
 ---

--- a/tests/testthat/_snaps/backend-mysql.md
+++ b/tests/testthat/_snaps/backend-mysql.md
@@ -22,7 +22,6 @@
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (`LHS`.`x` <=> `RHS`.`x`)
-      
 
 # can explain
 

--- a/tests/testthat/_snaps/backend-oracle.md
+++ b/tests/testthat/_snaps/backend-oracle.md
@@ -33,5 +33,4 @@
       FROM (`df`) `LHS`
       LEFT JOIN (`df`) `RHS`
       ON (decode(`LHS`.`x`, `RHS`.`x`, 0, 1) = 0)
-      
 

--- a/tests/testthat/_snaps/backend-postgres.md
+++ b/tests/testthat/_snaps/backend-postgres.md
@@ -8,7 +8,6 @@
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (`LHS`.`x` IS NOT DISTINCT FROM `RHS`.`x`)
-      
 
 # can explain
 

--- a/tests/testthat/_snaps/backend-sqlite.md
+++ b/tests/testthat/_snaps/backend-sqlite.md
@@ -8,7 +8,6 @@
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (`LHS`.`x` IS `RHS`.`x`)
-      
 
 # full and right join
 
@@ -16,16 +15,28 @@
       full_join(df1, df2, by = "x")
     Output
       <SQL>
-      SELECT `x`, `y.x`, `y.y`, `z`
-      FROM (SELECT COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`, `LHS`.`y` AS `y.x`, `RHS`.`y` AS `y.y`, `z`
-      FROM `df` AS `LHS`
-      LEFT JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x`)
-      UNION
-      SELECT COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`, `LHS`.`y` AS `y.x`, `RHS`.`y` AS `y.y`, `z`
-      FROM `df` AS `RHS`
-      LEFT JOIN `df` AS `LHS`
-      ON (`LHS`.`x` = `RHS`.`x`)
+      SELECT
+        `x`,
+        `y.x`,
+        `y.y`,
+        `z`
+      FROM (
+        SELECT
+          COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`,
+          `LHS`.`y` AS `y.x`,
+          `RHS`.`y` AS `y.y`,
+          `z`
+        FROM `df` AS `LHS`
+        LEFT JOIN `df` AS `RHS`
+        ON (`LHS`.`x` = `RHS`.`x`)  UNION
+        SELECT
+          COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`,
+          `LHS`.`y` AS `y.x`,
+          `RHS`.`y` AS `y.y`,
+          `z`
+        FROM `df` AS `RHS`
+        LEFT JOIN `df` AS `LHS`
+        ON (`LHS`.`x` = `RHS`.`x`)
       ) AS `q01`
 
 ---
@@ -34,11 +45,14 @@
       right_join(df2, df1, by = "x")
     Output
       <SQL>
-      SELECT `RHS`.`x` AS `x`, `LHS`.`y` AS `y.x`, `z`, `RHS`.`y` AS `y.y`
+      SELECT
+        `RHS`.`x` AS `x`,
+        `LHS`.`y` AS `y.x`,
+        `z`,
+        `RHS`.`y` AS `y.y`
       FROM `df` AS `RHS`
       LEFT JOIN `df` AS `LHS`
       ON (`LHS`.`x` = `RHS`.`x`)
-      
 
 # can explain a query
 

--- a/tests/testthat/_snaps/partial-eval.md
+++ b/tests/testthat/_snaps/partial-eval.md
@@ -4,7 +4,9 @@
       lf %>% summarise(across(a:b, "log"))
     Output
       <SQL>
-      SELECT LN(`a`) AS `a`, LN(`b`) AS `b`
+      SELECT
+        LN(`a`) AS `a`,
+        LN(`b`) AS `b`
       FROM `df`
 
 ---
@@ -13,7 +15,9 @@
       lf %>% summarise(across(a:b, "log", base = 2))
     Output
       <SQL>
-      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      SELECT
+        LOG(2.0, `a`) AS `a`,
+        LOG(2.0, `b`) AS `b`
       FROM `df`
 
 ---
@@ -22,7 +26,9 @@
       lf %>% summarise(across(a, c("log", "exp")))
     Output
       <SQL>
-      SELECT LN(`a`) AS `a_log`, EXP(`a`) AS `a_exp`
+      SELECT
+        LN(`a`) AS `a_log`,
+        EXP(`a`) AS `a_exp`
       FROM `df`
 
 # across() translates functions
@@ -31,7 +37,9 @@
       lf %>% summarise(across(a:b, log))
     Output
       <SQL>
-      SELECT LN(`a`) AS `a`, LN(`b`) AS `b`
+      SELECT
+        LN(`a`) AS `a`,
+        LN(`b`) AS `b`
       FROM `df`
 
 ---
@@ -40,7 +48,9 @@
       lf %>% summarise(across(a:b, log, base = 2))
     Output
       <SQL>
-      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      SELECT
+        LOG(2.0, `a`) AS `a`,
+        LOG(2.0, `b`) AS `b`
       FROM `df`
 
 ---
@@ -49,7 +59,11 @@
       lf %>% summarise(across(a:b, list(log, exp)))
     Output
       <SQL>
-      SELECT LN(`a`) AS `a_log`, EXP(`a`) AS `a_exp`, LN(`b`) AS `b_log`, EXP(`b`) AS `b_exp`
+      SELECT
+        LN(`a`) AS `a_log`,
+        EXP(`a`) AS `a_exp`,
+        LN(`b`) AS `b_log`,
+        EXP(`b`) AS `b_exp`
       FROM `df`
 
 # untranslatable functions are preserved
@@ -58,7 +72,9 @@
       lf %>% summarise(across(a:b, SQL_LOG))
     Output
       <SQL>
-      SELECT SQL_LOG(`a`) AS `a`, SQL_LOG(`b`) AS `b`
+      SELECT
+        SQL_LOG(`a`) AS `a`,
+        SQL_LOG(`b`) AS `b`
       FROM `df`
 
 # across() translates formulas
@@ -67,7 +83,9 @@
       lf %>% summarise(across(a:b, ~log(.x, 2)))
     Output
       <SQL>
-      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      SELECT
+        LOG(2.0, `a`) AS `a`,
+        LOG(2.0, `b`) AS `b`
       FROM `df`
 
 ---
@@ -76,7 +94,9 @@
       lf %>% summarise(across(a:b, list(~log(.x, 2))))
     Output
       <SQL>
-      SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
+      SELECT
+        LOG(2.0, `a`) AS `a`,
+        LOG(2.0, `b`) AS `b`
       FROM `df`
 
 # across() translates NULL
@@ -85,7 +105,9 @@
       lf %>% mutate(across(a:b))
     Output
       <SQL>
-      SELECT `a`, `b`
+      SELECT
+        `a`,
+        `b`
       FROM `df`
 
 # old _at functions continue to work
@@ -98,7 +120,9 @@
       This warning is displayed only once per session.
     Output
       <SQL>
-      SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
+      SELECT
+        SUM(`a`) AS `a`,
+        SUM(`b`) AS `b`
       FROM `df`
 
 ---
@@ -107,7 +131,9 @@
       lf %>% dplyr::summarise_at(dplyr::vars(a:b), sum)
     Output
       <SQL>
-      SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
+      SELECT
+        SUM(`a`) AS `a`,
+        SUM(`b`) AS `b`
       FROM `df`
 
 ---
@@ -116,7 +142,9 @@
       lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~sum(.))
     Output
       <SQL>
-      SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
+      SELECT
+        SUM(`a`) AS `a`,
+        SUM(`b`) AS `b`
       FROM `df`
 
 # if_all/any works in filter()
@@ -145,7 +173,10 @@
       lf %>% mutate(c = if_all(a:b, ~. > 0))
     Output
       <SQL>
-      SELECT `a`, `b`, `a` > 0.0 AND `b` > 0.0 AS `c`
+      SELECT
+        `a`,
+        `b`,
+        `a` > 0.0 AND `b` > 0.0 AS `c`
       FROM `df`
 
 ---
@@ -154,6 +185,9 @@
       lf %>% mutate(c = if_any(a:b, ~. > 0))
     Output
       <SQL>
-      SELECT `a`, `b`, `a` > 0.0 OR `b` > 0.0 AS `c`
+      SELECT
+        `a`,
+        `b`,
+        `a` > 0.0 OR `b` > 0.0 AS `c`
       FROM `df`
 

--- a/tests/testthat/_snaps/query-join.md
+++ b/tests/testthat/_snaps/query-join.md
@@ -26,8 +26,10 @@
         `LHS`.`y` AS `y`
       FROM `df` AS `LHS`
       INNER JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND
-        `LHS`.`y` = `RHS`.`y`)
+      ON (
+        `LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`
+      )
 
 ---
 
@@ -42,8 +44,10 @@
         `LHS`.`y` AS `y`
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND
-        `LHS`.`y` = `RHS`.`y`)
+      ON (
+        `LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`
+      )
 
 ---
 
@@ -58,8 +62,10 @@
         `RHS`.`y` AS `y`
       FROM `df` AS `LHS`
       RIGHT JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND
-        `LHS`.`y` = `RHS`.`y`)
+      ON (
+        `LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`
+      )
 
 ---
 
@@ -74,8 +80,10 @@
         COALESCE(`LHS`.`y`, `RHS`.`y`) AS `y`
       FROM `df` AS `LHS`
       FULL JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND
-        `LHS`.`y` = `RHS`.`y`)
+      ON (
+        `LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`
+      )
 
 # only disambiguates shared variables
 

--- a/tests/testthat/_snaps/query-join.md
+++ b/tests/testthat/_snaps/query-join.md
@@ -21,11 +21,13 @@
       Joining, by = c("x", "y")
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x`, `LHS`.`y` AS `y`
+      SELECT
+        `LHS`.`x` AS `x`,
+        `LHS`.`y` AS `y`
       FROM `df` AS `LHS`
       INNER JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
-      
+      ON (`LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`)
 
 ---
 
@@ -35,11 +37,13 @@
       Joining, by = c("x", "y")
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x`, `LHS`.`y` AS `y`
+      SELECT
+        `LHS`.`x` AS `x`,
+        `LHS`.`y` AS `y`
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
-      
+      ON (`LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`)
 
 ---
 
@@ -49,11 +53,13 @@
       Joining, by = c("x", "y")
     Output
       <SQL>
-      SELECT `RHS`.`x` AS `x`, `RHS`.`y` AS `y`
+      SELECT
+        `RHS`.`x` AS `x`,
+        `RHS`.`y` AS `y`
       FROM `df` AS `LHS`
       RIGHT JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
-      
+      ON (`LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`)
 
 ---
 
@@ -63,11 +69,13 @@
       Joining, by = c("x", "y")
     Output
       <SQL>
-      SELECT COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`, COALESCE(`LHS`.`y`, `RHS`.`y`) AS `y`
+      SELECT
+        COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`,
+        COALESCE(`LHS`.`y`, `RHS`.`y`) AS `y`
       FROM `df` AS `LHS`
       FULL JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
-      
+      ON (`LHS`.`x` = `RHS`.`x` AND
+        `LHS`.`y` = `RHS`.`y`)
 
 # only disambiguates shared variables
 
@@ -77,11 +85,13 @@
       Joining, by = "x"
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x`, `y`, `z`
+      SELECT
+        `LHS`.`x` AS `x`,
+        `y`,
+        `z`
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (`LHS`.`x` = `RHS`.`x`)
-      
 
 ---
 
@@ -89,11 +99,13 @@
       left_join(lf1, lf2, by = c(y = "z"))
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x.x`, `y`, `RHS`.`x` AS `x.y`
+      SELECT
+        `LHS`.`x` AS `x.x`,
+        `y`,
+        `RHS`.`x` AS `x.y`
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (`LHS`.`y` = `RHS`.`z`)
-      
 
 # sql_on query doesn't change unexpectedly
 
@@ -101,11 +113,14 @@
       inner_join(lf1, lf2, sql_on = "LHS.y < RHS.z")
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x.x`, `y`, `RHS`.`x` AS `x.y`, `z`
+      SELECT
+        `LHS`.`x` AS `x.x`,
+        `y`,
+        `RHS`.`x` AS `x.y`,
+        `z`
       FROM `df` AS `LHS`
       INNER JOIN `df` AS `RHS`
       ON (LHS.y < RHS.z)
-      
 
 ---
 
@@ -113,11 +128,14 @@
       left_join(lf1, lf2, sql_on = "LHS.y < RHS.z")
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x.x`, `y`, `RHS`.`x` AS `x.y`, `z`
+      SELECT
+        `LHS`.`x` AS `x.x`,
+        `y`,
+        `RHS`.`x` AS `x.y`,
+        `z`
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (LHS.y < RHS.z)
-      
 
 ---
 
@@ -125,11 +143,14 @@
       right_join(lf1, lf2, sql_on = "LHS.y < RHS.z")
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x.x`, `y`, `RHS`.`x` AS `x.y`, `z`
+      SELECT
+        `LHS`.`x` AS `x.x`,
+        `y`,
+        `RHS`.`x` AS `x.y`,
+        `z`
       FROM `df` AS `LHS`
       RIGHT JOIN `df` AS `RHS`
       ON (LHS.y < RHS.z)
-      
 
 ---
 
@@ -137,11 +158,14 @@
       full_join(lf1, lf2, sql_on = "LHS.y < RHS.z")
     Output
       <SQL>
-      SELECT `LHS`.`x` AS `x.x`, `y`, `RHS`.`x` AS `x.y`, `z`
+      SELECT
+        `LHS`.`x` AS `x.x`,
+        `y`,
+        `RHS`.`x` AS `x.y`,
+        `z`
       FROM `df` AS `LHS`
       FULL JOIN `df` AS `RHS`
       ON (LHS.y < RHS.z)
-      
 
 ---
 

--- a/tests/testthat/_snaps/query-semi-join.md
+++ b/tests/testthat/_snaps/query-semi-join.md
@@ -24,8 +24,9 @@
       SELECT * FROM `df` AS `LHS`
       WHERE EXISTS (
         SELECT 1 FROM `df` AS `RHS`
-        WHERE (`LHS`.`x` = `RHS`.`x` AND
-          `LHS`.`y` = `RHS`.`y`)
+        WHERE
+          (`LHS`.`x` = `RHS`.`x`) AND
+          (`LHS`.`y` = `RHS`.`y`)
       )
 
 ---
@@ -39,7 +40,8 @@
       SELECT * FROM `df` AS `LHS`
       WHERE NOT EXISTS (
         SELECT 1 FROM `df` AS `RHS`
-        WHERE (`LHS`.`x` = `RHS`.`x` AND
-          `LHS`.`y` = `RHS`.`y`)
+        WHERE
+          (`LHS`.`x` = `RHS`.`x`) AND
+          (`LHS`.`y` = `RHS`.`y`)
       )
 

--- a/tests/testthat/_snaps/query-semi-join.md
+++ b/tests/testthat/_snaps/query-semi-join.md
@@ -24,7 +24,8 @@
       SELECT * FROM `df` AS `LHS`
       WHERE EXISTS (
         SELECT 1 FROM `df` AS `RHS`
-        WHERE (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
+        WHERE (`LHS`.`x` = `RHS`.`x` AND
+          `LHS`.`y` = `RHS`.`y`)
       )
 
 ---
@@ -38,6 +39,7 @@
       SELECT * FROM `df` AS `LHS`
       WHERE NOT EXISTS (
         SELECT 1 FROM `df` AS `RHS`
-        WHERE (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
+        WHERE (`LHS`.`x` = `RHS`.`x` AND
+          `LHS`.`y` = `RHS`.`y`)
       )
 

--- a/tests/testthat/_snaps/query-set-op.md
+++ b/tests/testthat/_snaps/query-set-op.md
@@ -21,11 +21,15 @@
       union(lf, lf)
     Output
       <SQL>
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
       UNION
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
 
 ---
 
@@ -33,11 +37,15 @@
       setdiff(lf, lf)
     Output
       <SQL>
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
       EXCEPT
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
 
 ---
 
@@ -45,11 +53,15 @@
       intersect(lf, lf)
     Output
       <SQL>
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
       INTERSECT
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
 
 ---
 
@@ -57,11 +69,15 @@
       union(lf, lf, all = TRUE)
     Output
       <SQL>
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
       UNION ALL
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
 
 ---
 
@@ -69,11 +85,15 @@
       setdiff(lf, lf, all = TRUE)
     Output
       <SQL>
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
       EXCEPT ALL
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
 
 ---
 
@@ -81,9 +101,13 @@
       intersect(lf, lf, all = TRUE)
     Output
       <SQL>
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
       INTERSECT ALL
-      (SELECT *
-      FROM `df`)
+      (
+        SELECT *
+        FROM `df`
+      )
 

--- a/tests/testthat/_snaps/verb-arrange.md
+++ b/tests/testthat/_snaps/verb-arrange.md
@@ -68,7 +68,9 @@
       lf %>% arrange(a) %>% select(-a) %>% mutate(c = lag(b))
     Output
       <SQL>
-      SELECT `b`, LAG(`b`, 1, NULL) OVER (ORDER BY `a`) AS `c`
+      SELECT
+        `b`,
+        LAG(`b`, 1, NULL) OVER (ORDER BY `a`) AS `c`
       FROM `df`
       ORDER BY `a`
 
@@ -81,9 +83,11 @@
     Output
       <SQL>
       SELECT *
-      FROM (SELECT *
-      FROM `df`
-      LIMIT 1) `q01`
+      FROM (
+        SELECT *
+        FROM `df`
+        LIMIT 1
+      ) `q01`
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% head(1)
@@ -98,17 +102,21 @@
     Output
       <SQL>
       SELECT *
-      FROM (SELECT *
-      FROM `df`
-      ORDER BY `a`
-      LIMIT 1) `q01`
+      FROM (
+        SELECT *
+        FROM `df`
+        ORDER BY `a`
+        LIMIT 1
+      ) `q01`
       ORDER BY `b`
     Code
       # mutate
       lf %>% mutate(a = b) %>% arrange(a)
     Output
       <SQL>
-      SELECT `b` AS `a`, `b`
+      SELECT
+        `b` AS `a`,
+        `b`
       FROM `df`
       ORDER BY `a`
     Code
@@ -116,7 +124,9 @@
       lf %>% arrange(a) %>% mutate(a = b) %>% arrange(a)
     Output
       <SQL>
-      SELECT `b` AS `a`, `b`
+      SELECT
+        `b` AS `a`,
+        `b`
       FROM `df`
       ORDER BY `a`
     Code
@@ -126,7 +136,9 @@
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
       <SQL>
-      SELECT 1.0 AS `a`, `b`
+      SELECT
+        1.0 AS `a`,
+        `b`
       FROM `df`
       ORDER BY `b`
     Code
@@ -136,9 +148,15 @@
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
       <SQL>
-      SELECT -`a` AS `a`, `b`
-      FROM (SELECT -`a` AS `a`, `b`
-      FROM `df`) `q01`
+      SELECT
+        -`a` AS `a`,
+        `b`
+      FROM (
+        SELECT
+          -`a` AS `a`,
+          `b`
+        FROM `df`
+      ) `q01`
 
 # can combine arrange with dual table verbs
 
@@ -154,12 +172,16 @@
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
       <SQL>
-      SELECT `LHS`.`a` AS `a`, `b`, `c`
-      FROM (SELECT *
-      FROM `df`) `LHS`
+      SELECT
+        `LHS`.`a` AS `a`,
+        `b`,
+        `c`
+      FROM (
+        SELECT *
+        FROM `df`
+      ) `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (`LHS`.`a` = `RHS`.`a`)
-      
     Code
       lf %>% arrange(a) %>% semi_join(rf)
     Message <message>
@@ -169,8 +191,10 @@
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
       <SQL>
-      SELECT * FROM (SELECT *
-      FROM `df`) `LHS`
+      SELECT * FROM (
+        SELECT *
+        FROM `df`
+      ) `LHS`
       WHERE EXISTS (
         SELECT 1 FROM `df` AS `RHS`
         WHERE (`LHS`.`a` = `RHS`.`a`)
@@ -179,12 +203,22 @@
       lf %>% arrange(a) %>% union(rf)
     Output
       <SQL>
-      (SELECT `a`, `b`, NULL AS `c`
-      FROM `df`
-      ORDER BY `a`)
+      (
+        SELECT
+          `a`,
+          `b`,
+          NULL AS `c`
+        FROM `df`
+        ORDER BY `a`
+      )
       UNION
-      (SELECT `a`, NULL AS `b`, `c`
-      FROM `df`)
+      (
+        SELECT
+          `a`,
+          NULL AS `b`,
+          `c`
+        FROM `df`
+      )
     Code
       # can arrange after join
       lf %>% left_join(rf) %>% arrange(a)
@@ -193,10 +227,14 @@
     Output
       <SQL>
       SELECT *
-      FROM (SELECT `LHS`.`a` AS `a`, `b`, `c`
-      FROM `df` AS `LHS`
-      LEFT JOIN `df` AS `RHS`
-      ON (`LHS`.`a` = `RHS`.`a`)
+      FROM (
+        SELECT
+          `LHS`.`a` AS `a`,
+          `b`,
+          `c`
+        FROM `df` AS `LHS`
+        LEFT JOIN `df` AS `RHS`
+        ON (`LHS`.`a` = `RHS`.`a`)
       ) `q01`
       ORDER BY `a`
     Code
@@ -206,21 +244,35 @@
     Output
       <SQL>
       SELECT *
-      FROM (SELECT * FROM `df` AS `LHS`
-      WHERE EXISTS (
-        SELECT 1 FROM `df` AS `RHS`
-        WHERE (`LHS`.`a` = `RHS`.`a`)
-      )) `q01`
+      FROM (
+        SELECT * FROM `df` AS `LHS`
+        WHERE EXISTS (
+          SELECT 1 FROM `df` AS `RHS`
+          WHERE (`LHS`.`a` = `RHS`.`a`)
+        )
+      ) `q01`
       ORDER BY `a`
     Code
       lf %>% union(rf) %>% arrange(a)
     Output
       <SQL>
       SELECT *
-      FROM ((SELECT `a`, `b`, NULL AS `c`
-      FROM `df`)
-      UNION
-      (SELECT `a`, NULL AS `b`, `c`
-      FROM `df`)) `q01`
+      FROM (
+        (
+          SELECT
+            `a`,
+            `b`,
+            NULL AS `c`
+          FROM `df`
+        )
+        UNION
+        (
+          SELECT
+            `a`,
+            NULL AS `b`,
+            `c`
+          FROM `df`
+        )
+      ) `q01`
       ORDER BY `a`
 

--- a/tests/testthat/_snaps/verb-count.md
+++ b/tests/testthat/_snaps/verb-count.md
@@ -4,7 +4,9 @@
       db %>% count(g)
     Output
       <SQL>
-      SELECT `g`, COUNT(*) AS `n`
+      SELECT
+        `g`,
+        COUNT(*) AS `n`
       FROM `df`
       GROUP BY `g`
 
@@ -14,7 +16,9 @@
       db %>% count(g, wt = x)
     Output
       <SQL>
-      SELECT `g`, SUM(`x`) AS `n`
+      SELECT
+        `g`,
+        SUM(`x`) AS `n`
       FROM `df`
       GROUP BY `g`
 
@@ -24,7 +28,9 @@
       db %>% count(g, sort = TRUE)
     Output
       <SQL>
-      SELECT `g`, COUNT(*) AS `n`
+      SELECT
+        `g`,
+        COUNT(*) AS `n`
       FROM `df`
       GROUP BY `g`
       ORDER BY `n` DESC

--- a/tests/testthat/_snaps/verb-expand.md
+++ b/tests/testthat/_snaps/verb-expand.md
@@ -4,11 +4,17 @@
       lazy_frame(x = 1, y = 1) %>% tidyr::expand(x, y)
     Output
       <SQL>
-      SELECT `x`, `y`
-      FROM (SELECT DISTINCT `x`
-      FROM `df`) `LHS`
-      LEFT JOIN (SELECT DISTINCT `y`
-      FROM `df`) `RHS`
+      SELECT
+        `x`,
+        `y`
+      FROM (
+        SELECT DISTINCT `x`
+        FROM `df`
+      ) `LHS`
+      LEFT JOIN (
+        SELECT DISTINCT `y`
+        FROM `df`
+      ) `RHS`
       
 
 # nesting doesn't expand values
@@ -17,7 +23,9 @@
       df_lazy %>% tidyr::expand(nesting(x, y))
     Output
       <SQL>
-      SELECT DISTINCT `x`, `y`
+      SELECT DISTINCT
+        `x`,
+        `y`
       FROM `df`
 
 # expand accepts expressions
@@ -35,7 +43,9 @@
       tidyr::expand(df, nesting(x_half = round(x / 2), x1 = x + 1))
     Output
       <SQL>
-      SELECT DISTINCT ROUND(`x` / 2.0, 0) AS `x_half`, `x` + 1.0 AS `x1`
+      SELECT DISTINCT
+        ROUND(`x` / 2.0, 0) AS `x_half`,
+        `x` + 1.0 AS `x1`
       FROM `df`
 
 # expand respects groups
@@ -44,13 +54,23 @@
       df_lazy %>% group_by(a) %>% tidyr::expand(b, c)
     Output
       <SQL>
-      SELECT `LHS`.`a` AS `a`, `b`, `c`
-      FROM (SELECT DISTINCT `a`, `b`
-      FROM `df`) `LHS`
-      LEFT JOIN (SELECT DISTINCT `a`, `c`
-      FROM `df`) `RHS`
+      SELECT
+        `LHS`.`a` AS `a`,
+        `b`,
+        `c`
+      FROM (
+        SELECT DISTINCT
+          `a`,
+          `b`
+        FROM `df`
+      ) `LHS`
+      LEFT JOIN (
+        SELECT DISTINCT
+          `a`,
+          `c`
+        FROM `df`
+      ) `RHS`
       ON (`LHS`.`a` = `RHS`.`a`)
-      
 
 # NULL inputs
 
@@ -75,7 +95,9 @@
       lazy_frame(x = 1, y = "a") %>% tidyr::replace_na(list(x = 0, y = "unknown"))
     Output
       <SQL>
-      SELECT COALESCE(`x`, 0.0) AS `x`, COALESCE(`y`, 'unknown') AS `y`
+      SELECT
+        COALESCE(`x`, 0.0) AS `x`,
+        COALESCE(`y`, 'unknown') AS `y`
       FROM `df`
 
 # replace_na ignores missing columns
@@ -93,15 +115,31 @@
       df_lazy %>% tidyr::complete(x, y, fill = list(z = "c"))
     Output
       <SQL>
-      SELECT `x`, `y`, COALESCE(`z`, 'c') AS `z`
-      FROM (SELECT COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`, COALESCE(`LHS`.`y`, `RHS`.`y`) AS `y`, `z`
-      FROM (SELECT `x`, `y`
-      FROM (SELECT DISTINCT `x`
-      FROM `df`) `LHS`
-      LEFT JOIN (SELECT DISTINCT `y`
-      FROM `df`) `RHS`
-      ) `LHS`
-      FULL JOIN `df` AS `RHS`
-      ON (`LHS`.`x` = `RHS`.`x` AND `LHS`.`y` = `RHS`.`y`)
+      SELECT
+        `x`,
+        `y`,
+        COALESCE(`z`, 'c') AS `z`
+      FROM (
+        SELECT
+          COALESCE(`LHS`.`x`, `RHS`.`x`) AS `x`,
+          COALESCE(`LHS`.`y`, `RHS`.`y`) AS `y`,
+          `z`
+        FROM (
+          SELECT
+            `x`,
+            `y`
+          FROM (
+            SELECT DISTINCT `x`
+            FROM `df`
+          ) `LHS`
+          LEFT JOIN (
+            SELECT DISTINCT `y`
+            FROM `df`
+          ) `RHS`
+      
+        ) `LHS`
+        FULL JOIN `df` AS `RHS`
+        ON (`LHS`.`x` = `RHS`.`x` AND
+          `LHS`.`y` = `RHS`.`y`)
       ) `q01`
 

--- a/tests/testthat/_snaps/verb-expand.md
+++ b/tests/testthat/_snaps/verb-expand.md
@@ -139,7 +139,9 @@
       
         ) `LHS`
         FULL JOIN `df` AS `RHS`
-        ON (`LHS`.`x` = `RHS`.`x` AND
-          `LHS`.`y` = `RHS`.`y`)
+        ON (
+          `LHS`.`x` = `RHS`.`x` AND
+          `LHS`.`y` = `RHS`.`y`
+        )
       ) `q01`
 

--- a/tests/testthat/_snaps/verb-fill.md
+++ b/tests/testthat/_snaps/verb-fill.md
@@ -4,9 +4,18 @@
       df_lazy_ns %>% window_order(id) %>% tidyr::fill(n1, .direction = "up")
     Output
       <SQL>
-      SELECT `id`, `group`, MAX(`n1`) OVER (PARTITION BY `..dbplyr_partion_1`) AS `n1`
-      FROM (SELECT `id`, `group`, `n1`, SUM(CASE WHEN (((`n1`) IS NULL)) THEN (0) WHEN NOT(((`n1`) IS NULL)) THEN (1) END) OVER (ORDER BY -`id` ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partion_1`
-      FROM `df`)
+      SELECT
+        `id`,
+        `group`,
+        MAX(`n1`) OVER (PARTITION BY `..dbplyr_partion_1`) AS `n1`
+      FROM (
+        SELECT
+          `id`,
+          `group`,
+          `n1`,
+          SUM(CASE WHEN (((`n1`) IS NULL)) THEN (0) WHEN NOT(((`n1`) IS NULL)) THEN (1) END) OVER (ORDER BY -`id` ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partion_1`
+        FROM `df`
+      )
 
 ---
 
@@ -14,7 +23,10 @@
       df_lazy_std %>% window_order(id) %>% tidyr::fill(n1, .direction = "up")
     Output
       <SQL>
-      SELECT `id`, `group`, LAST_VALUE(`n1` IGNORE NULLS) OVER (ORDER BY -`id`) AS `n1`
+      SELECT
+        `id`,
+        `group`,
+        LAST_VALUE(`n1` IGNORE NULLS) OVER (ORDER BY -`id`) AS `n1`
       FROM `df`
 
 # up-direction works with descending
@@ -23,9 +35,18 @@
       df_lazy_ns %>% window_order(desc(id)) %>% tidyr::fill(n1, .direction = "up")
     Output
       <SQL>
-      SELECT `id`, `group`, MAX(`n1`) OVER (PARTITION BY `..dbplyr_partion_1`) AS `n1`
-      FROM (SELECT `id`, `group`, `n1`, SUM(CASE WHEN (((`n1`) IS NULL)) THEN (0) WHEN NOT(((`n1`) IS NULL)) THEN (1) END) OVER (ORDER BY -`id` DESC ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partion_1`
-      FROM `df`)
+      SELECT
+        `id`,
+        `group`,
+        MAX(`n1`) OVER (PARTITION BY `..dbplyr_partion_1`) AS `n1`
+      FROM (
+        SELECT
+          `id`,
+          `group`,
+          `n1`,
+          SUM(CASE WHEN (((`n1`) IS NULL)) THEN (0) WHEN NOT(((`n1`) IS NULL)) THEN (1) END) OVER (ORDER BY -`id` DESC ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partion_1`
+        FROM `df`
+      )
 
 ---
 
@@ -33,7 +54,10 @@
       df_lazy_std %>% window_order(desc(id)) %>% tidyr::fill(n1, .direction = "up")
     Output
       <SQL>
-      SELECT `id`, `group`, LAST_VALUE(`n1` IGNORE NULLS) OVER (ORDER BY -`id` DESC) AS `n1`
+      SELECT
+        `id`,
+        `group`,
+        LAST_VALUE(`n1` IGNORE NULLS) OVER (ORDER BY -`id` DESC) AS `n1`
       FROM `df`
 
 # groups are respected
@@ -42,9 +66,18 @@
       group_by(df_lazy_ns, group) %>% window_order(id) %>% tidyr::fill(n1)
     Output
       <SQL>
-      SELECT `id`, `group`, MAX(`n1`) OVER (PARTITION BY `group`, `..dbplyr_partion_1`) AS `n1`
-      FROM (SELECT `id`, `group`, `n1`, SUM(CASE WHEN (((`n1`) IS NULL)) THEN (0) WHEN NOT(((`n1`) IS NULL)) THEN (1) END) OVER (PARTITION BY `group` ORDER BY `id` ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partion_1`
-      FROM `df`)
+      SELECT
+        `id`,
+        `group`,
+        MAX(`n1`) OVER (PARTITION BY `group`, `..dbplyr_partion_1`) AS `n1`
+      FROM (
+        SELECT
+          `id`,
+          `group`,
+          `n1`,
+          SUM(CASE WHEN (((`n1`) IS NULL)) THEN (0) WHEN NOT(((`n1`) IS NULL)) THEN (1) END) OVER (PARTITION BY `group` ORDER BY `id` ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partion_1`
+        FROM `df`
+      )
 
 ---
 
@@ -52,7 +85,10 @@
       group_by(df_lazy_std, group) %>% window_order(id) %>% tidyr::fill(n1)
     Output
       <SQL>
-      SELECT `id`, `group`, LAST_VALUE(`n1` IGNORE NULLS) OVER (PARTITION BY `group` ORDER BY `id`) AS `n1`
+      SELECT
+        `id`,
+        `group`,
+        LAST_VALUE(`n1` IGNORE NULLS) OVER (PARTITION BY `group` ORDER BY `id`) AS `n1`
       FROM `df`
 
 # fill errors on unsorted data

--- a/tests/testthat/_snaps/verb-joins.md
+++ b/tests/testthat/_snaps/verb-joins.md
@@ -8,5 +8,4 @@
       FROM `df` AS `LHS`
       LEFT JOIN `df` AS `RHS`
       ON (CASE WHEN (`LHS`.`x` = `RHS`.`x`) OR (`LHS`.`x` IS NULL AND `RHS`.`x` IS NULL) THEN 0 ELSE 1 = 0)
-      
 

--- a/tests/testthat/_snaps/verb-mutate.md
+++ b/tests/testthat/_snaps/verb-mutate.md
@@ -5,9 +5,13 @@
     Output
       <SQL>
       SELECT `x` + 4.0 AS `x`
-      FROM (SELECT `x` + 2.0 AS `x`
-      FROM (SELECT `x` + 1.0 AS `x`
-      FROM `multi_mutate`))
+      FROM (
+        SELECT `x` + 2.0 AS `x`
+        FROM (
+          SELECT `x` + 1.0 AS `x`
+          FROM `multi_mutate`
+        )
+      )
 
 # transmute includes all needed variables
 
@@ -15,9 +19,15 @@
       out
     Output
       <SQL>
-      SELECT `x`, `x` + `y` AS `x2`
-      FROM (SELECT `x` / 2.0 AS `x`, `y`
-      FROM `df`) `q01`
+      SELECT
+        `x`,
+        `x` + `y` AS `x2`
+      FROM (
+        SELECT
+          `x` / 2.0 AS `x`,
+          `y`
+        FROM `df`
+      ) `q01`
 
 # mutate generates subqueries as needed
 
@@ -26,8 +36,10 @@
     Output
       <SQL>
       SELECT `x` + 1.0 AS `x`
-      FROM (SELECT `x` + 1.0 AS `x`
-      FROM `df`)
+      FROM (
+        SELECT `x` + 1.0 AS `x`
+        FROM `df`
+      )
 
 ---
 
@@ -35,9 +47,16 @@
       lf %>% mutate(x1 = x + 1, x2 = x1 + 1)
     Output
       <SQL>
-      SELECT `x`, `x1`, `x1` + 1.0 AS `x2`
-      FROM (SELECT `x`, `x` + 1.0 AS `x1`
-      FROM `df`)
+      SELECT
+        `x`,
+        `x1`,
+        `x1` + 1.0 AS `x2`
+      FROM (
+        SELECT
+          `x`,
+          `x` + 1.0 AS `x1`
+        FROM `df`
+      )
 
 # mutate collapses over nested select
 
@@ -45,7 +64,9 @@
       lf %>% select(x:y) %>% mutate(x = x * 2, y = y * 2)
     Output
       <SQL>
-      SELECT `x` * 2.0 AS `x`, `y` * 2.0 AS `y`
+      SELECT
+        `x` * 2.0 AS `x`,
+        `y` * 2.0 AS `y`
       FROM `df`
 
 ---
@@ -54,6 +75,8 @@
       lf %>% select(y:x) %>% mutate(x = x * 2, y = y * 2)
     Output
       <SQL>
-      SELECT `y` * 2.0 AS `y`, `x` * 2.0 AS `x`
+      SELECT
+        `y` * 2.0 AS `y`,
+        `x` * 2.0 AS `x`
       FROM `df`
 

--- a/tests/testthat/_snaps/verb-pivot-longer.md
+++ b/tests/testthat/_snaps/verb-pivot-longer.md
@@ -4,11 +4,19 @@
       lazy_frame(x = 1:2, y = 3:4) %>% tidyr::pivot_longer(x:y)
     Output
       <SQL>
-      (SELECT 'x' AS `name`, `x` AS `value`
-      FROM `df`)
+      (
+        SELECT
+          'x' AS `name`,
+          `x` AS `value`
+        FROM `df`
+      )
       UNION ALL
-      (SELECT 'y' AS `name`, `y` AS `value`
-      FROM `df`)
+      (
+        SELECT
+          'y' AS `name`,
+          `y` AS `value`
+        FROM `df`
+      )
 
 # can add multiple columns from spec
 
@@ -16,11 +24,21 @@
       pv
     Output
       <SQL>
-      (SELECT 11 AS `a`, 13 AS `b`, `x` AS `v`
-      FROM `df`)
+      (
+        SELECT
+          11 AS `a`,
+          13 AS `b`,
+          `x` AS `v`
+        FROM `df`
+      )
       UNION ALL
-      (SELECT 12 AS `a`, 14 AS `b`, `y` AS `v`
-      FROM `df`)
+      (
+        SELECT
+          12 AS `a`,
+          14 AS `b`,
+          `y` AS `v`
+        FROM `df`
+      )
 
 # preserves original keys
 
@@ -28,11 +46,21 @@
       pv
     Output
       <SQL>
-      (SELECT `x`, 'y' AS `name`, `y` AS `value`
-      FROM `df`)
+      (
+        SELECT
+          `x`,
+          'y' AS `name`,
+          `y` AS `value`
+        FROM `df`
+      )
       UNION ALL
-      (SELECT `x`, 'z' AS `name`, `z` AS `value`
-      FROM `df`)
+      (
+        SELECT
+          `x`,
+          'z' AS `name`,
+          `z` AS `value`
+        FROM `df`
+      )
 
 # can drop missing values
 
@@ -42,11 +70,21 @@
     Output
       <SQL>
       SELECT *
-      FROM ((SELECT 'x' AS `name`, `x` AS `value`
-      FROM `df`)
-      UNION ALL
-      (SELECT 'y' AS `name`, `y` AS `value`
-      FROM `df`)) `q01`
+      FROM (
+        (
+          SELECT
+            'x' AS `name`,
+            `x` AS `value`
+          FROM `df`
+        )
+        UNION ALL
+        (
+          SELECT
+            'y' AS `name`,
+            `y` AS `value`
+          FROM `df`
+        )
+      ) `q01`
       WHERE (NOT(((`value`) IS NULL)))
 
 # can handle missing combinations
@@ -55,12 +93,29 @@
       sql
     Output
       <SQL>
-      (SELECT `id`, `n`, `x`, NULL AS `y`
-      FROM (SELECT `id`, '1' AS `n`, `x_1` AS `x`
-      FROM `df`) `q01`)
+      (
+        SELECT
+          `id`,
+          `n`,
+          `x`,
+          NULL AS `y`
+        FROM (
+          SELECT
+            `id`,
+            '1' AS `n`,
+            `x_1` AS `x`
+          FROM `df`
+        ) `q01`
+      )
       UNION ALL
-      (SELECT `id`, '2' AS `n`, `x_2` AS `x`, `y_2` AS `y`
-      FROM `df`)
+      (
+        SELECT
+          `id`,
+          '2' AS `n`,
+          `x_2` AS `x`,
+          `y_2` AS `y`
+        FROM `df`
+      )
 
 # can override default output column type
 
@@ -68,7 +123,9 @@
       lazy_frame(x = 1) %>% tidyr::pivot_longer(x, values_transform = list(value = as.character))
     Output
       <SQL>
-      SELECT 'x' AS `name`, CAST(`x` AS TEXT) AS `value`
+      SELECT
+        'x' AS `name`,
+        CAST(`x` AS TEXT) AS `value`
       FROM `df`
 
 # can pivot to multiple measure cols
@@ -77,7 +134,10 @@
       pv
     Output
       <SQL>
-      SELECT 1.0 AS `row`, `x` AS `X`, `y` AS `Y`
+      SELECT
+        1.0 AS `row`,
+        `x` AS `X`,
+        `y` AS `Y`
       FROM `df`
 
 # .value can be at any position in `names_to`
@@ -86,11 +146,23 @@
       value_first
     Output
       <SQL>
-      (SELECT `i`, 't1' AS `time`, `y_t1` AS `y`, `z_t1` AS `z`
-      FROM `df`)
+      (
+        SELECT
+          `i`,
+          't1' AS `time`,
+          `y_t1` AS `y`,
+          `z_t1` AS `z`
+        FROM `df`
+      )
       UNION ALL
-      (SELECT `i`, 't2' AS `time`, `y_t2` AS `y`, `z_t2` AS `z`
-      FROM `df`)
+      (
+        SELECT
+          `i`,
+          't2' AS `time`,
+          `y_t2` AS `y`,
+          `z_t2` AS `z`
+        FROM `df`
+      )
 
 ---
 
@@ -98,9 +170,21 @@
       value_second
     Output
       <SQL>
-      (SELECT `i`, 't1' AS `time`, `t1_y` AS `y`, `t1_z` AS `z`
-      FROM `df`)
+      (
+        SELECT
+          `i`,
+          't1' AS `time`,
+          `t1_y` AS `y`,
+          `t1_z` AS `z`
+        FROM `df`
+      )
       UNION ALL
-      (SELECT `i`, 't2' AS `time`, `t2_y` AS `y`, `t2_z` AS `z`
-      FROM `df`)
+      (
+        SELECT
+          `i`,
+          't2' AS `time`,
+          `t2_y` AS `y`,
+          `t2_z` AS `z`
+        FROM `df`
+      )
 

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -4,7 +4,10 @@
       lazy_frame(key = c("x", "y", "z"), val = 1:3) %>% dbplyr_pivot_wider_spec(spec)
     Output
       <SQL>
-      SELECT MAX(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`, MAX(CASE WHEN (`key` = 'y') THEN (`val`) END) AS `y`, MAX(CASE WHEN (`key` = 'z') THEN (`val`) END) AS `z`
+      SELECT
+        MAX(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`,
+        MAX(CASE WHEN (`key` = 'y') THEN (`val`) END) AS `y`,
+        MAX(CASE WHEN (`key` = 'z') THEN (`val`) END) AS `z`
       FROM `df`
 
 # implicit missings turn into explicit missings
@@ -14,7 +17,10 @@
         spec)
     Output
       <SQL>
-      SELECT `a`, MAX(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`, MAX(CASE WHEN (`key` = 'y') THEN (`val`) END) AS `y`
+      SELECT
+        `a`,
+        MAX(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`,
+        MAX(CASE WHEN (`key` = 'y') THEN (`val`) END) AS `y`
       FROM `df`
       GROUP BY `a`
 
@@ -30,7 +36,9 @@
       dbplyr_pivot_wider_spec(df, spec1, values_fn = sum)
     Output
       <SQL>
-      SELECT `a`, SUM(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`
+      SELECT
+        `a`,
+        SUM(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`
       FROM `df`
       GROUP BY `a`
 
@@ -45,9 +53,17 @@
       dbplyr_pivot_wider_spec(df_lazy, spec, values_fill = 0)
     Output
       <SQL>
-      SELECT `g`, `name`, `value`, MAX(CASE WHEN (`key` = 'x') THEN (`val`) WHEN NOT(`key` = 'x') THEN (0.0) END) AS `x`, MAX(CASE WHEN (`key` = 'y') THEN (`val`) WHEN NOT(`key` = 'y') THEN (0.0) END) AS `y`
+      SELECT
+        `g`,
+        `name`,
+        `value`,
+        MAX(CASE WHEN (`key` = 'x') THEN (`val`) WHEN NOT(`key` = 'x') THEN (0.0) END) AS `x`,
+        MAX(CASE WHEN (`key` = 'y') THEN (`val`) WHEN NOT(`key` = 'y') THEN (0.0) END) AS `y`
       FROM `df`
-      GROUP BY `g`, `name`, `value`
+      GROUP BY
+        `g`,
+        `name`,
+        `value`
 
 ---
 
@@ -55,9 +71,17 @@
       dbplyr_pivot_wider_spec(df_lazy, spec, values_fill = list(value = 0))
     Output
       <SQL>
-      SELECT `g`, `name`, `value`, MAX(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`, MAX(CASE WHEN (`key` = 'y') THEN (`val`) END) AS `y`
+      SELECT
+        `g`,
+        `name`,
+        `value`,
+        MAX(CASE WHEN (`key` = 'x') THEN (`val`) END) AS `x`,
+        MAX(CASE WHEN (`key` = 'y') THEN (`val`) END) AS `y`
       FROM `df`
-      GROUP BY `g`, `name`, `value`
+      GROUP BY
+        `g`,
+        `name`,
+        `value`
 
 # cannot pivot lazy frames
 

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -11,7 +11,9 @@
       lf %>% select(2:1) %>% select(2:1)
     Output
       <SQL>
-      SELECT `x`, `y`
+      SELECT
+        `x`,
+        `y`
       FROM `df`
 
 ---
@@ -20,7 +22,9 @@
       lf %>% select(2:1) %>% select(2:1) %>% select(2:1)
     Output
       <SQL>
-      SELECT `y`, `x`
+      SELECT
+        `y`,
+        `x`
       FROM `df`
 
 ---

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -6,9 +6,13 @@
     Message <message>
       `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
     Output
-      <SQL> SELECT `x`, `y`
+      <SQL> SELECT
+        `x`,
+        `y`
       FROM `df`
-      GROUP BY `x`, `y`
+      GROUP BY
+        `x`,
+        `y`
 
 ---
 
@@ -20,7 +24,9 @@
     Code
       out %>% sql_render
     Output
-      <SQL> SELECT `x`, COUNT(*) AS `n`
+      <SQL> SELECT
+        `x`,
+        COUNT(*) AS `n`
       FROM `verb-summarise`
       GROUP BY `x`
 

--- a/tests/testthat/_snaps/verb-uncount.md
+++ b/tests/testthat/_snaps/verb-uncount.md
@@ -5,9 +5,13 @@
     Output
       <SQL>
       SELECT `x`
-      FROM (SELECT `x`, `w`, `..dbplyr_row_id`
-      FROM `dbplyr_2001` AS `LHS`
-      INNER JOIN `dbplyr_2003` AS `RHS`
-      ON (`RHS`.`..dbplyr_row_id` <= `LHS`.`w`)
+      FROM (
+        SELECT
+          `x`,
+          `w`,
+          `..dbplyr_row_id`
+        FROM `dbplyr_2001` AS `LHS`
+        INNER JOIN `dbplyr_2003` AS `RHS`
+        ON (`RHS`.`..dbplyr_row_id` <= `LHS`.`w`)
       )
 

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -102,13 +102,13 @@ test_that("convert between bit and boolean as needed", {
 
 test_that("handles ORDER BY in subqueries", {
   expect_snapshot(
-    sql_query_select(simulate_mssql(), "x", "y", order_by = "z", subquery = TRUE)
+    sql_query_select(simulate_mssql(), ident("x"), ident("y"), order_by = "z", subquery = TRUE)
   )
 })
 
 test_that("custom limit translation", {
   expect_snapshot(
-    sql_query_select(simulate_mssql(), "x", "y", order_by = "z", limit = 10)
+    sql_query_select(simulate_mssql(), ident("x"), ident("y"), order_by = ident("z"), limit = 10)
   )
 })
 

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -135,7 +135,7 @@ test_that("sequence of operations work", {
 
 test_that("quoting for rendering mutated grouped table", {
   out <- memdb_frame(x = 1, y = 2) %>% mutate(y = x)
-  expect_match(out %>% sql_render, "^SELECT `x`, `x` AS `y`\nFROM `[^`]*`$")
+  expect_match(out %>% sql_render, "^SELECT\n  `x`,\n  `x` AS `y`\nFROM `[^`]*`$")
   expect_equal(out %>% collect, tibble(x = 1, y = 1))
 })
 


### PR DESCRIPTION
Fixes #636.

I am not sure what should be controllable via an option and what should be the new default. I think the following options make sense

* **base indent:** the base indent used; defaults to two spaces "&nbsp;&nbsp;" but this could be any number of spaces or tabs
* **indent_strategy:** I added four strategies
  * `"legacy"`: produces the same output as `dbplyr` does currently
  * `"minimal"`: indent subqueries
  * `"indent"`: each field on its own line. Line break after keyword and fields are one level more intended than the keyword
```sql
SELECT
  `mpg`,
  `cyl`,
  `disp`
```
  * `"align"`: each field on its own line. No line break and fields are all aligned
```sql
SELECT `mpg`,
       `cyl`,
       `disp`
```
* **align on AS:**

maybe
* **"AND" position:**
  * `"line_end"`
  * `"line_start"`: it is a bit easier to remove (or comment out) the last condition
```sql
WHERE
  `mpg` > 1 AND
  `cyl` = 6

-- vs

WHERE
  `mpg` > 1
  AND `cyl` = 6
```
* **"comma" position:** same like for "AND"
* **"keyword alignment:**
  * `"left"`
  * `"right"`
```sql
SELECT *
FROM df

-- vs

SELECT *
  FROM df
```
* **truncate strings**: truncate long strings?
* **truncate lists/vectors**

## Select query
``` r
tbl_lazy(mtcars) %>% 
  mutate(mpg = mpg + 1,
         mpg = mpg - 1) %>% 
  filter(
    mpg > 1,
    cyl == 6
  ) %>% 
  group_by(mpg, cyl) %>% 
  summarise(mpg = mean(mpg, na.rm = TRUE))
```

before
```sql
SELECT `mpg`, `cyl`, AVG(`mpg`) AS `mpg`
FROM (SELECT `mpg` - 1.0 AS `mpg`, `cyl`, `disp`, `hp`, `drat`, `wt`, `qsec`, `vs`, `am`, `gear`, `carb`
FROM (SELECT `mpg` + 1.0 AS `mpg`, `cyl`, `disp`, `hp`, `drat`, `wt`, `qsec`, `vs`, `am`, `gear`, `carb`
FROM `df`) `q01`) `q02`
WHERE ((`mpg` > 1.0) AND (`cyl` = 6.0))
GROUP BY `mpg`, `cyl`
```

after
```sql
SELECT
  `mpg`,
  `cyl`,
  AVG(`mpg`) AS `mpg`
FROM (
  SELECT
    `mpg` - 1.0 AS `mpg`,
    `cyl`,
    `disp`,
    `hp`,
    `drat`,
    `wt`,
    `qsec`,
    `vs`,
    `am`,
    `gear`,
    `carb`
  FROM (
    SELECT
      `mpg` + 1.0 AS `mpg`,
      `cyl`,
      `disp`,
      `hp`,
      `drat`,
      `wt`,
      `qsec`,
      `vs`,
      `am`,
      `gear`,
      `carb`
    FROM `df`
  ) `q01`
) `q02`
WHERE
  (`mpg` > 1.0) AND
  (`cyl` = 6.0)
GROUP BY
  `mpg`,
  `cyl`
```

## Union Query
```r
union(
  union(
    tbl_lazy(mtcars) %>% 
      select(mpg, cyl),
    tbl_lazy(mtcars) %>% 
      select(mpg, cyl)
  ),
  tbl_lazy(mtcars) %>% 
    filter(mpg > 1) %>% 
    transmute(mpg = mpg + 1, cyl)
)
```

before

```sql
((SELECT `mpg`, `cyl`
FROM `df`)
UNION
(SELECT `mpg`, `cyl`
FROM `df`))
UNION
(SELECT `mpg` + 1.0 AS `mpg`, `cyl`
FROM `df`
WHERE (`mpg` > 1.0))
```

after

```sql
(
  (
    SELECT
      `mpg`,
      `cyl`
    FROM `df`
  )
  UNION
  (
    SELECT
      `mpg`,
      `cyl`
    FROM `df`
  )
)
UNION
(
  SELECT
    `mpg` + 1.0 AS `mpg`,
    `cyl`
  FROM `df`
  WHERE (`mpg` > 1.0)
)
```