### PR TITLE
Update `pivot_wider()` documentation

### DIFF
--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -1,11 +1,13 @@
 #' Pivot data from long to wide
 #'
+#' @description
 #' `pivot_wider()` "widens" data, increasing the number of columns and
 #' decreasing the number of rows. The inverse transformation is
 #' `pivot_longer()`.
+#' Learn more in `vignette("pivot", "tidyr")`.
+#'
 #' Note that `pivot_wider()` is not and cannot be lazy because we need to look
 #' at the data to figure out what the new column names will be.
-#' Learn more in `vignette("pivot", "tidyr")`.
 #'
 #' @details
 #' The big difference to `pivot_wider()` for local data frames is that

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -3,7 +3,8 @@
 #' `pivot_wider()` "widens" data, increasing the number of columns and
 #' decreasing the number of rows. The inverse transformation is
 #' `pivot_longer()`.
-#' Note that `pivot_wider()` is not lazy but has to collect the data.
+#' Note that `pivot_wider()` is not and cannot be lazy because we need to look
+#' at the data to figure out what the new column names will be.
 #' Learn more in `vignette("pivot", "tidyr")`.
 #'
 #' @details

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -3,6 +3,7 @@
 #' `pivot_wider()` "widens" data, increasing the number of columns and
 #' decreasing the number of rows. The inverse transformation is
 #' `pivot_longer()`.
+#' Note that `pivot_wider()` is not lazy but has to collect the data.
 #' Learn more in `vignette("pivot", "tidyr")`.
 #'
 #' @details

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -94,6 +94,7 @@ unused columns using \code{unused_fn}.}
 \code{pivot_wider()} "widens" data, increasing the number of columns and
 decreasing the number of rows. The inverse transformation is
 \code{pivot_longer()}.
+Note that \code{pivot_wider()} is not lazy but has to collect the data.
 Learn more in \code{vignette("pivot", "tidyr")}.
 }
 \details{

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -94,7 +94,8 @@ unused columns using \code{unused_fn}.}
 \code{pivot_wider()} "widens" data, increasing the number of columns and
 decreasing the number of rows. The inverse transformation is
 \code{pivot_longer()}.
-Note that \code{pivot_wider()} is not lazy but has to collect the data.
+Note that \code{pivot_wider()} is not and cannot be lazy because we need to look
+at the data to figure out what the new column names will be.
 Learn more in \code{vignette("pivot", "tidyr")}.
 }
 \details{


### PR DESCRIPTION
Users are confused that `pivot_wider()` is not lazy (e.g. #598, #703). Collecting is only necessary to generate the spec.
As long as `tidyr::pivot_wider_spec()` is not made a generic I see two ways of handling this:

* just update the documentation (like it is done here) or
* export `dbplyr_pivot_wider_spec()` (which is lazy) so people can generate the spec locally.

@hadley Do you have any preference?