### PR TITLE
`compute()` can handle named `name`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* `compute()` can now handle when `name` is named by unnaming it first
+  (@mgirlich, #623).
+
 * The partial evaluation code is now more aligned with `dtplyr`. This makes it
   easier to transfer bug fixes and new features from one package to the other.
   In this process the second argument of `partial_eval()` was changed to a lazy

--- a/R/verb-compute.R
+++ b/R/verb-compute.R
@@ -37,7 +37,7 @@ compute.tbl_sql <- function(x,
                             indexes = list(),
                             analyze = TRUE,
                             ...) {
-
+  name <- unname(name)
   vars <- op_vars(x)
   assert_that(all(unlist(indexes) %in% vars))
   assert_that(all(unlist(unique_indexes) %in% vars))

--- a/tests/testthat/test-verb-compute.R
+++ b/tests/testthat/test-verb-compute.R
@@ -74,6 +74,16 @@ test_that("compute keeps window and groups", {
   expect_equal(op_grps(out), "x")
 })
 
+test_that("compute can handle named name", {
+  name <- set_names(unique_subquery_name(), unique_subquery_name())
+  expect_equal(
+    memdb_frame(x = 1:10) %>%
+      compute() %>%
+      collect(),
+    tibble(x = 1:10)
+  )
+})
+
 # ops ---------------------------------------------------------------------
 
 test_that("sorting preserved across compute and collapse", {


### PR DESCRIPTION
Fixes #623