### PR TITLE
Added missing connection parameter to the dbplyr_fill0 implementation

### DIFF
--- a/R/verb-fill.R
+++ b/R/verb-fill.R
@@ -141,6 +141,7 @@ dbplyr_fill0.SQLiteConnection <- function(.con,
     cols_to_fill,
     ~ translate_sql(
       cumsum(case_when(is.na(!!.x) ~ 0L, TRUE ~ 1L)),
+      con = .con,
       vars_order = translate_sql(!!!order_by_cols, con = .con),
       vars_group = op_grps(.data),
     )


### PR DESCRIPTION
The connection parameter was not passed to the first translate_sql() call in the dbplyr_fill0 implementation for databases without support for IGNORE NULLS. Because of that the quotes other than \`  \` were not correct for that particular translate_sql() call.

Following the example in the [fill documentation](https://dbplyr.tidyverse.org/reference/fill.tbl_lazy.html) the produced SQL was as follows with a database that uses " " as quotes:

```sql
<SQL>
SELECT "group", "name", "role", MAX("n_squirrels") OVER (PARTITION BY "..dbplyr_partion_1") AS "n_squirrels", 
MAX("n_squirrels2") OVER (PARTITION BY "..dbplyr_partion_2") AS "n_squirrels2", "id" FROM
(SELECT "group", "name", "role", "n_squirrels", "n_squirrels2", "id", SUM(CASE WHEN (((`n_squirrels`) IS NULL)) THEN 0 
ELSE 1 END) OVER (ORDER BY "id" ROWS UNBOUNDED PRECEDING) AS "..dbplyr_partion_1", 
SUM(CASE WHEN (((`n_squirrels2`) IS NULL))  THEN 0 ELSE 1 END) OVER (ORDER BY "id" ROWS UNBOUNDED PRECEDING) AS
"..dbplyr_partion_2" FROM "squirrels") "q01"
```

So following the `SUM(CASE WHEN...` there are wrong quotes in two places (around the variable names).

The fix was simple and only requires that the missing connection parameter is added to the translate_sql() call as shown in the commit.
