### PR TITLE
Update to rlang 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     methods,
     purrr (>= 0.2.5),
     R6 (>= 2.2.2),
-    rlang (>= 0.2.0),
+    rlang (>= 1.0.0),
     tibble (>= 1.4.2),
     tidyselect (>= 0.2.4),
     utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-gb
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Collate: 
     'utils.R'
     'sql.R'

--- a/R/escape.R
+++ b/R/escape.R
@@ -140,7 +140,7 @@ error_embed <- function(type, expr) {
   abort(c(
     glue("Cannot translate {type} to SQL."),
     glue("Force evaluation in R with (e.g.) `!!{expr}` or `local({expr})`")
-  ))
+  ), call = NULL)
 }
 
 #' @export

--- a/R/test-frame.R
+++ b/R/test-frame.R
@@ -95,6 +95,6 @@ test_srcs <- local({
 
 # Modern helpers ----------------------------------------------------------
 
-copy_to_test <- function(src, df, ...) {
-  copy_to(src_test(src), df, "test", ..., overwrite = TRUE)
+copy_to_test <- function(src, df, ..., name = "test") {
+  copy_to(src_test(src), df, name, ..., overwrite = TRUE)
 }

--- a/R/verb-count.R
+++ b/R/verb-count.R
@@ -55,8 +55,11 @@ check_name <- function(name, vars) {
     return(name)
   }
 
-  abort(c(
-    glue("'{name}' already present in output"),
-    i = "Use `name = \"new_name\"` to pick a new name."
-  ))
+  abort(
+    c(
+      glue("'{name}' already present in output"),
+      i = "Use `name = \"new_name\"` to pick a new name."
+    ),
+    call = caller_env()
+  )
 }

--- a/R/verb-distinct.R
+++ b/R/verb-distinct.R
@@ -17,9 +17,8 @@
 distinct.tbl_lazy <- function(.data, ..., .keep_all = FALSE) {
   if (dots_n(...) > 0) {
     if (.keep_all) {
-      stop(
-        "Can only find distinct value of specified columns if .keep_all is FALSE",
-        call. = FALSE
+      abort(
+        "Can only find distinct value of specified columns if `.keep_all` is FALSE"
       )
     }
 

--- a/R/verb-expand.R
+++ b/R/verb-expand.R
@@ -10,22 +10,20 @@
 #' more details.
 #' @inheritParams tibble::as_tibble
 #' @inherit arrange.tbl_lazy return
-#' @examples
-#' if (require("tidyr", quietly = TRUE)) {
-#'   fruits <- memdb_frame(
-#'     type   = c("apple", "orange", "apple", "orange", "orange", "orange"),
-#'     year   = c(2010, 2010, 2012, 2010, 2010, 2012),
-#'     size = c("XS", "S",  "M", "S", "S", "M"),
-#'     weights = rnorm(6)
-#'   )
+#' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
+#' fruits <- memdb_frame(
+#'   type   = c("apple", "orange", "apple", "orange", "orange", "orange"),
+#'   year   = c(2010, 2010, 2012, 2010, 2010, 2012),
+#'   size = c("XS", "S",  "M", "S", "S", "M"),
+#'   weights = rnorm(6)
+#' )
 #'
-#'   # All possible combinations ---------------------------------------
-#'   fruits %>% expand(type)
-#'   fruits %>% expand(type, size)
+#' # All possible combinations ---------------------------------------
+#' fruits %>% tidyr::expand(type)
+#' fruits %>% tidyr::expand(type, size)
 #'
-#'   # Only combinations that already appear in the data ---------------
-#'   fruits %>% expand(nesting(type, size))
-#' }
+#' # Only combinations that already appear in the data ---------------
+#' fruits %>% tidyr::expand(nesting(type, size))
 expand.tbl_lazy <- function(data, ..., .name_repair = "check_unique") {
   dots <- purrr::discard(quos(...), quo_is_null)
 
@@ -91,21 +89,19 @@ extract_expand_dot_vars <- function(dot) {
 #'
 #' @inherit arrange.tbl_lazy return
 #'
-#' @examples
-#' if (require("tidyr", quietly = TRUE)) {
-#'   df <- memdb_frame(
-#'     group = c(1:2, 1),
-#'     item_id = c(1:2, 2),
-#'     item_name = c("a", "b", "b"),
-#'     value1 = 1:3,
-#'     value2 = 4:6
-#'   )
+#' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
+#' df <- memdb_frame(
+#'   group = c(1:2, 1),
+#'   item_id = c(1:2, 2),
+#'   item_name = c("a", "b", "b"),
+#'   value1 = 1:3,
+#'   value2 = 4:6
+#' )
 #'
-#'   df %>% complete(group, nesting(item_id, item_name))
+#' df %>% tidyr::complete(group, nesting(item_id, item_name))
 #'
-#'   # You can also choose to fill in missing values
-#'   df %>% complete(group, nesting(item_id, item_name), fill = list(value1 = 0))
-#' }
+#' # You can also choose to fill in missing values
+#' df %>% tidyr::complete(group, nesting(item_id, item_name), fill = list(value1 = 0))
 complete.tbl_lazy <- function(data, ..., fill = list()) {
   full <- tidyr::expand(data, ...)
 
@@ -128,11 +124,9 @@ complete.tbl_lazy <- function(data, ..., fill = list()) {
 #'
 #' @inherit arrange.tbl_lazy return
 #'
-#' @examples
-#' if (require("tidyr", quietly = TRUE)) {
-#'   df <- memdb_frame(x = c(1, 2, NA), y = c("a", NA, "b"))
-#'   df %>% replace_na(list(x = 0, y = "unknown"))
-#' }
+#' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
+#' df <- memdb_frame(x = c(1, 2, NA), y = c("a", NA, "b"))
+#' df %>% tidyr::replace_na(list(x = 0, y = "unknown"))
 replace_na.tbl_lazy <- function(data, replace = list(), ...) {
   stopifnot(is_list(replace))
   stopifnot(is_empty(replace) || is_named(replace))

--- a/R/verb-fill.R
+++ b/R/verb-fill.R
@@ -8,7 +8,7 @@
 #'   yourself beforehand; for example replace `arrange(x, desc(y))` by
 #'   `arrange(desc(x), y)`.
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
 #' squirrels <- tibble::tribble(
 #'   ~group,    ~name,     ~role,     ~n_squirrels, ~ n_squirrels2,
 #'   1,      "Sam",    "Observer",   NA,                 1,
@@ -26,14 +26,12 @@
 #' )
 #' squirrels$id <- 1:12
 #'
-#' if (require("tidyr", quietly = TRUE)) {
-#'   tbl_memdb(squirrels) %>%
-#'     window_order(id) %>%
-#'     tidyr::fill(
-#'       n_squirrels,
-#'       n_squirrels2,
-#'     )
-#' }
+#' tbl_memdb(squirrels) %>%
+#'   window_order(id) %>%
+#'   tidyr::fill(
+#'     n_squirrels,
+#'     n_squirrels2,
+#'   )
 fill.tbl_lazy <- function(.data, ..., .direction = c("down", "up")) {
   sim_data <- simulate_vars(.data)
   cols_to_fill <- syms(names(tidyselect::eval_select(expr(c(...)), sim_data)))

--- a/R/verb-pivot-longer.R
+++ b/R/verb-pivot-longer.R
@@ -48,18 +48,16 @@
 #' @param names_ptypes A list of column name-prototype pairs.
 #' @param values_ptypes Not supported.
 #' @param ... Additional arguments passed on to methods.
-#' @examples
+#' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
 #' # See vignette("pivot") for examples and explanation
 #'
 #' # Simplest case where column names are character data
-#' if (require("tidyr", quietly = TRUE)) {
-#'   memdb_frame(
-#'     id = c("a", "b"),
-#'     x = 1:2,
-#'     y = 3:4
-#'   ) %>%
-#'     pivot_longer(-id)
-#' }
+#' memdb_frame(
+#'   id = c("a", "b"),
+#'   x = 1:2,
+#'   y = 3:4
+#' ) %>%
+#'   tidyr::pivot_longer(-id)
 pivot_longer.tbl_lazy <- function(data,
                                   cols,
                                   names_to = "name",

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -53,8 +53,7 @@
 #' `NULL`.
 #' @param ... Unused; included for compatibility with generic.
 #'
-#' @examples
-#' if (require("tidyr", quietly = TRUE)) {
+#' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
 #' memdb_frame(
 #'   id = 1,
 #'   key = c("x", "y"),
@@ -65,7 +64,6 @@
 #'     names_from = key,
 #'     values_from = value
 #'   )
-#' }
 pivot_wider.tbl_lazy <- function(data,
                                  id_cols = NULL,
                                  names_from = name,

--- a/R/verb-slice.R
+++ b/R/verb-slice.R
@@ -142,23 +142,23 @@ check_slice_size <- function(n, prop) {
     list(type = "n", n = 1L)
   } else if (!missing(n) && missing(prop)) {
     if (!is.numeric(n) || length(n) != 1) {
-      abort("`n` must be a single number.")
+      abort("`n` must be a single number.", call = caller_env())
     }
     if (is.na(n) || n < 0) {
-      abort("`n` must be a non-missing positive number.")
+      abort("`n` must be a non-missing positive number.", call = caller_env())
     }
 
     list(type = "n", n = as.integer(n))
   } else if (!missing(prop) && missing(n)) {
     if (!is.numeric(prop) || length(prop) != 1) {
-      abort("`prop` must be a single number")
+      abort("`prop` must be a single number", call = caller_env())
     }
     if (is.na(prop) || prop < 0) {
-      abort("`prop` must be a non-missing positive number.")
+      abort("`prop` must be a non-missing positive number.", call = caller_env())
     }
     list(type = "prop", prop = prop)
   } else {
-    abort("Must supply exactly one of `n` and `prop` arguments.")
+    abort("Must supply exactly one of `n` and `prop` arguments.", call = caller_env())
   }
 }
 

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -63,7 +63,7 @@ check_summarise_vars <- function(dots) {
         ),
         `i` = "You need an extra mutate() step to use it."
       )
-      abort(message)
+      abort(message, call = caller_env())
     }
   }
 }
@@ -77,13 +77,14 @@ check_groups <- function(.groups) {
     return()
   }
 
-  abort(c(
+  message <- c(
     paste0(
       "`.groups` can't be ", as_label(.groups),
       if (.groups == "rowwise") " in dbplyr"
     ),
     i = 'Possible values are NULL (default), "drop_last", "drop", and "keep"'
-  ))
+  )
+  abort(message, call = caller_env())
 }
 
 #' @export

--- a/man/complete.tbl_lazy.Rd
+++ b/man/complete.tbl_lazy.Rd
@@ -25,18 +25,18 @@ Turns implicit missing values into explicit missing values. This is a method
 for the \code{\link[tidyr:complete]{tidyr::complete()}} generic.
 }
 \examples{
-if (require("tidyr", quietly = TRUE)) {
-  df <- memdb_frame(
-    group = c(1:2, 1),
-    item_id = c(1:2, 2),
-    item_name = c("a", "b", "b"),
-    value1 = 1:3,
-    value2 = 4:6
-  )
+\dontshow{if (rlang::is_installed("tidyr", version = "1.0.0")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+df <- memdb_frame(
+  group = c(1:2, 1),
+  item_id = c(1:2, 2),
+  item_name = c("a", "b", "b"),
+  value1 = 1:3,
+  value2 = 4:6
+)
 
-  df \%>\% complete(group, nesting(item_id, item_name))
+df \%>\% tidyr::complete(group, nesting(item_id, item_name))
 
-  # You can also choose to fill in missing values
-  df \%>\% complete(group, nesting(item_id, item_name), fill = list(value1 = 0))
-}
+# You can also choose to fill in missing values
+df \%>\% tidyr::complete(group, nesting(item_id, item_name), fill = list(value1 = 0))
+\dontshow{\}) # examplesIf}
 }

--- a/man/dbplyr-package.Rd
+++ b/man/dbplyr-package.Rd
@@ -8,11 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-A 'dplyr' back end for databases that allows you to
-    work with remote database tables as if they are in-memory data frames.
-    Basic features works with any database that has a 'DBI' back end; more
-    advanced features require 'SQL' translation to be provided by the
-    package author.
+A 'dplyr' back end for databases that allows you to work with remote database tables as if they are in-memory data frames. Basic features works with any database that has a 'DBI' back end; more advanced features require 'SQL' translation to be provided by the package author.
 }
 \seealso{
 Useful links:

--- a/man/expand.tbl_lazy.Rd
+++ b/man/expand.tbl_lazy.Rd
@@ -39,19 +39,19 @@ result explicitly, so the order might be different to what \code{expand()}
 returns for data frames.
 }
 \examples{
-if (require("tidyr", quietly = TRUE)) {
-  fruits <- memdb_frame(
-    type   = c("apple", "orange", "apple", "orange", "orange", "orange"),
-    year   = c(2010, 2010, 2012, 2010, 2010, 2012),
-    size = c("XS", "S",  "M", "S", "S", "M"),
-    weights = rnorm(6)
-  )
+\dontshow{if (rlang::is_installed("tidyr", version = "1.0.0")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+fruits <- memdb_frame(
+  type   = c("apple", "orange", "apple", "orange", "orange", "orange"),
+  year   = c(2010, 2010, 2012, 2010, 2010, 2012),
+  size = c("XS", "S",  "M", "S", "S", "M"),
+  weights = rnorm(6)
+)
 
-  # All possible combinations ---------------------------------------
-  fruits \%>\% expand(type)
-  fruits \%>\% expand(type, size)
+# All possible combinations ---------------------------------------
+fruits \%>\% tidyr::expand(type)
+fruits \%>\% tidyr::expand(type, size)
 
-  # Only combinations that already appear in the data ---------------
-  fruits \%>\% expand(nesting(type, size))
-}
+# Only combinations that already appear in the data ---------------
+fruits \%>\% tidyr::expand(nesting(type, size))
+\dontshow{\}) # examplesIf}
 }

--- a/man/fill.tbl_lazy.Rd
+++ b/man/fill.tbl_lazy.Rd
@@ -21,6 +21,7 @@ yourself beforehand; for example replace \code{arrange(x, desc(y))} by
 Fill in missing values with previous or next value
 }
 \examples{
+\dontshow{if (rlang::is_installed("tidyr", version = "1.0.0")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 squirrels <- tibble::tribble(
   ~group,    ~name,     ~role,     ~n_squirrels, ~ n_squirrels2,
   1,      "Sam",    "Observer",   NA,                 1,
@@ -38,12 +39,11 @@ squirrels <- tibble::tribble(
 )
 squirrels$id <- 1:12
 
-if (require("tidyr", quietly = TRUE)) {
-  tbl_memdb(squirrels) \%>\%
-    window_order(id) \%>\%
-    tidyr::fill(
-      n_squirrels,
-      n_squirrels2,
-    )
-}
+tbl_memdb(squirrels) \%>\%
+  window_order(id) \%>\%
+  tidyr::fill(
+    n_squirrels,
+    n_squirrels2,
+  )
+\dontshow{\}) # examplesIf}
 }

--- a/man/memdb_frame.Rd
+++ b/man/memdb_frame.Rd
@@ -15,14 +15,15 @@ src_memdb()
 \arguments{
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}>
 A set of name-value pairs. These arguments are
-processed with \code{\link[rlang:nse-defuse]{rlang::quos()}} and support unquote via \code{\link{!!}} and
+processed with \code{\link[rlang:topic-defuse]{rlang::quos()}} and support unquote via \code{\link{!!}} and
 unquote-splice via \code{\link{!!!}}. Use \verb{:=} to create columns that start with a dot.
 
 Arguments are evaluated sequentially.
 You can refer to previously created elements directly or using the \link{.data}
 pronoun.
-An existing \code{.data} pronoun, provided e.g. inside \code{\link[dplyr:mutate]{dplyr::mutate()}},
-is not available.}
+To refer explicitly to objects in the calling environment, use \code{\link{!!}} or
+\link{.env}, e.g. \code{!!.data} or \code{.env$.data} for the special case of an object
+named \code{.data}.}
 
 \item{df}{Data frame to copy}
 

--- a/man/pivot_longer.tbl_lazy.Rd
+++ b/man/pivot_longer.tbl_lazy.Rd
@@ -90,15 +90,15 @@ following columns
 }
 }
 \examples{
+\dontshow{if (rlang::is_installed("tidyr", version = "1.0.0")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # See vignette("pivot") for examples and explanation
 
 # Simplest case where column names are character data
-if (require("tidyr", quietly = TRUE)) {
-  memdb_frame(
-    id = c("a", "b"),
-    x = 1:2,
-    y = 3:4
-  ) \%>\%
-    pivot_longer(-id)
-}
+memdb_frame(
+  id = c("a", "b"),
+  x = 1:2,
+  y = 3:4
+) \%>\%
+  tidyr::pivot_longer(-id)
+\dontshow{\}) # examplesIf}
 }

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -84,7 +84,7 @@ The translation to SQL code basically works as follows:
 }
 }
 \examples{
-if (require("tidyr", quietly = TRUE)) {
+\dontshow{if (rlang::is_installed("tidyr", version = "1.0.0")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 memdb_frame(
   id = 1,
   key = c("x", "y"),
@@ -95,5 +95,5 @@ memdb_frame(
     names_from = key,
     values_from = value
   )
-}
+\dontshow{\}) # examplesIf}
 }

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -73,7 +73,7 @@ identified.
 The translation to SQL code basically works as follows:
 \enumerate{
 \item Get unique keys in \code{names_from} column.
-\item For each key value generate an expression of the form:\if{html}{\out{<div class="sql">}}\preformatted{value_fn(
+\item For each key value generate an expression of the form:\if{html}{\out{<div class="sourceCode sql">}}\preformatted{value_fn(
   CASE WHEN (`names from column` == `key value`)
   THEN (`value column`)
   END

--- a/man/pull.tbl_sql.Rd
+++ b/man/pull.tbl_sql.Rd
@@ -20,7 +20,7 @@ The default returns the last column (on the assumption that's the
 column you've created most recently).
 
 This argument is taken by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names and column locations).}
 }
 \value{

--- a/man/replace_na.tbl_lazy.Rd
+++ b/man/replace_na.tbl_lazy.Rd
@@ -23,8 +23,8 @@ and return data to R.
 This is a method for the \code{\link[tidyr:replace_na]{tidyr::replace_na()}} generic.
 }
 \examples{
-if (require("tidyr", quietly = TRUE)) {
-  df <- memdb_frame(x = c(1, 2, NA), y = c("a", NA, "b"))
-  df \%>\% replace_na(list(x = 0, y = "unknown"))
-}
+\dontshow{if (rlang::is_installed("tidyr", version = "1.0.0")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+df <- memdb_frame(x = c(1, 2, NA), y = c("a", NA, "b"))
+df \%>\% tidyr::replace_na(list(x = 0, y = "unknown"))
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -96,7 +96,8 @@
     Code
       sql_query_select(simulate_mssql(), ident("x"), ident("y"), order_by = "z",
       subquery = TRUE)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output

--- a/tests/testthat/_snaps/escape.md
+++ b/tests/testthat/_snaps/escape.md
@@ -1,10 +1,18 @@
 # shiny objects give useful errors
 
-    Cannot translate shiny inputs to SQL.
-    * Force evaluation in R with (e.g.) `!!input$x` or `local(input$x)`
+    Code
+      lf %>% filter(a == input$x) %>% show_query()
+    Condition
+      Error:
+      ! Cannot translate shiny inputs to SQL.
+      * Force evaluation in R with (e.g.) `!!input$x` or `local(input$x)`
 
 ---
 
-    Cannot translate a shiny reactive to SQL.
-    * Force evaluation in R with (e.g.) `!!foo()` or `local(foo())`
+    Code
+      lf %>% filter(a == x()) %>% show_query()
+    Condition
+      Error:
+      ! Cannot translate a shiny reactive to SQL.
+      * Force evaluation in R with (e.g.) `!!foo()` or `local(foo())`
 

--- a/tests/testthat/_snaps/partial-eval.md
+++ b/tests/testthat/_snaps/partial-eval.md
@@ -68,7 +68,7 @@
 # across() translates formulas
 
     Code
-      lf %>% summarise(across(a:b, ~log(.x, 2)))
+      lf %>% summarise(across(a:b, ~ log(.x, 2)))
     Output
       <SQL>
       SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
@@ -77,7 +77,7 @@
 ---
 
     Code
-      lf %>% summarise(across(a:b, list(~log(.x, 2))))
+      lf %>% summarise(across(a:b, list(~ log(.x, 2))))
     Output
       <SQL>
       SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
@@ -96,7 +96,8 @@
 
     Code
       lf %>% dplyr::summarise_at(dplyr::vars(a:b), "sum")
-    Warning <simpleWarning>
+    Condition
+      Warning:
       Missing values are always removed in SQL.
       Use `SUM(x, na.rm = TRUE)` to silence this warning
       This warning is displayed only once per session.
@@ -117,7 +118,7 @@
 ---
 
     Code
-      lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~sum(.))
+      lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~ sum(.))
     Output
       <SQL>
       SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
@@ -126,7 +127,7 @@
 # if_all/any works in filter()
 
     Code
-      lf %>% filter(if_all(a:b, ~. > 0))
+      lf %>% filter(if_all(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT *
@@ -136,7 +137,7 @@
 ---
 
     Code
-      lf %>% filter(if_any(a:b, ~. > 0))
+      lf %>% filter(if_any(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT *
@@ -146,7 +147,7 @@
 # if_all/any works in mutate()
 
     Code
-      lf %>% mutate(c = if_all(a:b, ~. > 0))
+      lf %>% mutate(c = if_all(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT `a`, `b`, `a` > 0.0 AND `b` > 0.0 AS `c`
@@ -155,7 +156,7 @@
 ---
 
     Code
-      lf %>% mutate(c = if_any(a:b, ~. > 0))
+      lf %>% mutate(c = if_any(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT `a`, `b`, `a` > 0.0 OR `b` > 0.0 AS `c`
@@ -164,7 +165,7 @@
 # if_all/any uses every colum as default
 
     Code
-      lf %>% filter(if_all(.fns = ~. > 0))
+      lf %>% filter(if_all(.fns = ~ . > 0))
     Output
       <SQL>
       SELECT *
@@ -174,7 +175,7 @@
 ---
 
     Code
-      lf %>% filter(if_any(.fns = ~. > 0))
+      lf %>% filter(if_any(.fns = ~ . > 0))
     Output
       <SQL>
       SELECT *

--- a/tests/testthat/_snaps/query-join.md
+++ b/tests/testthat/_snaps/query-join.md
@@ -2,7 +2,7 @@
 
     Code
       sql_build(left_join(lf1, lf2))
-    Message <message>
+    Message
       Joining, by = "x"
     Output
       <SQL JOIN (LEFT)>
@@ -17,7 +17,7 @@
 
     Code
       inner_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -30,7 +30,7 @@
 
     Code
       left_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -43,7 +43,7 @@
 
     Code
       right_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -56,7 +56,7 @@
 
     Code
       full_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -71,7 +71,7 @@
 
     Code
       left_join(lf1, lf2)
-    Message <message>
+    Message
       Joining, by = "x"
     Output
       <SQL>

--- a/tests/testthat/_snaps/query-semi-join.md
+++ b/tests/testthat/_snaps/query-semi-join.md
@@ -2,7 +2,7 @@
 
     Code
       sql_build(semi_join(lf1, lf2))
-    Message <message>
+    Message
       Joining, by = "x"
     Output
       <SQL SEMI JOIN>
@@ -17,7 +17,7 @@
 
     Code
       semi_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -31,7 +31,7 @@
 
     Code
       anti_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>

--- a/tests/testthat/_snaps/translate-sql-string.md
+++ b/tests/testthat/_snaps/translate-sql-string.md
@@ -2,27 +2,31 @@
 
     Code
       substr("test")
-    Error <simpleError>
-      argument "start" is missing, with no default
+    Condition
+      Error in `check_integer()`:
+      ! argument "start" is missing, with no default
 
 ---
 
     Code
       substr("test", 0)
-    Error <simpleError>
-      argument "stop" is missing, with no default
+    Condition
+      Error in `check_integer()`:
+      ! argument "stop" is missing, with no default
 
 ---
 
     Code
       substr("test", "x", 1)
-    Error <rlang_error>
-      `start` must be a single number
+    Condition
+      Error in `check_integer()`:
+      ! `start` must be a single number
 
 ---
 
     Code
       substr("test", 1, "x")
-    Error <rlang_error>
-      `stop` must be a single number
+    Condition
+      Error in `check_integer()`:
+      ! `stop` must be a single number
 

--- a/tests/testthat/_snaps/translate-sql.md
+++ b/tests/testthat/_snaps/translate-sql.md
@@ -1,12 +1,24 @@
 # namespace calls are translated
 
-    There is no package called 'NOSUCHPACKAGE'
+    Code
+      translate_sql(NOSUCHPACKAGE::foo())
+    Condition
+      Error:
+      ! There is no package called 'NOSUCHPACKAGE'
 
 ---
 
-    'NOSUCHFUNCTION' is not an exported object from 'dbplyr'
+    Code
+      translate_sql(dbplyr::NOSUCHFUNCTION())
+    Condition
+      Error:
+      ! 'NOSUCHFUNCTION' is not an exported object from 'dbplyr'
 
 ---
 
-    No known translation for base::abbreviate()
+    Code
+      translate_sql(base::abbreviate(x))
+    Condition
+      Error:
+      ! No known translation for base::abbreviate()
 

--- a/tests/testthat/_snaps/verb-arrange.md
+++ b/tests/testthat/_snaps/verb-arrange.md
@@ -22,7 +22,8 @@
     Code
       # double arrange
       lf %>% arrange(a) %>% arrange(b)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -40,7 +41,8 @@
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% select(-a) %>% arrange(b)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -125,7 +127,8 @@
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% mutate(a = 1) %>% arrange(b)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -135,7 +138,8 @@
       ORDER BY `b`
     Code
       lf %>% mutate(a = -a) %>% arrange(a) %>% mutate(a = -a)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -153,9 +157,10 @@
       rf <- lazy_frame(a = 1:3, c = 4:6)
       # warn if arrange before join
       lf %>% arrange(a) %>% left_join(rf)
-    Message <message>
+    Message
       Joining, by = "a"
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -169,9 +174,10 @@
         ON (`LHS`.`a` = `RHS`.`a`)
     Code
       lf %>% arrange(a) %>% semi_join(rf)
-    Message <message>
+    Message
       Joining, by = "a"
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -201,7 +207,7 @@
     Code
       # can arrange after join
       lf %>% left_join(rf) %>% arrange(a)
-    Message <message>
+    Message
       Joining, by = "a"
     Output
       <SQL>
@@ -215,7 +221,7 @@
       ORDER BY `a`
     Code
       lf %>% semi_join(rf) %>% arrange(a)
-    Message <message>
+    Message
       Joining, by = "a"
     Output
       <SQL>

--- a/tests/testthat/_snaps/verb-count.md
+++ b/tests/testthat/_snaps/verb-count.md
@@ -34,7 +34,8 @@
     Code
       db <- lazy_frame(g = 1, x = 2)
       db %>% count(g, name = "g")
-    Error <rlang_error>
-      'g' already present in output
+    Condition
+      Error in `check_name()`:
+      ! 'g' already present in output
       i Use `name = "new_name"` to pick a new name.
 

--- a/tests/testthat/_snaps/verb-count.md
+++ b/tests/testthat/_snaps/verb-count.md
@@ -35,7 +35,7 @@
       db <- lazy_frame(g = 1, x = 2)
       db %>% count(g, name = "g")
     Condition
-      Error in `check_name()`:
+      Error in `tally()`:
       ! 'g' already present in output
       i Use `name = "new_name"` to pick a new name.
 

--- a/tests/testthat/_snaps/verb-distinct.md
+++ b/tests/testthat/_snaps/verb-distinct.md
@@ -1,4 +1,8 @@
 # distinct throws error if column is specified and .keep_all is TRUE
 
-    Can only find distinct value of specified columns if .keep_all is FALSE
+    Code
+      mf %>% distinct(x, .keep_all = TRUE) %>% collect()
+    Condition
+      Error in `distinct()`:
+      ! Can only find distinct value of specified columns if `.keep_all` is FALSE
 

--- a/tests/testthat/_snaps/verb-expand.md
+++ b/tests/testthat/_snaps/verb-expand.md
@@ -78,17 +78,29 @@
 
 # expand() errors when expected
 
-    Must supply variables in `...`
+    Code
+      tidyr::expand(memdb_frame(x = 1))
+    Condition
+      Error in `tidyr::expand()`:
+      ! Must supply variables in `...`
 
 ---
 
-    Must supply variables in `...`
+    Code
+      tidyr::expand(memdb_frame(x = 1), x = NULL)
+    Condition
+      Error in `tidyr::expand()`:
+      ! Must supply variables in `...`
 
 # nesting() respects .name_repair
 
-    Names must be unique.
-    x These names are duplicated:
-      * "x" at locations 1 and 2.
+    Code
+      tidyr::expand(memdb_frame(x = 1, y = 1), nesting(x, x = x + 1))
+    Condition
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
 
 # replace_na replaces missing values
 

--- a/tests/testthat/_snaps/verb-pivot-longer.md
+++ b/tests/testthat/_snaps/verb-pivot-longer.md
@@ -140,7 +140,7 @@
 
     Code
       out <- df %>% tidyr::pivot_longer(c(x, y), names_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * name -> name...2
       * value -> value...3

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -26,9 +26,13 @@
 
 # error when overwriting existing column
 
-    Names must be unique.
-    x These names are duplicated:
-      * "a" at locations 1 and 2.
+    Code
+      tidyr::pivot_wider(df, names_from = key, values_from = val)
+    Condition
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
 
 # values_fn can be a single function
 
@@ -42,8 +46,12 @@
 
 # values_fn cannot be NULL
 
-    `values_fn` must not be NULL
-    i `values_fn` must be a function or a named list of functions
+    Code
+      dbplyr_pivot_wider_spec(df, spec1, values_fn = NULL)
+    Condition
+      Error in `dbplyr_pivot_wider_spec()`:
+      ! `values_fn` must not be NULL
+      i `values_fn` must be a function or a named list of functions
 
 # can fill in missing cells
 
@@ -77,6 +85,10 @@
 
 # cannot pivot lazy frames
 
-    `dbplyr_build_wider_spec()` doesn't work with local lazy tibbles.
-    i Use `memdb_frame()` together with `show_query()` to see the SQL code.
+    Code
+      tidyr::pivot_wider(lazy_frame(name = "x", value = 1))
+    Condition
+      Error in `dbplyr_build_wider_spec()`:
+      ! `dbplyr_build_wider_spec()` doesn't work with local lazy tibbles.
+      i Use `memdb_frame()` together with `show_query()` to see the SQL code.
 

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -2,7 +2,7 @@
 
     Code
       out <- mf %>% select(a) %>% collect()
-    Message <message>
+    Message
       Adding missing grouping variables: `b`
 
 # multiple selects are collapsed

--- a/tests/testthat/_snaps/verb-slice.md
+++ b/tests/testthat/_snaps/verb-slice.md
@@ -1,58 +1,114 @@
 # slice, head and tail aren't available
 
-    slice() is not supported on database backends
+    Code
+      lf %>% slice()
+    Condition
+      Error in `slice()`:
+      ! slice() is not supported on database backends
 
 ---
 
-    slice_head() is not supported on database backends
-    i Please use slice_min() instead
+    Code
+      lf %>% slice_head()
+    Condition
+      Error in `slice_head()`:
+      ! slice_head() is not supported on database backends
+      i Please use slice_min() instead
 
 ---
 
-    slice_tail() is not supported on database backends
-    i Please use slice_max() instead
+    Code
+      lf %>% slice_tail()
+    Condition
+      Error in `slice_tail()`:
+      ! slice_tail() is not supported on database backends
+      i Please use slice_max() instead
 
 # slice_min handles arguments
 
-    Argument `order_by` is missing, with no default.
+    Code
+      db %>% slice_min()
+    Condition
+      Error in `slice_min()`:
+      ! Argument `order_by` is missing, with no default.
 
 ---
 
-    Can only use `prop` when `with_ties = TRUE`
+    Code
+      db %>% slice_min(id, prop = 0.5, with_ties = FALSE)
+    Condition
+      Error in `slice_by()`:
+      ! Can only use `prop` when `with_ties = TRUE`
 
 # slice_max orders in opposite order
 
-    Argument `order_by` is missing, with no default.
+    Code
+      db %>% slice_max()
+    Condition
+      Error in `slice_max()`:
+      ! Argument `order_by` is missing, with no default.
 
 # slice_sample errors when expected
 
-    Sampling with replacement is not supported on database backends
+    Code
+      db %>% slice_sample(replace = TRUE)
+    Condition
+      Error in `slice_sample()`:
+      ! Sampling with replacement is not supported on database backends
 
 ---
 
-    Weighted resampling is not supported on database backends
+    Code
+      db %>% slice_sample(weight_by = x)
+    Condition
+      Error in `slice_sample()`:
+      ! Weighted resampling is not supported on database backends
 
 ---
 
-    Sampling by `prop` is not supported on database backends
+    Code
+      db %>% slice_sample(prop = 0.5)
+    Condition
+      Error in `slice_sample()`:
+      ! Sampling by `prop` is not supported on database backends
 
 # check_slice_size checks for common issues
 
-    Must supply exactly one of `n` and `prop` arguments.
+    Code
+      lf %>% slice_sample(n = 1, prop = 1)
+    Condition
+      Error in `slice_sample()`:
+      ! Must supply exactly one of `n` and `prop` arguments.
 
 ---
 
-    `n` must be a single number.
+    Code
+      lf %>% slice_sample(n = "a")
+    Condition
+      Error in `slice_sample()`:
+      ! `n` must be a single number.
 
 ---
 
-    `prop` must be a single number
+    Code
+      lf %>% slice_sample(prop = "a")
+    Condition
+      Error in `slice_sample()`:
+      ! `prop` must be a single number
 
 ---
 
-    `n` must be a non-missing positive number.
+    Code
+      lf %>% slice_sample(n = -1)
+    Condition
+      Error in `slice_sample()`:
+      ! `n` must be a non-missing positive number.
 
 ---
 
-    `prop` must be a non-missing positive number.
+    Code
+      lf %>% slice_sample(prop = -1)
+    Condition
+      Error in `slice_sample()`:
+      ! `prop` must be a non-missing positive number.
 

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -9,7 +9,7 @@
     Code
       eval_bare(expr(lazy_frame(x = 1, y = 2) %>% dplyr::group_by(x, y) %>% dplyr::summarise() %>%
         remote_query()), env(global_env()))
-    Message <message>
+    Message
       `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
     Output
       <SQL> SELECT `x`, `y`

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -1,8 +1,12 @@
 # can't refer to freshly created variables
 
-    In `dbplyr` you cannot use a variable created in the same summarise.
-    x `z` refers to `y` which was created earlier in this summarise().
-    i You need an extra mutate() step to use it.
+    Code
+      summarise(mf1, y = sum(x), z = sum(y))
+    Condition
+      Error in `summarise()`:
+      ! In `dbplyr` you cannot use a variable created in the same summarise.
+      x `z` refers to `y` which was created earlier in this summarise().
+      i You need an extra mutate() step to use it.
 
 # summarise(.groups=)
 
@@ -18,8 +22,12 @@
 
 ---
 
-    `.groups` can't be "rowwise" in dbplyr
-    i Possible values are NULL (default), "drop_last", "drop", and "keep"
+    Code
+      df %>% summarise(.groups = "rowwise")
+    Condition
+      Error in `summarise()`:
+      ! `.groups` can't be "rowwise" in dbplyr
+      i Possible values are NULL (default), "drop_last", "drop", and "keep"
 
 # quoting for rendering summarized grouped table
 

--- a/tests/testthat/_snaps/verb-uncount.md
+++ b/tests/testthat/_snaps/verb-uncount.md
@@ -7,8 +7,8 @@
       SELECT `x`
       FROM (
         SELECT `x`, `w`, `..dbplyr_row_id`
-        FROM `dbplyr_2001` AS `LHS`
-        INNER JOIN `dbplyr_2003` AS `RHS`
+        FROM `test` AS `LHS`
+        INNER JOIN `dbplyr_table` AS `RHS`
           ON (`RHS`.`..dbplyr_row_id` <= `LHS`.`w`)
       )
 

--- a/tests/testthat/test-escape.R
+++ b/tests/testthat/test-escape.R
@@ -98,8 +98,8 @@ test_that("shiny objects give useful errors", {
   input <- structure(list(), class = "reactivevalues")
   x <- structure(function() "y", class = "reactive")
 
-  expect_snapshot_error(lf %>% filter(a == input$x) %>% show_query())
-  expect_snapshot_error(lf %>% filter(a == x()) %>% show_query())
+  expect_snapshot(error = TRUE, lf %>% filter(a == input$x) %>% show_query())
+  expect_snapshot(error = TRUE, lf %>% filter(a == x()) %>% show_query())
 })
 
 # names_to_as() -----------------------------------------------------------

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -1,5 +1,5 @@
 test_that("remote_name returns null for computed tables", {
-  mf <- memdb_frame(x = 5, .name = "refxiudlph")
+  mf <- copy_to_test("sqlite", tibble(x = 5), name = "refxiudlph")
   expect_equal(remote_name(mf), ident("refxiudlph"))
 
   mf2 <- mf %>% filter(x == 3)

--- a/tests/testthat/test-sql-build.R
+++ b/tests/testthat/test-sql-build.R
@@ -1,5 +1,5 @@
 test_that("rendering table wraps in SELECT *", {
-  out <- memdb_frame(x = 1, .name = "test-sql-build")
+  out <- copy_to_test("sqlite", tibble(x = 1), name = "test-sql-build")
   expect_snapshot(out %>% sql_render())
   expect_equal(out %>% collect(), tibble(x = 1))
 })

--- a/tests/testthat/test-tbl-sql.R
+++ b/tests/testthat/test-tbl-sql.R
@@ -61,7 +61,7 @@ test_that("check basic group size implementation", {
 # tbl_sum -------------------------------------------------------------------
 
 test_that("ungrouped output", {
-  mf <- memdb_frame(x = 1:5, y = 1:5, .name = "tbl_sum_test")
+  mf <- copy_to_test("sqlite", tibble(x = 1:5, y = 1:5), name = "tbl_sum_test")
 
   out1 <- tbl_sum(mf)
   expect_named(out1, c("Source", "Database"))

--- a/tests/testthat/test-translate-sql.R
+++ b/tests/testthat/test-translate-sql.R
@@ -10,9 +10,9 @@ test_that("namespace calls are translated", {
   expect_equal(translate_sql(dplyr::n(), window = FALSE), sql("COUNT(*)"))
   expect_equal(translate_sql(base::ceiling(x)), sql("CEIL(`x`)"))
 
-  expect_snapshot_error(translate_sql(NOSUCHPACKAGE::foo()))
-  expect_snapshot_error(translate_sql(dbplyr::NOSUCHFUNCTION()))
-  expect_snapshot_error(translate_sql(base::abbreviate(x)))
+  expect_snapshot(error = TRUE, translate_sql(NOSUCHPACKAGE::foo()))
+  expect_snapshot(error = TRUE, translate_sql(dbplyr::NOSUCHFUNCTION()))
+  expect_snapshot(error = TRUE, translate_sql(base::abbreviate(x)))
 })
 
 test_that("Wrong number of arguments raises error", {

--- a/tests/testthat/test-verb-arrange.R
+++ b/tests/testthat/test-verb-arrange.R
@@ -10,7 +10,7 @@ test_that("two arranges equivalent to one", {
 # sql_render --------------------------------------------------------------
 
 test_that("quoting for rendering ordered grouped table", {
-  db <- memdb_frame(x = 1, y = 2, .name = "test-verb-arrange")
+  db <- copy_to_test("sqlite", tibble(x = 1, y = 2), name = "test-verb-arrange")
   out <- db %>% group_by(x) %>% arrange(y) %>% ungroup()
   expect_snapshot(sql_render(out))
   expect_equal(collect(out), tibble(x = 1, y = 2))

--- a/tests/testthat/test-verb-distinct.R
+++ b/tests/testthat/test-verb-distinct.R
@@ -23,7 +23,7 @@ test_that("distinct for single column equivalent to local unique (#1937)", {
 
 test_that("distinct throws error if column is specified and .keep_all is TRUE", {
   mf <- memdb_frame(x = 1:10)
-  expect_snapshot_error(mf %>% distinct(x, .keep_all = TRUE) %>% collect())
+  expect_snapshot(error = TRUE, mf %>% distinct(x, .keep_all = TRUE) %>% collect())
 })
 
 test_that("distinct doesn't duplicate colum names if grouped (#354)", {

--- a/tests/testthat/test-verb-expand.R
+++ b/tests/testthat/test-verb-expand.R
@@ -55,12 +55,12 @@ test_that("NULL inputs", {
 })
 
 test_that("expand() errors when expected", {
-  expect_snapshot_error(tidyr::expand(memdb_frame(x = 1)))
-  expect_snapshot_error(tidyr::expand(memdb_frame(x = 1), x = NULL))
+  expect_snapshot(error = TRUE, tidyr::expand(memdb_frame(x = 1)))
+  expect_snapshot(error = TRUE, tidyr::expand(memdb_frame(x = 1), x = NULL))
 })
 
 test_that("nesting() respects .name_repair", {
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     tidyr::expand(
       memdb_frame(x = 1, y = 1),
       nesting(x, x = x + 1)

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -22,7 +22,7 @@ test_that("can refer to fresly created values", {
     collect()
   expect_equal(out1, tibble(x1 = 1, x2 = 2, x3 = 3, x4 = 4))
 
-  out2 <- memdb_frame(x = 1, .name = "multi_mutate") %>%
+  out2 <- copy_to_test("sqlite", tibble(x = 1), name = "multi_mutate") %>%
     mutate(x = x + 1, x = x + 2, x = x + 4)
   expect_equal(collect(out2), tibble(x = 8))
   expect_snapshot(show_query(out2))

--- a/tests/testthat/test-verb-pivot-wider.R
+++ b/tests/testthat/test-verb-pivot-wider.R
@@ -57,7 +57,8 @@ test_that("error when overwriting existing column", {
     key = c("a", "b"),
     val = c(1, 2)
   )
-  expect_snapshot_error(
+  expect_snapshot(
+    error = TRUE,
     tidyr::pivot_wider(df, names_from = key, values_from = val)
   )
 })
@@ -140,7 +141,7 @@ test_that("values_fn can be a single function", {
 test_that("values_fn cannot be NULL", {
   df <- lazy_frame(a = 1, key = "x", val = 1)
 
-  expect_snapshot_error(dbplyr_pivot_wider_spec(df, spec1, values_fn = NULL))
+  expect_snapshot(error = TRUE, dbplyr_pivot_wider_spec(df, spec1, values_fn = NULL))
 })
 
 # can fill missing cells --------------------------------------------------
@@ -208,7 +209,7 @@ test_that("column order in output matches spec", {
 })
 
 test_that("cannot pivot lazy frames", {
-  expect_snapshot_error(tidyr::pivot_wider(lazy_frame(name = "x", value = 1)))
+  expect_snapshot(error = TRUE, tidyr::pivot_wider(lazy_frame(name = "x", value = 1)))
 })
 
 # multiple names ----------------------------------------------------------

--- a/tests/testthat/test-verb-slice.R
+++ b/tests/testthat/test-verb-slice.R
@@ -1,8 +1,8 @@
 test_that("slice, head and tail aren't available", {
   lf <- lazy_frame(x = 1)
-  expect_snapshot_error(lf %>% slice())
-  expect_snapshot_error(lf %>% slice_head())
-  expect_snapshot_error(lf %>% slice_tail())
+  expect_snapshot(error = TRUE, lf %>% slice())
+  expect_snapshot(error = TRUE, lf %>% slice_head())
+  expect_snapshot(error = TRUE, lf %>% slice_tail())
 })
 
 test_that("slice_min handles arguments", {
@@ -14,8 +14,8 @@ test_that("slice_min handles arguments", {
   expect_equal(db %>% slice_min(id, n = 2) %>% pull(), c(1, 2))
   expect_equal(db %>% slice_min(id, prop = 0.5) %>% pull(), 1)
 
-  expect_snapshot_error(db %>% slice_min())
-  expect_snapshot_error(db %>% slice_min(id, prop = 0.5, with_ties = FALSE))
+  expect_snapshot(error = TRUE, db %>% slice_min())
+  expect_snapshot(error = TRUE, db %>% slice_min(id, prop = 0.5, with_ties = FALSE))
 })
 
 test_that("slice_max orders in opposite order", {
@@ -23,7 +23,7 @@ test_that("slice_max orders in opposite order", {
 
   expect_equal(db %>% slice_max(id) %>% pull(), 3)
   expect_equal(db %>% slice_max(x) %>% pull(), 3)
-  expect_snapshot_error(db %>% slice_max())
+  expect_snapshot(error = TRUE, db %>% slice_max())
 })
 
 test_that("slice_sample errors when expected", {
@@ -33,9 +33,9 @@ test_that("slice_sample errors when expected", {
   # shows that it doesn't always return the same result
   expect_error(db %>% slice_sample() %>% pull(), NA)
 
-  expect_snapshot_error(db %>% slice_sample(replace = TRUE))
-  expect_snapshot_error(db %>% slice_sample(weight_by = x))
-  expect_snapshot_error(db %>% slice_sample(prop = 0.5))
+  expect_snapshot(error = TRUE, db %>% slice_sample(replace = TRUE))
+  expect_snapshot(error = TRUE, db %>% slice_sample(weight_by = x))
+  expect_snapshot(error = TRUE, db %>% slice_sample(prop = 0.5))
 })
 
 test_that("window_order is preserved", {
@@ -46,9 +46,11 @@ test_that("window_order is preserved", {
 })
 
 test_that("check_slice_size checks for common issues", {
-  expect_snapshot_error(check_slice_size(n = 1, prop = 1))
-  expect_snapshot_error(check_slice_size(n = "a"))
-  expect_snapshot_error(check_slice_size(prop = "a"))
-  expect_snapshot_error(check_slice_size(n = -1))
-  expect_snapshot_error(check_slice_size(prop = -1))
+  lf <- lazy_frame(x = c(1, 1, 2), id = c(1, 2, 3))
+
+  expect_snapshot(error = TRUE, lf %>% slice_sample(n = 1, prop = 1))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(n = "a"))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(prop = "a"))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(n = -1))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(prop = -1))
 })

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -52,7 +52,7 @@ test_that("summarise(.groups=)", {
 # sql-render --------------------------------------------------------------
 
 test_that("quoting for rendering summarized grouped table", {
-  out <- memdb_frame(x = 1, .name = "verb-summarise") %>%
+  out <- copy_to_test("sqlite", tibble(x = 1), name = "verb-summarise") %>%
     group_by(x) %>%
     summarise(n = n())
   expect_snapshot(out %>% sql_render)

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -18,7 +18,7 @@ test_that("summarise performs partial evaluation", {
 
 test_that("can't refer to freshly created variables", {
   mf1 <- lazy_frame(x = 1)
-  expect_snapshot_error(summarise(mf1, y = sum(x), z = sum(y)))
+  expect_snapshot(error = TRUE, summarise(mf1, y = sum(x), z = sum(y)))
 })
 
 test_that("summarise(.groups=)", {
@@ -46,7 +46,7 @@ test_that("summarise(.groups=)", {
   expect_equal(df %>% summarise(.groups = "drop") %>% group_vars(), character())
   expect_equal(df %>% summarise(.groups = "keep") %>% group_vars(), c("x", "y"))
 
-  expect_snapshot_error(df %>% summarise(.groups = "rowwise"))
+  expect_snapshot(error = TRUE, df %>% summarise(.groups = "rowwise"))
 })
 
 # sql-render --------------------------------------------------------------

--- a/tests/testthat/test-verb-uncount.R
+++ b/tests/testthat/test-verb-uncount.R
@@ -1,10 +1,19 @@
 test_that("symbols weights are dropped in output", {
-  # workaround so that sql snapshot is always the same
-  withr::local_options(list(dbplyr_table_name = 2000))
-  df <- memdb_frame(x = 1, w = 1)
+  df <- copy_to_test("sqlite", tibble(x = 1, w = 1))
   expect_equal(dbplyr_uncount(df, w) %>% collect(), tibble(x = 1))
 
-  expect_snapshot(dbplyr_uncount(df, w) %>% show_query())
+  expect_snapshot(
+    dbplyr_uncount(df, w) %>% show_query(),
+    transform = function(lines) {
+      lines_to_transform <- grepl("INNER JOIN", lines)
+      lines[lines_to_transform] <- gsub(
+        "`dbplyr_\\d+`", "`dbplyr_table`",
+        lines[lines_to_transform]
+      )
+
+      lines
+    }
+  )
 })
 
 test_that("can request to preserve symbols", {


### PR DESCRIPTION
* Update snapshots
* Update documentation
* Use @examplesIf for `tidyr` verbs
* Use `expect_snapshot(error = TRUE)` pattern instead of `expect_snapshot_error()` to show error call
* Improve some error messages from helper functions by passing a call to `abort()`