### PR TITLE
Fix typo in shiny object name

### DIFF
--- a/R/escape.R
+++ b/R/escape.R
@@ -132,7 +132,7 @@ escape.data.frame <- function(x, parens = TRUE, collapse = ", ", con = NULL) {
 
 #' @export
 escape.reactivevalues <- function(x, parens = TRUE, collapse = ", ", con = NULL) {
-  error_embed("shiny inputs", "inputs$x")
+  error_embed("shiny inputs", "input$x")
 }
 
 # Also used in default_ops() for reactives


### PR DESCRIPTION
I hit this error while building a shiny app running on a lazy_tbl:
```
ERROR: Cannot translate shiny inputs to SQL.
* Force evaluation in R with (e.g.) `!!inputs$x` or `local(inputs$x)`
```

When I tried the proposed solution, it did not work. This is because the object is called `input$x` not `inputs$x`