### PR TITLE
Add support for lubridate week() for PostgreSQL backend

### DIFF
--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -107,6 +107,9 @@ sql_translation.PqConnection <- function(con) {
       },
 
       # lubridate functions
+      week = function(x) {
+        sql_expr(EXTRACT(WEEK %FROM% !!x))
+      },
       month = function(x, label = FALSE, abbr = TRUE) {
         if (!label) {
           sql_expr(EXTRACT(MONTH %FROM% !!x))


### PR DESCRIPTION
Added translation for lubridate function `week()` in PostgreSQL backend.

Resolves #675 

Signed-off-by: andres <afquinteromoreano@gmail.com>