### PR TITLE
Update to rlang 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     methods,
     purrr (>= 0.2.5),
     R6 (>= 2.2.2),
-    rlang (>= 0.2.0),
+    rlang (>= 1.0.0),
     tibble (>= 1.4.2),
     tidyselect (>= 0.2.4),
     utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-gb
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Collate: 
     'utils.R'
     'sql.R'

--- a/R/escape.R
+++ b/R/escape.R
@@ -140,7 +140,7 @@ error_embed <- function(type, expr) {
   abort(c(
     glue("Cannot translate {type} to SQL."),
     glue("Force evaluation in R with (e.g.) `!!{expr}` or `local({expr})`")
-  ))
+  ), call = NULL)
 }
 
 #' @export

--- a/R/verb-count.R
+++ b/R/verb-count.R
@@ -55,8 +55,11 @@ check_name <- function(name, vars) {
     return(name)
   }
 
-  abort(c(
-    glue("'{name}' already present in output"),
-    i = "Use `name = \"new_name\"` to pick a new name."
-  ))
+  abort(
+    c(
+      glue("'{name}' already present in output"),
+      i = "Use `name = \"new_name\"` to pick a new name."
+    ),
+    call = caller_env()
+  )
 }

--- a/R/verb-slice.R
+++ b/R/verb-slice.R
@@ -142,23 +142,23 @@ check_slice_size <- function(n, prop) {
     list(type = "n", n = 1L)
   } else if (!missing(n) && missing(prop)) {
     if (!is.numeric(n) || length(n) != 1) {
-      abort("`n` must be a single number.")
+      abort("`n` must be a single number.", call = caller_env())
     }
     if (is.na(n) || n < 0) {
-      abort("`n` must be a non-missing positive number.")
+      abort("`n` must be a non-missing positive number.", call = caller_env())
     }
 
     list(type = "n", n = as.integer(n))
   } else if (!missing(prop) && missing(n)) {
     if (!is.numeric(prop) || length(prop) != 1) {
-      abort("`prop` must be a single number")
+      abort("`prop` must be a single number", call = caller_env())
     }
     if (is.na(prop) || prop < 0) {
-      abort("`prop` must be a non-missing positive number.")
+      abort("`prop` must be a non-missing positive number.", call = caller_env())
     }
     list(type = "prop", prop = prop)
   } else {
-    abort("Must supply exactly one of `n` and `prop` arguments.")
+    abort("Must supply exactly one of `n` and `prop` arguments.", call = caller_env())
   }
 }
 

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -63,7 +63,7 @@ check_summarise_vars <- function(dots) {
         ),
         `i` = "You need an extra mutate() step to use it."
       )
-      abort(message)
+      abort(message, call = caller_env())
     }
   }
 }
@@ -77,13 +77,14 @@ check_groups <- function(.groups) {
     return()
   }
 
-  abort(c(
+  message <- c(
     paste0(
       "`.groups` can't be ", as_label(.groups),
       if (.groups == "rowwise") " in dbplyr"
     ),
     i = 'Possible values are NULL (default), "drop_last", "drop", and "keep"'
-  ))
+  )
+  abort(message, call = caller_env())
 }
 
 #' @export

--- a/man/dbplyr-package.Rd
+++ b/man/dbplyr-package.Rd
@@ -8,11 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-A 'dplyr' back end for databases that allows you to
-    work with remote database tables as if they are in-memory data frames.
-    Basic features works with any database that has a 'DBI' back end; more
-    advanced features require 'SQL' translation to be provided by the
-    package author.
+A 'dplyr' back end for databases that allows you to work with remote database tables as if they are in-memory data frames. Basic features works with any database that has a 'DBI' back end; more advanced features require 'SQL' translation to be provided by the package author.
 }
 \seealso{
 Useful links:

--- a/man/memdb_frame.Rd
+++ b/man/memdb_frame.Rd
@@ -15,14 +15,15 @@ src_memdb()
 \arguments{
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}>
 A set of name-value pairs. These arguments are
-processed with \code{\link[rlang:nse-defuse]{rlang::quos()}} and support unquote via \code{\link{!!}} and
+processed with \code{\link[rlang:topic-defuse]{rlang::quos()}} and support unquote via \code{\link{!!}} and
 unquote-splice via \code{\link{!!!}}. Use \verb{:=} to create columns that start with a dot.
 
 Arguments are evaluated sequentially.
 You can refer to previously created elements directly or using the \link{.data}
 pronoun.
-An existing \code{.data} pronoun, provided e.g. inside \code{\link[dplyr:mutate]{dplyr::mutate()}},
-is not available.}
+To refer explicitly to objects in the calling environment, use \code{\link{!!}} or
+\link{.env}, e.g. \code{!!.data} or \code{.env$.data} for the special case of an object
+named \code{.data}.}
 
 \item{df}{Data frame to copy}
 

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -73,7 +73,7 @@ identified.
 The translation to SQL code basically works as follows:
 \enumerate{
 \item Get unique keys in \code{names_from} column.
-\item For each key value generate an expression of the form:\if{html}{\out{<div class="sql">}}\preformatted{value_fn(
+\item For each key value generate an expression of the form:\if{html}{\out{<div class="sourceCode sql">}}\preformatted{value_fn(
   CASE WHEN (`names from column` == `key value`)
   THEN (`value column`)
   END

--- a/man/pull.tbl_sql.Rd
+++ b/man/pull.tbl_sql.Rd
@@ -20,7 +20,7 @@ The default returns the last column (on the assumption that's the
 column you've created most recently).
 
 This argument is taken by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names and column locations).}
 }
 \value{

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -96,7 +96,8 @@
     Code
       sql_query_select(simulate_mssql(), ident("x"), ident("y"), order_by = "z",
       subquery = TRUE)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output

--- a/tests/testthat/_snaps/escape.md
+++ b/tests/testthat/_snaps/escape.md
@@ -1,10 +1,18 @@
 # shiny objects give useful errors
 
-    Cannot translate shiny inputs to SQL.
-    * Force evaluation in R with (e.g.) `!!input$x` or `local(input$x)`
+    Code
+      lf %>% filter(a == input$x) %>% show_query()
+    Condition
+      Error in `error_embed()`:
+      ! Cannot translate shiny inputs to SQL.
+      * Force evaluation in R with (e.g.) `!!input$x` or `local(input$x)`
 
 ---
 
-    Cannot translate a shiny reactive to SQL.
-    * Force evaluation in R with (e.g.) `!!foo()` or `local(foo())`
+    Code
+      lf %>% filter(a == x()) %>% show_query()
+    Condition
+      Error in `error_embed()`:
+      ! Cannot translate a shiny reactive to SQL.
+      * Force evaluation in R with (e.g.) `!!foo()` or `local(foo())`
 

--- a/tests/testthat/_snaps/escape.md
+++ b/tests/testthat/_snaps/escape.md
@@ -3,7 +3,7 @@
     Code
       lf %>% filter(a == input$x) %>% show_query()
     Condition
-      Error in `error_embed()`:
+      Error:
       ! Cannot translate shiny inputs to SQL.
       * Force evaluation in R with (e.g.) `!!input$x` or `local(input$x)`
 
@@ -12,7 +12,7 @@
     Code
       lf %>% filter(a == x()) %>% show_query()
     Condition
-      Error in `error_embed()`:
+      Error:
       ! Cannot translate a shiny reactive to SQL.
       * Force evaluation in R with (e.g.) `!!foo()` or `local(foo())`
 

--- a/tests/testthat/_snaps/partial-eval.md
+++ b/tests/testthat/_snaps/partial-eval.md
@@ -68,7 +68,7 @@
 # across() translates formulas
 
     Code
-      lf %>% summarise(across(a:b, ~log(.x, 2)))
+      lf %>% summarise(across(a:b, ~ log(.x, 2)))
     Output
       <SQL>
       SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
@@ -77,7 +77,7 @@
 ---
 
     Code
-      lf %>% summarise(across(a:b, list(~log(.x, 2))))
+      lf %>% summarise(across(a:b, list(~ log(.x, 2))))
     Output
       <SQL>
       SELECT LOG(2.0, `a`) AS `a`, LOG(2.0, `b`) AS `b`
@@ -96,7 +96,8 @@
 
     Code
       lf %>% dplyr::summarise_at(dplyr::vars(a:b), "sum")
-    Warning <simpleWarning>
+    Condition
+      Warning:
       Missing values are always removed in SQL.
       Use `SUM(x, na.rm = TRUE)` to silence this warning
       This warning is displayed only once per session.
@@ -117,7 +118,7 @@
 ---
 
     Code
-      lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~sum(.))
+      lf %>% dplyr::summarise_at(dplyr::vars(a:b), ~ sum(.))
     Output
       <SQL>
       SELECT SUM(`a`) AS `a`, SUM(`b`) AS `b`
@@ -126,7 +127,7 @@
 # if_all/any works in filter()
 
     Code
-      lf %>% filter(if_all(a:b, ~. > 0))
+      lf %>% filter(if_all(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT *
@@ -136,7 +137,7 @@
 ---
 
     Code
-      lf %>% filter(if_any(a:b, ~. > 0))
+      lf %>% filter(if_any(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT *
@@ -146,7 +147,7 @@
 # if_all/any works in mutate()
 
     Code
-      lf %>% mutate(c = if_all(a:b, ~. > 0))
+      lf %>% mutate(c = if_all(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT `a`, `b`, `a` > 0.0 AND `b` > 0.0 AS `c`
@@ -155,7 +156,7 @@
 ---
 
     Code
-      lf %>% mutate(c = if_any(a:b, ~. > 0))
+      lf %>% mutate(c = if_any(a:b, ~ . > 0))
     Output
       <SQL>
       SELECT `a`, `b`, `a` > 0.0 OR `b` > 0.0 AS `c`
@@ -164,7 +165,7 @@
 # if_all/any uses every colum as default
 
     Code
-      lf %>% filter(if_all(.fns = ~. > 0))
+      lf %>% filter(if_all(.fns = ~ . > 0))
     Output
       <SQL>
       SELECT *
@@ -174,7 +175,7 @@
 ---
 
     Code
-      lf %>% filter(if_any(.fns = ~. > 0))
+      lf %>% filter(if_any(.fns = ~ . > 0))
     Output
       <SQL>
       SELECT *

--- a/tests/testthat/_snaps/query-join.md
+++ b/tests/testthat/_snaps/query-join.md
@@ -2,7 +2,7 @@
 
     Code
       sql_build(left_join(lf1, lf2))
-    Message <message>
+    Message
       Joining, by = "x"
     Output
       <SQL JOIN (LEFT)>
@@ -17,7 +17,7 @@
 
     Code
       inner_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -30,7 +30,7 @@
 
     Code
       left_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -43,7 +43,7 @@
 
     Code
       right_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -56,7 +56,7 @@
 
     Code
       full_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -71,7 +71,7 @@
 
     Code
       left_join(lf1, lf2)
-    Message <message>
+    Message
       Joining, by = "x"
     Output
       <SQL>

--- a/tests/testthat/_snaps/query-semi-join.md
+++ b/tests/testthat/_snaps/query-semi-join.md
@@ -2,7 +2,7 @@
 
     Code
       sql_build(semi_join(lf1, lf2))
-    Message <message>
+    Message
       Joining, by = "x"
     Output
       <SQL SEMI JOIN>
@@ -17,7 +17,7 @@
 
     Code
       semi_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>
@@ -31,7 +31,7 @@
 
     Code
       anti_join(lf, lf)
-    Message <message>
+    Message
       Joining, by = c("x", "y")
     Output
       <SQL>

--- a/tests/testthat/_snaps/translate-sql-string.md
+++ b/tests/testthat/_snaps/translate-sql-string.md
@@ -2,27 +2,31 @@
 
     Code
       substr("test")
-    Error <simpleError>
-      argument "start" is missing, with no default
+    Condition
+      Error in `check_integer()`:
+      ! argument "start" is missing, with no default
 
 ---
 
     Code
       substr("test", 0)
-    Error <simpleError>
-      argument "stop" is missing, with no default
+    Condition
+      Error in `check_integer()`:
+      ! argument "stop" is missing, with no default
 
 ---
 
     Code
       substr("test", "x", 1)
-    Error <rlang_error>
-      `start` must be a single number
+    Condition
+      Error in `check_integer()`:
+      ! `start` must be a single number
 
 ---
 
     Code
       substr("test", 1, "x")
-    Error <rlang_error>
-      `stop` must be a single number
+    Condition
+      Error in `check_integer()`:
+      ! `stop` must be a single number
 

--- a/tests/testthat/_snaps/translate-sql.md
+++ b/tests/testthat/_snaps/translate-sql.md
@@ -1,12 +1,24 @@
 # namespace calls are translated
 
-    There is no package called 'NOSUCHPACKAGE'
+    Code
+      translate_sql(NOSUCHPACKAGE::foo())
+    Condition
+      Error:
+      ! There is no package called 'NOSUCHPACKAGE'
 
 ---
 
-    'NOSUCHFUNCTION' is not an exported object from 'dbplyr'
+    Code
+      translate_sql(dbplyr::NOSUCHFUNCTION())
+    Condition
+      Error:
+      ! 'NOSUCHFUNCTION' is not an exported object from 'dbplyr'
 
 ---
 
-    No known translation for base::abbreviate()
+    Code
+      translate_sql(base::abbreviate(x))
+    Condition
+      Error:
+      ! No known translation for base::abbreviate()
 

--- a/tests/testthat/_snaps/verb-arrange.md
+++ b/tests/testthat/_snaps/verb-arrange.md
@@ -22,7 +22,8 @@
     Code
       # double arrange
       lf %>% arrange(a) %>% arrange(b)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -40,7 +41,8 @@
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% select(-a) %>% arrange(b)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -125,7 +127,8 @@
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% mutate(a = 1) %>% arrange(b)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -135,7 +138,8 @@
       ORDER BY `b`
     Code
       lf %>% mutate(a = -a) %>% arrange(a) %>% mutate(a = -a)
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -153,9 +157,10 @@
       rf <- lazy_frame(a = 1:3, c = 4:6)
       # warn if arrange before join
       lf %>% arrange(a) %>% left_join(rf)
-    Message <message>
+    Message
       Joining, by = "a"
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -169,9 +174,10 @@
         ON (`LHS`.`a` = `RHS`.`a`)
     Code
       lf %>% arrange(a) %>% semi_join(rf)
-    Message <message>
+    Message
       Joining, by = "a"
-    Warning <warning>
+    Condition
+      Warning:
       ORDER BY is ignored in subqueries without LIMIT
       i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
@@ -201,7 +207,7 @@
     Code
       # can arrange after join
       lf %>% left_join(rf) %>% arrange(a)
-    Message <message>
+    Message
       Joining, by = "a"
     Output
       <SQL>
@@ -215,7 +221,7 @@
       ORDER BY `a`
     Code
       lf %>% semi_join(rf) %>% arrange(a)
-    Message <message>
+    Message
       Joining, by = "a"
     Output
       <SQL>

--- a/tests/testthat/_snaps/verb-count.md
+++ b/tests/testthat/_snaps/verb-count.md
@@ -34,7 +34,8 @@
     Code
       db <- lazy_frame(g = 1, x = 2)
       db %>% count(g, name = "g")
-    Error <rlang_error>
-      'g' already present in output
+    Condition
+      Error in `check_name()`:
+      ! 'g' already present in output
       i Use `name = "new_name"` to pick a new name.
 

--- a/tests/testthat/_snaps/verb-count.md
+++ b/tests/testthat/_snaps/verb-count.md
@@ -35,7 +35,7 @@
       db <- lazy_frame(g = 1, x = 2)
       db %>% count(g, name = "g")
     Condition
-      Error in `check_name()`:
+      Error in `tally()`:
       ! 'g' already present in output
       i Use `name = "new_name"` to pick a new name.
 

--- a/tests/testthat/_snaps/verb-distinct.md
+++ b/tests/testthat/_snaps/verb-distinct.md
@@ -1,4 +1,8 @@
 # distinct throws error if column is specified and .keep_all is TRUE
 
-    Can only find distinct value of specified columns if .keep_all is FALSE
+    Code
+      mf %>% distinct(x, .keep_all = TRUE) %>% collect()
+    Condition
+      Error:
+      ! Can only find distinct value of specified columns if .keep_all is FALSE
 

--- a/tests/testthat/_snaps/verb-expand.md
+++ b/tests/testthat/_snaps/verb-expand.md
@@ -78,17 +78,29 @@
 
 # expand() errors when expected
 
-    Must supply variables in `...`
+    Code
+      tidyr::expand(memdb_frame(x = 1))
+    Condition
+      Error in `tidyr::expand()`:
+      ! Must supply variables in `...`
 
 ---
 
-    Must supply variables in `...`
+    Code
+      tidyr::expand(memdb_frame(x = 1), x = NULL)
+    Condition
+      Error in `tidyr::expand()`:
+      ! Must supply variables in `...`
 
 # nesting() respects .name_repair
 
-    Names must be unique.
-    x These names are duplicated:
-      * "x" at locations 1 and 2.
+    Code
+      tidyr::expand(memdb_frame(x = 1, y = 1), nesting(x, x = x + 1))
+    Condition
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "x" at locations 1 and 2.
 
 # replace_na replaces missing values
 

--- a/tests/testthat/_snaps/verb-pivot-longer.md
+++ b/tests/testthat/_snaps/verb-pivot-longer.md
@@ -140,7 +140,7 @@
 
     Code
       out <- df %>% tidyr::pivot_longer(c(x, y), names_repair = "unique")
-    Message <simpleMessage>
+    Message
       New names:
       * name -> name...2
       * value -> value...3

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -26,9 +26,13 @@
 
 # error when overwriting existing column
 
-    Names must be unique.
-    x These names are duplicated:
-      * "a" at locations 1 and 2.
+    Code
+      tidyr::pivot_wider(df, names_from = key, values_from = val)
+    Condition
+      Error in `stop_vctrs()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
 
 # values_fn can be a single function
 
@@ -42,8 +46,12 @@
 
 # values_fn cannot be NULL
 
-    `values_fn` must not be NULL
-    i `values_fn` must be a function or a named list of functions
+    Code
+      dbplyr_pivot_wider_spec(df, spec1, values_fn = NULL)
+    Condition
+      Error in `dbplyr_pivot_wider_spec()`:
+      ! `values_fn` must not be NULL
+      i `values_fn` must be a function or a named list of functions
 
 # can fill in missing cells
 
@@ -77,6 +85,10 @@
 
 # cannot pivot lazy frames
 
-    `dbplyr_build_wider_spec()` doesn't work with local lazy tibbles.
-    i Use `memdb_frame()` together with `show_query()` to see the SQL code.
+    Code
+      tidyr::pivot_wider(lazy_frame(name = "x", value = 1))
+    Condition
+      Error in `dbplyr_build_wider_spec()`:
+      ! `dbplyr_build_wider_spec()` doesn't work with local lazy tibbles.
+      i Use `memdb_frame()` together with `show_query()` to see the SQL code.
 

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -2,7 +2,7 @@
 
     Code
       out <- mf %>% select(a) %>% collect()
-    Message <message>
+    Message
       Adding missing grouping variables: `b`
 
 # multiple selects are collapsed

--- a/tests/testthat/_snaps/verb-slice.md
+++ b/tests/testthat/_snaps/verb-slice.md
@@ -75,40 +75,40 @@
 # check_slice_size checks for common issues
 
     Code
-      check_slice_size(n = 1, prop = 1)
+      lf %>% slice_sample(n = 1, prop = 1)
     Condition
-      Error in `check_slice_size()`:
+      Error in `slice_sample()`:
       ! Must supply exactly one of `n` and `prop` arguments.
 
 ---
 
     Code
-      check_slice_size(n = "a")
+      lf %>% slice_sample(n = "a")
     Condition
-      Error in `check_slice_size()`:
+      Error in `slice_sample()`:
       ! `n` must be a single number.
 
 ---
 
     Code
-      check_slice_size(prop = "a")
+      lf %>% slice_sample(prop = "a")
     Condition
-      Error in `check_slice_size()`:
+      Error in `slice_sample()`:
       ! `prop` must be a single number
 
 ---
 
     Code
-      check_slice_size(n = -1)
+      lf %>% slice_sample(n = -1)
     Condition
-      Error in `check_slice_size()`:
+      Error in `slice_sample()`:
       ! `n` must be a non-missing positive number.
 
 ---
 
     Code
-      check_slice_size(prop = -1)
+      lf %>% slice_sample(prop = -1)
     Condition
-      Error in `check_slice_size()`:
+      Error in `slice_sample()`:
       ! `prop` must be a non-missing positive number.
 

--- a/tests/testthat/_snaps/verb-slice.md
+++ b/tests/testthat/_snaps/verb-slice.md
@@ -1,58 +1,114 @@
 # slice, head and tail aren't available
 
-    slice() is not supported on database backends
+    Code
+      lf %>% slice()
+    Condition
+      Error in `slice()`:
+      ! slice() is not supported on database backends
 
 ---
 
-    slice_head() is not supported on database backends
-    i Please use slice_min() instead
+    Code
+      lf %>% slice_head()
+    Condition
+      Error in `slice_head()`:
+      ! slice_head() is not supported on database backends
+      i Please use slice_min() instead
 
 ---
 
-    slice_tail() is not supported on database backends
-    i Please use slice_max() instead
+    Code
+      lf %>% slice_tail()
+    Condition
+      Error in `slice_tail()`:
+      ! slice_tail() is not supported on database backends
+      i Please use slice_max() instead
 
 # slice_min handles arguments
 
-    Argument `order_by` is missing, with no default.
+    Code
+      db %>% slice_min()
+    Condition
+      Error in `slice_min()`:
+      ! Argument `order_by` is missing, with no default.
 
 ---
 
-    Can only use `prop` when `with_ties = TRUE`
+    Code
+      db %>% slice_min(id, prop = 0.5, with_ties = FALSE)
+    Condition
+      Error in `slice_by()`:
+      ! Can only use `prop` when `with_ties = TRUE`
 
 # slice_max orders in opposite order
 
-    Argument `order_by` is missing, with no default.
+    Code
+      db %>% slice_max()
+    Condition
+      Error in `slice_max()`:
+      ! Argument `order_by` is missing, with no default.
 
 # slice_sample errors when expected
 
-    Sampling with replacement is not supported on database backends
+    Code
+      db %>% slice_sample(replace = TRUE)
+    Condition
+      Error in `slice_sample()`:
+      ! Sampling with replacement is not supported on database backends
 
 ---
 
-    Weighted resampling is not supported on database backends
+    Code
+      db %>% slice_sample(weight_by = x)
+    Condition
+      Error in `slice_sample()`:
+      ! Weighted resampling is not supported on database backends
 
 ---
 
-    Sampling by `prop` is not supported on database backends
+    Code
+      db %>% slice_sample(prop = 0.5)
+    Condition
+      Error in `slice_sample()`:
+      ! Sampling by `prop` is not supported on database backends
 
 # check_slice_size checks for common issues
 
-    Must supply exactly one of `n` and `prop` arguments.
+    Code
+      check_slice_size(n = 1, prop = 1)
+    Condition
+      Error in `check_slice_size()`:
+      ! Must supply exactly one of `n` and `prop` arguments.
 
 ---
 
-    `n` must be a single number.
+    Code
+      check_slice_size(n = "a")
+    Condition
+      Error in `check_slice_size()`:
+      ! `n` must be a single number.
 
 ---
 
-    `prop` must be a single number
+    Code
+      check_slice_size(prop = "a")
+    Condition
+      Error in `check_slice_size()`:
+      ! `prop` must be a single number
 
 ---
 
-    `n` must be a non-missing positive number.
+    Code
+      check_slice_size(n = -1)
+    Condition
+      Error in `check_slice_size()`:
+      ! `n` must be a non-missing positive number.
 
 ---
 
-    `prop` must be a non-missing positive number.
+    Code
+      check_slice_size(prop = -1)
+    Condition
+      Error in `check_slice_size()`:
+      ! `prop` must be a non-missing positive number.
 

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -9,7 +9,7 @@
     Code
       eval_bare(expr(lazy_frame(x = 1, y = 2) %>% dplyr::group_by(x, y) %>% dplyr::summarise() %>%
         remote_query()), env(global_env()))
-    Message <message>
+    Message
       `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
     Output
       <SQL> SELECT `x`, `y`

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -3,7 +3,7 @@
     Code
       summarise(mf1, y = sum(x), z = sum(y))
     Condition
-      Error in `check_summarise_vars()`:
+      Error in `summarise()`:
       ! In `dbplyr` you cannot use a variable created in the same summarise.
       x `z` refers to `y` which was created earlier in this summarise().
       i You need an extra mutate() step to use it.
@@ -25,7 +25,7 @@
     Code
       df %>% summarise(.groups = "rowwise")
     Condition
-      Error in `check_groups()`:
+      Error in `summarise()`:
       ! `.groups` can't be "rowwise" in dbplyr
       i Possible values are NULL (default), "drop_last", "drop", and "keep"
 

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -1,8 +1,12 @@
 # can't refer to freshly created variables
 
-    In `dbplyr` you cannot use a variable created in the same summarise.
-    x `z` refers to `y` which was created earlier in this summarise().
-    i You need an extra mutate() step to use it.
+    Code
+      summarise(mf1, y = sum(x), z = sum(y))
+    Condition
+      Error in `check_summarise_vars()`:
+      ! In `dbplyr` you cannot use a variable created in the same summarise.
+      x `z` refers to `y` which was created earlier in this summarise().
+      i You need an extra mutate() step to use it.
 
 # summarise(.groups=)
 
@@ -18,8 +22,12 @@
 
 ---
 
-    `.groups` can't be "rowwise" in dbplyr
-    i Possible values are NULL (default), "drop_last", "drop", and "keep"
+    Code
+      df %>% summarise(.groups = "rowwise")
+    Condition
+      Error in `check_groups()`:
+      ! `.groups` can't be "rowwise" in dbplyr
+      i Possible values are NULL (default), "drop_last", "drop", and "keep"
 
 # quoting for rendering summarized grouped table
 

--- a/tests/testthat/test-escape.R
+++ b/tests/testthat/test-escape.R
@@ -98,8 +98,8 @@ test_that("shiny objects give useful errors", {
   input <- structure(list(), class = "reactivevalues")
   x <- structure(function() "y", class = "reactive")
 
-  expect_snapshot_error(lf %>% filter(a == input$x) %>% show_query())
-  expect_snapshot_error(lf %>% filter(a == x()) %>% show_query())
+  expect_snapshot(error = TRUE, lf %>% filter(a == input$x) %>% show_query())
+  expect_snapshot(error = TRUE, lf %>% filter(a == x()) %>% show_query())
 })
 
 # names_to_as() -----------------------------------------------------------

--- a/tests/testthat/test-translate-sql.R
+++ b/tests/testthat/test-translate-sql.R
@@ -10,9 +10,9 @@ test_that("namespace calls are translated", {
   expect_equal(translate_sql(dplyr::n(), window = FALSE), sql("COUNT(*)"))
   expect_equal(translate_sql(base::ceiling(x)), sql("CEIL(`x`)"))
 
-  expect_snapshot_error(translate_sql(NOSUCHPACKAGE::foo()))
-  expect_snapshot_error(translate_sql(dbplyr::NOSUCHFUNCTION()))
-  expect_snapshot_error(translate_sql(base::abbreviate(x)))
+  expect_snapshot(error = TRUE, translate_sql(NOSUCHPACKAGE::foo()))
+  expect_snapshot(error = TRUE, translate_sql(dbplyr::NOSUCHFUNCTION()))
+  expect_snapshot(error = TRUE, translate_sql(base::abbreviate(x)))
 })
 
 test_that("Wrong number of arguments raises error", {

--- a/tests/testthat/test-verb-distinct.R
+++ b/tests/testthat/test-verb-distinct.R
@@ -23,7 +23,7 @@ test_that("distinct for single column equivalent to local unique (#1937)", {
 
 test_that("distinct throws error if column is specified and .keep_all is TRUE", {
   mf <- memdb_frame(x = 1:10)
-  expect_snapshot_error(mf %>% distinct(x, .keep_all = TRUE) %>% collect())
+  expect_snapshot(error = TRUE, mf %>% distinct(x, .keep_all = TRUE) %>% collect())
 })
 
 test_that("distinct doesn't duplicate colum names if grouped (#354)", {

--- a/tests/testthat/test-verb-expand.R
+++ b/tests/testthat/test-verb-expand.R
@@ -55,12 +55,12 @@ test_that("NULL inputs", {
 })
 
 test_that("expand() errors when expected", {
-  expect_snapshot_error(tidyr::expand(memdb_frame(x = 1)))
-  expect_snapshot_error(tidyr::expand(memdb_frame(x = 1), x = NULL))
+  expect_snapshot(error = TRUE, tidyr::expand(memdb_frame(x = 1)))
+  expect_snapshot(error = TRUE, tidyr::expand(memdb_frame(x = 1), x = NULL))
 })
 
 test_that("nesting() respects .name_repair", {
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     tidyr::expand(
       memdb_frame(x = 1, y = 1),
       nesting(x, x = x + 1)

--- a/tests/testthat/test-verb-pivot-wider.R
+++ b/tests/testthat/test-verb-pivot-wider.R
@@ -57,7 +57,7 @@ test_that("error when overwriting existing column", {
     key = c("a", "b"),
     val = c(1, 2)
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     tidyr::pivot_wider(df, names_from = key, values_from = val)
   )
 })
@@ -140,7 +140,7 @@ test_that("values_fn can be a single function", {
 test_that("values_fn cannot be NULL", {
   df <- lazy_frame(a = 1, key = "x", val = 1)
 
-  expect_snapshot_error(dbplyr_pivot_wider_spec(df, spec1, values_fn = NULL))
+  expect_snapshot(error = TRUE, dbplyr_pivot_wider_spec(df, spec1, values_fn = NULL))
 })
 
 # can fill missing cells --------------------------------------------------
@@ -208,7 +208,7 @@ test_that("column order in output matches spec", {
 })
 
 test_that("cannot pivot lazy frames", {
-  expect_snapshot_error(tidyr::pivot_wider(lazy_frame(name = "x", value = 1)))
+  expect_snapshot(error = TRUE, tidyr::pivot_wider(lazy_frame(name = "x", value = 1)))
 })
 
 # multiple names ----------------------------------------------------------

--- a/tests/testthat/test-verb-slice.R
+++ b/tests/testthat/test-verb-slice.R
@@ -46,9 +46,11 @@ test_that("window_order is preserved", {
 })
 
 test_that("check_slice_size checks for common issues", {
-  expect_snapshot(error = TRUE, check_slice_size(n = 1, prop = 1))
-  expect_snapshot(error = TRUE, check_slice_size(n = "a"))
-  expect_snapshot(error = TRUE, check_slice_size(prop = "a"))
-  expect_snapshot(error = TRUE, check_slice_size(n = -1))
-  expect_snapshot(error = TRUE, check_slice_size(prop = -1))
+  lf <- lazy_frame(x = c(1, 1, 2), id = c(1, 2, 3))
+
+  expect_snapshot(error = TRUE, lf %>% slice_sample(n = 1, prop = 1))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(n = "a"))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(prop = "a"))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(n = -1))
+  expect_snapshot(error = TRUE, lf %>% slice_sample(prop = -1))
 })

--- a/tests/testthat/test-verb-slice.R
+++ b/tests/testthat/test-verb-slice.R
@@ -1,8 +1,8 @@
 test_that("slice, head and tail aren't available", {
   lf <- lazy_frame(x = 1)
-  expect_snapshot_error(lf %>% slice())
-  expect_snapshot_error(lf %>% slice_head())
-  expect_snapshot_error(lf %>% slice_tail())
+  expect_snapshot(error = TRUE, lf %>% slice())
+  expect_snapshot(error = TRUE, lf %>% slice_head())
+  expect_snapshot(error = TRUE, lf %>% slice_tail())
 })
 
 test_that("slice_min handles arguments", {
@@ -14,8 +14,8 @@ test_that("slice_min handles arguments", {
   expect_equal(db %>% slice_min(id, n = 2) %>% pull(), c(1, 2))
   expect_equal(db %>% slice_min(id, prop = 0.5) %>% pull(), 1)
 
-  expect_snapshot_error(db %>% slice_min())
-  expect_snapshot_error(db %>% slice_min(id, prop = 0.5, with_ties = FALSE))
+  expect_snapshot(error = TRUE, db %>% slice_min())
+  expect_snapshot(error = TRUE, db %>% slice_min(id, prop = 0.5, with_ties = FALSE))
 })
 
 test_that("slice_max orders in opposite order", {
@@ -23,7 +23,7 @@ test_that("slice_max orders in opposite order", {
 
   expect_equal(db %>% slice_max(id) %>% pull(), 3)
   expect_equal(db %>% slice_max(x) %>% pull(), 3)
-  expect_snapshot_error(db %>% slice_max())
+  expect_snapshot(error = TRUE, db %>% slice_max())
 })
 
 test_that("slice_sample errors when expected", {
@@ -33,9 +33,9 @@ test_that("slice_sample errors when expected", {
   # shows that it doesn't always return the same result
   expect_error(db %>% slice_sample() %>% pull(), NA)
 
-  expect_snapshot_error(db %>% slice_sample(replace = TRUE))
-  expect_snapshot_error(db %>% slice_sample(weight_by = x))
-  expect_snapshot_error(db %>% slice_sample(prop = 0.5))
+  expect_snapshot(error = TRUE, db %>% slice_sample(replace = TRUE))
+  expect_snapshot(error = TRUE, db %>% slice_sample(weight_by = x))
+  expect_snapshot(error = TRUE, db %>% slice_sample(prop = 0.5))
 })
 
 test_that("window_order is preserved", {
@@ -46,9 +46,9 @@ test_that("window_order is preserved", {
 })
 
 test_that("check_slice_size checks for common issues", {
-  expect_snapshot_error(check_slice_size(n = 1, prop = 1))
-  expect_snapshot_error(check_slice_size(n = "a"))
-  expect_snapshot_error(check_slice_size(prop = "a"))
-  expect_snapshot_error(check_slice_size(n = -1))
-  expect_snapshot_error(check_slice_size(prop = -1))
+  expect_snapshot(error = TRUE, check_slice_size(n = 1, prop = 1))
+  expect_snapshot(error = TRUE, check_slice_size(n = "a"))
+  expect_snapshot(error = TRUE, check_slice_size(prop = "a"))
+  expect_snapshot(error = TRUE, check_slice_size(n = -1))
+  expect_snapshot(error = TRUE, check_slice_size(prop = -1))
 })

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -18,7 +18,7 @@ test_that("summarise performs partial evaluation", {
 
 test_that("can't refer to freshly created variables", {
   mf1 <- lazy_frame(x = 1)
-  expect_snapshot_error(summarise(mf1, y = sum(x), z = sum(y)))
+  expect_snapshot(error = TRUE, summarise(mf1, y = sum(x), z = sum(y)))
 })
 
 test_that("summarise(.groups=)", {
@@ -46,7 +46,7 @@ test_that("summarise(.groups=)", {
   expect_equal(df %>% summarise(.groups = "drop") %>% group_vars(), character())
   expect_equal(df %>% summarise(.groups = "keep") %>% group_vars(), c("x", "y"))
 
-  expect_snapshot_error(df %>% summarise(.groups = "rowwise"))
+  expect_snapshot(error = TRUE, df %>% summarise(.groups = "rowwise"))
 })
 
 # sql-render --------------------------------------------------------------


### PR DESCRIPTION
* Update snapshots
* Update documentation
* Use `expect_snapshot(error = TRUE)` pattern instead of `expect_snapshot_error()` to show error call
* Improve some error messages from helper functions by passing a call to `abort()`