### PR TITLE
Add `ON COMMIT PRESERVE ROWS` when creating temporary table in Oracle

### DIFF
--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -120,7 +120,7 @@ sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...,
 sql_query_save.Oracle <- function(con, sql, name, temporary = TRUE, ...) {
   build_sql(
     "CREATE ", if (temporary) sql("GLOBAL TEMPORARY "), "TABLE \n",
-    as.sql(name, con), " ON COMMIT PRESERVE ROWS AS\n", sql,
+    as.sql(name, con), if (temporary) " ON COMMIT PRESERVE ROWS", " AS\n", sql,
     con = con
   )
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -120,7 +120,7 @@ sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...,
 sql_query_save.Oracle <- function(con, sql, name, temporary = TRUE, ...) {
   build_sql(
     "CREATE ", if (temporary) sql("GLOBAL TEMPORARY "), "TABLE \n",
-    as.sql(name, con), "ON COMMIT PRESERVE ROWS AS\n", sql,
+    as.sql(name, con), " ON COMMIT PRESERVE ROWS AS\n", sql,
     con = con
   )
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -120,7 +120,7 @@ sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...,
 sql_query_save.Oracle <- function(con, sql, name, temporary = TRUE, ...) {
   build_sql(
     "CREATE ", if (temporary) sql("GLOBAL TEMPORARY "), "TABLE \n",
-    as.sql(name, con), if (temporary) " ON COMMIT PRESERVE ROWS", " AS\n", sql,
+    as.sql(name, con), if (temporary) sql(" ON COMMIT PRESERVE ROWS"), " AS\n", sql,
     con = con
   )
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -120,7 +120,7 @@ sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ...,
 sql_query_save.Oracle <- function(con, sql, name, temporary = TRUE, ...) {
   build_sql(
     "CREATE ", if (temporary) sql("GLOBAL TEMPORARY "), "TABLE \n",
-    as.sql(name, con), " AS\n", sql,
+    as.sql(name, con), "ON COMMIT PRESERVE ROWS AS\n", sql,
     con = con
   )
 }

--- a/tests/testthat/_snaps/backend-oracle.md
+++ b/tests/testthat/_snaps/backend-oracle.md
@@ -40,7 +40,7 @@
       sql_query_save(con, sql("SELECT * FROM foo"), in_schema("schema", "tbl"))
     Output
       <SQL> CREATE GLOBAL TEMPORARY TABLE 
-      `schema`.`tbl` AS
+      `schema`.`tbl` ON COMMIT PRESERVE ROWS AS
       SELECT * FROM foo
 
 ---


### PR DESCRIPTION
Closes #750 

Tested this out locally and fixes the issue - without this additional statement the temporary table is blank.

https://stackoverflow.com/questions/27093937/how-to-create-a-temporary-table-as-copy-of-another-table-in-oracle