### PR TITLE
`explain()` passes `...` to methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `explain()` now passes `...` to methods (@mgirlich, #783).
+
 * `compute()` can now handle when `name` is named by unnaming it first
   (@mgirlich, #623).
 

--- a/R/explain.R
+++ b/R/explain.R
@@ -14,7 +14,7 @@ explain.tbl_sql <- function(x, ...) {
   show_query(x)
   cat_line()
   cat_line("<PLAN>")
-  cat_line(remote_query_plan(x))
+  cat_line(remote_query_plan(x, ...))
 
   invisible(x)
 }

--- a/R/remote.R
+++ b/R/remote.R
@@ -6,6 +6,7 @@
 #' `remote_con()` give the dplyr source and DBI connection respectively.
 #'
 #' @param x Remote table, currently must be a [tbl_sql].
+#' @param ... Additional arguments passed on to methods.
 #' @return The value, or `NULL` if not remote table, or not applicable.
 #'    For example, computed queries do not have a "name"
 #' @export
@@ -48,6 +49,6 @@ remote_query <- function(x) {
 
 #' @export
 #' @rdname remote_name
-remote_query_plan <- function(x) {
-  dbplyr_explain(remote_con(x), db_sql_render(remote_con(x), x$lazy_query))
+remote_query_plan <- function(x, ...) {
+  dbplyr_explain(remote_con(x), db_sql_render(remote_con(x), x$lazy_query), ...)
 }

--- a/man/complete.tbl_lazy.Rd
+++ b/man/complete.tbl_lazy.Rd
@@ -4,7 +4,7 @@
 \alias{complete.tbl_lazy}
 \title{Complete a SQL table with missing combinations of data}
 \usage{
-complete.tbl_lazy(data, ..., fill = list())
+\method{complete}{tbl_lazy}(data, ..., fill = list())
 }
 \arguments{
 \item{data}{A lazy data frame backed by a database query.}

--- a/man/expand.tbl_lazy.Rd
+++ b/man/expand.tbl_lazy.Rd
@@ -4,7 +4,7 @@
 \alias{expand.tbl_lazy}
 \title{Expand SQL tables to include all possible combinations of values}
 \usage{
-expand.tbl_lazy(data, ..., .name_repair = "check_unique")
+\method{expand}{tbl_lazy}(data, ..., .name_repair = "check_unique")
 }
 \arguments{
 \item{data}{A lazy data frame backed by a database query.}

--- a/man/fill.tbl_lazy.Rd
+++ b/man/fill.tbl_lazy.Rd
@@ -4,7 +4,7 @@
 \alias{fill.tbl_lazy}
 \title{Fill in missing values with previous or next value}
 \usage{
-fill.tbl_lazy(.data, ..., .direction = c("down", "up"))
+\method{fill}{tbl_lazy}(.data, ..., .direction = c("down", "up"))
 }
 \arguments{
 \item{.data}{A lazy data frame backed by a database query.}

--- a/man/pivot_longer.tbl_lazy.Rd
+++ b/man/pivot_longer.tbl_lazy.Rd
@@ -4,7 +4,7 @@
 \alias{pivot_longer.tbl_lazy}
 \title{Pivot data from wide to long}
 \usage{
-pivot_longer.tbl_lazy(
+\method{pivot_longer}{tbl_lazy}(
   data,
   cols,
   names_to = "name",

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -4,7 +4,7 @@
 \alias{pivot_wider.tbl_lazy}
 \title{Pivot data from long to wide}
 \usage{
-pivot_wider.tbl_lazy(
+\method{pivot_wider}{tbl_lazy}(
   data,
   id_cols = NULL,
   names_from = name,

--- a/man/remote_name.Rd
+++ b/man/remote_name.Rd
@@ -16,10 +16,12 @@ remote_con(x)
 
 remote_query(x)
 
-remote_query_plan(x)
+remote_query_plan(x, ...)
 }
 \arguments{
 \item{x}{Remote table, currently must be a \link{tbl_sql}.}
+
+\item{...}{Additional arguments passed on to methods.}
 }
 \value{
 The value, or \code{NULL} if not remote table, or not applicable.

--- a/man/replace_na.tbl_lazy.Rd
+++ b/man/replace_na.tbl_lazy.Rd
@@ -4,7 +4,7 @@
 \alias{replace_na.tbl_lazy}
 \title{Replace NAs with specified values}
 \usage{
-replace_na.tbl_lazy(data, replace = list(), ...)
+\method{replace_na}{tbl_lazy}(data, replace = list(), ...)
 }
 \arguments{
 \item{data}{A pair of lazy data frame backed by database queries.}

--- a/tests/testthat/_snaps/backend-postgres.md
+++ b/tests/testthat/_snaps/backend-postgres.md
@@ -22,3 +22,16 @@
                                                  QUERY PLAN
       1 Seq Scan on test  (cost=0.00..1.04 rows=3 width=36)
 
+---
+
+    Code
+      db %>% mutate(y = x + 1) %>% explain(format = "json")
+    Output
+      <SQL>
+      SELECT "x", "x" + 1.0 AS "y"
+      FROM "test"
+      
+      <PLAN>
+                                                                                                                                                                                                                                                                 QUERY PLAN
+      1 [\n  {\n    "Plan": {\n      "Node Type": "Seq Scan",\n      "Parallel Aware": false,\n      "Relation Name": "test",\n      "Alias": "test",\n      "Startup Cost": 0.00,\n      "Total Cost": 1.04,\n      "Plan Rows": 3,\n      "Plan Width": 36\n    }\n  }\n]
+

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -78,6 +78,9 @@ test_that("custom SQL translation", {
 test_that("can explain", {
   db <- copy_to_test("postgres", data.frame(x = 1:3))
   expect_snapshot(db %>% mutate(y = x + 1) %>% explain())
+
+  # `explain()` passes `...` to methods
+  expect_snapshot(db %>% mutate(y = x + 1) %>% explain(format = "json"))
 })
 
 test_that("can overwrite temp tables", {


### PR DESCRIPTION
Fixes #783.