### PR TITLE
New render pipeline

### DIFF
--- a/R/query2.R
+++ b/R/query2.R
@@ -1,0 +1,45 @@
+select_query2 <- function(from,
+                          select = list(),
+                          where = list(),
+                          group_by = list(),
+                          order_by = list(),
+                          limit = NULL,
+                          distinct = FALSE) {
+  vctrs::vec_assert(from, character(), 1L)
+  assert_list_of_sql_parts(select)
+  assert_list_of_sql_parts(where)
+  assert_list_of_sql_parts(group_by)
+  assert_list_of_sql_parts(order_by)
+  stopifnot(is.null(limit) || (is.numeric(limit) && length(limit) == 1L))
+  stopifnot(is.logical(distinct), length(distinct) == 1L)
+
+  structure(
+    list(
+      from = from,
+      select = select,
+      where = where,
+      group_by = group_by,
+      order_by = order_by,
+      distinct = distinct,
+      limit = limit
+    ),
+    class = c("select_query2", "query2")
+  )
+}
+
+assert_list_of_sql_parts <- function(x) {
+  vctrs::vec_assert(x, list())
+
+  all_valid <- purrr::every(x, is_sql_part)
+  if (!all_valid) {
+    abort("Every part of `x` must be a quosure, a symbol, or sql.")
+  }
+}
+
+is_sql_part <- function(x) {
+  if (rlang::is_quosure(x)) return(TRUE)
+  if (rlang::is_symbol(x)) return(TRUE)
+  if (is.sql(x)) return(TRUE)
+
+  FALSE
+}


### PR DESCRIPTION
## Current Translation Approach

The translation currently consists of two stages:

1. The "operation" stage: Whenever a "basic" `dplyr` verb is applied to a lazy table it adds an operation describing the verb and its argument to the `ops` field of the lazy table. This quickly results in a deeply nested list.
2. `sql_build()` creates a query object (`select_query()`, `join_query`, `semi_join_query`, or `set_op_query`) which is a container containing SQL for e.g. `SELECT` or `WHERE`
3. `sql_optimise()` tries to combine the query objects generated in the previous step to generate less nested SQL
4. `sql_render()` converts the query objects to actual SQL for the corresponding backend

Issues with the approach:
* the operations list is quickly deeply nested resulting in a big call stack in `sql_build()`
* many optimisations cannot be applied anymore as it would require re-rendering the SQL generated in the previous step
* Things like using CTEs is a bit hacky


## New Approach

Replace the `ops` field by a `query_list` field. This `query_list` consists of "lazy" query objects which are similar to the current query objects but they are containers for quosures instead of containers for SQL.

The new pipe basically looks as follows:

1. Each "basic" `dplyr` verb adds a or modifies the current "lazy" query object to the `query_list` field of the lazy tables
2. `sql_optimise()` removes unnecessary variables, tries to merge query objects, and removes trivial ones
3. `sql_build()` iterates over `query_list` and translates the quosures to SQL. It produces the current query objects
4. `sql_render()` can stay unchanged.

This should allow to tackle the following issues
* #725 
* #722 
* #721 
* #719

And help in these PRs
* #656 
* #637

Overall, this should allow to produce much more natural SQL.