### PR TITLE
Allow `stringr::` and `lubridate::` prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* Calls of the form `stringr::foo()` or `lubridate::foo()` are now evaluated in
+  the database, rather than locally (#197).
+
 * Fix translation of `quantile()` for MS SQL (@mgirlich, #620).
 
 * `add_count()` now doesn't change the groups of the input (@mgirlich, #614).

--- a/R/partial-eval.R
+++ b/R/partial-eval.R
@@ -104,7 +104,8 @@ partial_eval_sym <- function(sym, vars, env) {
 }
 
 is_namespaced_dplyr_call <- function(call) {
-  is_symbol(call[[1]], "::") && is_symbol(call[[2]], "dplyr")
+  packages <- c("dplyr", "stringr", "lubridate")
+  is_symbol(call[[1]], "::") && is_symbol(call[[2]], packages)
 }
 
 is_tidy_pronoun <- function(call) {

--- a/tests/testthat/test-partial-eval.R
+++ b/tests/testthat/test-partial-eval.R
@@ -5,6 +5,8 @@ test_that("namespace operators always evaluated locally", {
 
 test_that("namespaced calls to dplyr functions are stripped", {
   expect_equal(partial_eval(quote(dplyr::n())), expr(n()))
+  expect_equal(partial_eval(quote(stringr::str_to_lower(x))), expr(str_to_lower(x)))
+  expect_equal(partial_eval(quote(lubridate::today())), expr(today()))
 })
 
 test_that("use quosure environment for unevaluted formulas", {

--- a/tests/testthat/test-partial-eval.R
+++ b/tests/testthat/test-partial-eval.R
@@ -5,8 +5,9 @@ test_that("namespace operators always evaluated locally", {
 
 test_that("namespaced calls to dplyr functions are stripped", {
   expect_equal(partial_eval(quote(dplyr::n())), expr(n()))
-  expect_equal(partial_eval(quote(stringr::str_to_lower(x))), expr(str_to_lower(x)))
-  expect_equal(partial_eval(quote(lubridate::today())), expr(today()))
+  # hack to avoid check complaining about not declared imports
+  expect_equal(partial_eval(rlang::parse_expr("stringr::str_to_lower(x)")), expr(str_to_lower(x)))
+  expect_equal(partial_eval(rlang::parse_expr("lubridate::today()")), expr(today()))
 })
 
 test_that("use quosure environment for unevaluted formulas", {


### PR DESCRIPTION
Fixes #667