### PR TITLE
Support `.keep`, `.before`, and `.after` in `mutate()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
 # dbplyr (development version)
 
-* Multiple `across()` calls in `mutate()` and `transmute()` can now access
-  freshly created variables (@mgirlich, #671).
+* `mutate()` now supports the arguments `.keep`, `.before`, and `.after
+  (@mgirlich, #802).
 
-* `transmute()` now keeps grouping variables (@mgirlich, #671).
+* Multiple `across()` calls in `mutate()` and `transmute()` can now access
+  freshly created variables (@mgirlich, #802).
+
+* `transmute()` now keeps grouping variables (@mgirlich, #802).
 
 * Added `copy_inline()` as a `copy_to()` equivalent that does not need write
   access (@mgirlich, #628).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dbplyr (development version)
 
+* Multiple `across()` calls in `mutate()` and `transmute()` can now access
+  freshly created variables (@mgirlich, #671).
+
+* `transmute()` now keeps grouping variables (@mgirlich, #671).
+
 * Added `copy_inline()` as a `copy_to()` equivalent that does not need write
   access (@mgirlich, #628).
 

--- a/R/verb-mutate.R
+++ b/R/verb-mutate.R
@@ -69,9 +69,13 @@ transmute.tbl_lazy <- function(.data, ...) {
     .data$lazy_query <- add_select(.data, layer, "mutate")
   }
 
+  # Retain expression columns in order of their appearance
   cols_expr <- layer_info$modified_vars
+
+  # Retain untouched group variables up front
   cols_group <- group_vars(.data)
   cols_group <- setdiff(cols_group, cols_expr)
+
   cols_retain <- c(cols_group, cols_expr)
 
   select(.data, all_of(cols_retain))

--- a/R/verb-mutate.R
+++ b/R/verb-mutate.R
@@ -21,7 +21,11 @@
 #' db %>%
 #'   mutate(x1 = x + 1, x2 = x1 * 2) %>%
 #'   show_query()
-mutate.tbl_lazy <- function(.data, ..., .keep = c("all", "used", "unused", "none")) {
+mutate.tbl_lazy <- function(.data,
+                            ...,
+                            .keep = c("all", "used", "unused", "none"),
+                            .before = NULL,
+                            .after = NULL) {
   keep <- arg_match(.keep)
   layer_info <- get_mutate_layers(.data, ...)
   used <- layer_info$used_vars
@@ -43,6 +47,14 @@ mutate.tbl_lazy <- function(.data, ..., .keep = c("all", "used", "unused", "none
 
   cols_used <- setdiff(cols_data, c(cols_group, cols_expr_modified, names(used)[!used]))
   cols_unused <- setdiff(cols_data, c(cols_group, cols_expr_modified, names(used)[used]))
+
+  .before <- enquo(.before)
+  .after <- enquo(.after)
+
+  if (!quo_is_null(.before) || !quo_is_null(.after)) {
+    # Only change the order of new columns
+    out <- relocate(out, all_of(cols_expr_new), .before = !!.before, .after = !!.after)
+  }
 
   cols_out <- op_vars(out)
 

--- a/R/verb-mutate.R
+++ b/R/verb-mutate.R
@@ -4,6 +4,23 @@
 #' They are translated to computed expressions in the `SELECT` clause of
 #' the SQL query.
 #'
+#' @param .keep `r lifecycle::badge("experimental")`
+#'   Control which columns from `.data` are retained in the output. Grouping
+#'   columns and columns created by `...` are always kept.
+#'
+#'   * `"all"` retains all columns from `.data`. This is the default.
+#'   * `"used"` retains only the columns used in `...` to create new
+#'     columns. This is useful for checking your work, as it displays inputs
+#'     and outputs side-by-side.
+#'   * `"unused"` retains only the columns _not_ used in `...` to create new
+#'     columns. This is useful if you generate new columns, but no longer need
+#'     the columns used to generate them.
+#'   * `"none"` doesn't retain any extra columns from `.data`. Only the grouping
+#'     variables and columns created by `...` are kept.
+#' @param .before,.after `r lifecycle::badge("experimental")`
+#'   <[`tidy-select`][dplyr_tidy_select]> Optionally, control where new columns
+#'   should appear (the default is to add to the right hand side). See
+#'   [relocate()] for more details.
 #' @inheritParams arrange.tbl_lazy
 #' @inheritParams dplyr::mutate
 #' @inherit arrange.tbl_lazy return

--- a/R/verb-select.R
+++ b/R/verb-select.R
@@ -120,7 +120,7 @@ add_select <- function(.data, vars, op = c("select", "mutate")) {
   if (length(lazy_query$last_op) == 1 && lazy_query$last_op %in% c("select", "mutate")) {
     # Special optimisation when applied to pure projection() - this is
     # conservative and we could expand to any op_select() if combined with
-    # the logic in nest_vars()
+    # the logic in get_mutate_layers()
     select <- lazy_query$select
 
     if (purrr::every(vars, is.symbol)) {

--- a/man/mutate.tbl_lazy.Rd
+++ b/man/mutate.tbl_lazy.Rd
@@ -4,13 +4,28 @@
 \alias{mutate.tbl_lazy}
 \title{Create, modify, and delete columns}
 \usage{
-\method{mutate}{tbl_lazy}(.data, ...)
+\method{mutate}{tbl_lazy}(.data, ..., .keep = c("all", "used", "unused", "none"))
 }
 \arguments{
 \item{.data}{A lazy data frame backed by a database query.}
 
 \item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Variables, or functions of
 variables. Use \code{\link[dplyr:desc]{desc()}} to sort a variable in descending order.}
+
+\item{.keep}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
+Control which columns from \code{.data} are retained in the output. Grouping
+columns and columns created by \code{...} are always kept.
+\itemize{
+\item \code{"all"} retains all columns from \code{.data}. This is the default.
+\item \code{"used"} retains only the columns used in \code{...} to create new
+columns. This is useful for checking your work, as it displays inputs
+and outputs side-by-side.
+\item \code{"unused"} retains only the columns \emph{not} used in \code{...} to create new
+columns. This is useful if you generate new columns, but no longer need
+the columns used to generate them.
+\item \code{"none"} doesn't retain any extra columns from \code{.data}. Only the grouping
+variables and columns created by \code{...} are kept.
+}}
 }
 \value{
 Another \code{tbl_lazy}. Use \code{\link[=show_query]{show_query()}} to see the generated

--- a/man/mutate.tbl_lazy.Rd
+++ b/man/mutate.tbl_lazy.Rd
@@ -18,7 +18,7 @@
 \item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Variables, or functions of
 variables. Use \code{\link[dplyr:desc]{desc()}} to sort a variable in descending order.}
 
-\item{.keep}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
+\item{.keep}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Control which columns from \code{.data} are retained in the output. Grouping
 columns and columns created by \code{...} are always kept.
 \itemize{
@@ -33,15 +33,10 @@ the columns used to generate them.
 variables and columns created by \code{...} are kept.
 }}
 
-\item{.before}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
-<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
+\item{.before, .after}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+<\code{\link[=dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
 should appear (the default is to add to the right hand side). See
-\code{\link[dplyr:relocate]{relocate()}} for more details.}
-
-\item{.after}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
-<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
-should appear (the default is to add to the right hand side). See
-\code{\link[dplyr:relocate]{relocate()}} for more details.}
+\code{\link[=relocate]{relocate()}} for more details.}
 }
 \value{
 Another \code{tbl_lazy}. Use \code{\link[=show_query]{show_query()}} to see the generated

--- a/man/mutate.tbl_lazy.Rd
+++ b/man/mutate.tbl_lazy.Rd
@@ -4,7 +4,13 @@
 \alias{mutate.tbl_lazy}
 \title{Create, modify, and delete columns}
 \usage{
-\method{mutate}{tbl_lazy}(.data, ..., .keep = c("all", "used", "unused", "none"))
+\method{mutate}{tbl_lazy}(
+  .data,
+  ...,
+  .keep = c("all", "used", "unused", "none"),
+  .before = NULL,
+  .after = NULL
+)
 }
 \arguments{
 \item{.data}{A lazy data frame backed by a database query.}
@@ -26,6 +32,16 @@ the columns used to generate them.
 \item \code{"none"} doesn't retain any extra columns from \code{.data}. Only the grouping
 variables and columns created by \code{...} are kept.
 }}
+
+\item{.before}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
+<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
+should appear (the default is to add to the right hand side). See
+\code{\link[dplyr:relocate]{relocate()}} for more details.}
+
+\item{.after}{\ifelse{{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
+<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
+should appear (the default is to add to the right hand side). See
+\code{\link[dplyr:relocate]{relocate()}} for more details.}
 }
 \value{
 Another \code{tbl_lazy}. Use \code{\link[=show_query]{show_query()}} to see the generated

--- a/tests/testthat/_snaps/verb-mutate.md
+++ b/tests/testthat/_snaps/verb-mutate.md
@@ -40,8 +40,30 @@
       df %>% group_by(g) %>% transmute(across(.fns = ~0))
     Output
       <SQL>
-      SELECT 0.0 AS `x`
+      SELECT `g`, 0.0 AS `x`
       FROM `df`
+
+# across() can access previously created variables
+
+    Code
+      remote_query(out)
+    Output
+      <SQL> SELECT `x`, SQRT(`y`) AS `y`
+      FROM (
+        SELECT `x`, 2.0 AS `y`
+        FROM `dbplyr_122`
+      )
+
+# new columns take precedence over global variables
+
+    Code
+      remote_query(lf)
+    Output
+      <SQL> SELECT `x`, `y`, `y` + 1.0 AS `z`
+      FROM (
+        SELECT `x`, 2.0 AS `y`
+        FROM `df`
+      ) `q01`
 
 # mutate generates subqueries as needed
 
@@ -83,5 +105,24 @@
     Output
       <SQL>
       SELECT `y` * 2.0 AS `y`, `x` * 2.0 AS `x`
+      FROM `df`
+
+# var = NULL works when var is in original data
+
+    Code
+      remote_query(lf)
+    Output
+      <SQL> SELECT `x` * 2.0 AS `z`
+      FROM (
+        SELECT 2.0 AS `x`
+        FROM `df`
+      ) `q01`
+
+# var = NULL when var is in final output
+
+    Code
+      remote_query(lf)
+    Output
+      <SQL> SELECT `x`, 3.0 AS `y`
       FROM `df`
 

--- a/tests/testthat/_snaps/verb-mutate.md
+++ b/tests/testthat/_snaps/verb-mutate.md
@@ -46,13 +46,13 @@
 # across() can access previously created variables
 
     Code
-      remote_query(out)
+      remote_query(lf)
     Output
       <SQL> SELECT `x`, SQRT(`y`) AS `y`
       FROM (
         SELECT `x`, 2.0 AS `y`
-        FROM `dbplyr_122`
-      )
+        FROM `df`
+      ) `q01`
 
 # new columns take precedence over global variables
 
@@ -125,4 +125,15 @@
     Output
       <SQL> SELECT `x`, 3.0 AS `y`
       FROM `df`
+
+# temp var with nested arguments
+
+    Code
+      remote_query(lf)
+    Output
+      <SQL> SELECT `x`, `y` * 2.0 AS `z`
+      FROM (
+        SELECT `x`, 2.0 AS `y`
+        FROM `df`
+      ) `q01`
 

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -84,8 +84,8 @@ test_that("transmute() keeps grouping variables", {
 })
 
 test_that("across() can access previously created variables", {
-  out <- memdb_frame(x = 1) %>%
-    mutate(y = 2, across(y, sqrt))
+  out <- memdb_frame(x = 1) %>% mutate(y = 2, across(y, sqrt))
+  lf <- lazy_frame(x = 1) %>% mutate(y = 2, across(y, sqrt))
 
   expect_equal(
     collect(out),
@@ -97,7 +97,7 @@ test_that("across() can access previously created variables", {
     c("x", "y")
   )
 
-  expect_snapshot(remote_query(out))
+  expect_snapshot(remote_query(lf))
 })
 
 test_that("new columns take precedence over global variables", {

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -182,6 +182,93 @@ test_that("sequence of operations work", {
   expect_equal(out, tibble(y = 1, z = 2))
 })
 
+test_that(".keep = 'unused' keeps variables explicitly mentioned", {
+  df <- lazy_frame(x = 1, y = 2)
+  out <- mutate(df, x1 = x + 1, y = y, .keep = "unused")
+  expect_equal(op_vars(out), c("y", "x1"))
+})
+
+test_that(".keep = 'used' not affected by across()", {
+  df <- lazy_frame(x = 1, y = 2, z = 3, a = "a", b = "b", c = "c")
+
+  # This must evaluate every column in order to figure out if should
+  # be included in the set or not, but that shouldn't be counted for
+  # the purposes of "used" variables
+  out <- mutate(df, across(c("x", "y", "z"), identity), .keep = "unused")
+  expect_equal(op_vars(out), op_vars(df))
+})
+
+test_that(".keep = 'used' keeps variables used in expressions", {
+  df <- lazy_frame(a = 1, b = 2, c = 3, x = 1, y = 2)
+  out <- mutate(df, xy = x + y, .keep = "used")
+  expect_equal(op_vars(out), c("x", "y", "xy"))
+})
+
+test_that(".keep = 'none' only keeps grouping variables", {
+  df <- lazy_frame(x = 1, y = 2)
+  gf <- group_by(df, x)
+
+  expect_equal(op_vars(mutate(df, z = 1, .keep = "none")), "z")
+  expect_equal(op_vars(mutate(gf, z = 1, .keep = "none")), c("x", "z"))
+})
+
+test_that(".keep = 'none' retains original ordering (#5967)", {
+  df <- lazy_frame(x = 1, y = 2)
+  expect_equal(
+    df %>% mutate(y = 1, x = 2, .keep = "none") %>% op_vars(),
+    c("x", "y")
+  )
+
+  # even when grouped
+  gf <- group_by(df, x)
+  expect_equal(
+    gf %>% mutate(y = 1, x = 2, .keep = "none") %>% op_vars(),
+    c("x", "y")
+  )
+})
+
+test_that("dropping column with `NULL` then readding it retains original location", {
+  df <- lazy_frame(x = 1, y = 2, z = 3, a = 4)
+  df <- group_by(df, z)
+
+  expect_equal(
+    mutate(df, y = NULL, y = 3, .keep = "all") %>% op_vars(),
+    c("x", "y", "z", "a")
+  )
+  expect_equal(
+    mutate(df, b = a, y = NULL, y = 3, .keep = "used") %>% op_vars(),
+    c("y", "z", "a", "b")
+  )
+  expect_equal(
+    mutate(df, b = a, y = NULL, y = 3, .keep = "unused") %>% op_vars(),
+    c("x", "y", "z", "b")
+  )
+
+  skip("`.before` not yet supported")
+  # It isn't treated as a "new" column
+  expect_equal(mutate(df, y = NULL, y = 3, .keep = "all", .before = x) %>% op_vars(), c("x", "y", "z", "a"))
+})
+
+test_that(".keep= always retains grouping variables (#5582)", {
+  df <- lazy_frame(x = 1, y = 2, z = 3) %>% group_by(z)
+  expect_equal(
+    df %>% mutate(a = x + 1, .keep = "none") %>% op_vars(),
+    c("z", "a")
+  )
+  expect_equal(
+    df %>% mutate(a = x + 1, .keep = "all") %>% op_vars(),
+    c("x", "y", "z", "a")
+  )
+  expect_equal(
+    df %>% mutate(a = x + 1, .keep = "used") %>% op_vars(),
+    c("x", "z", "a")
+  )
+  expect_equal(
+    df %>% mutate(a = x + 1, .keep = "unused") %>% op_vars(),
+    c("y", "z", "a")
+  )
+})
+
 
 # sql_render --------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #670.

This PR replaces `nest_vars()` by a function that returns a list of layers. Unlike in #671 the order of variables is not changed. I still think it might be worth doing so, but then in a different PR.
Thanks to the layers most of the code to support `.keep`, `.before`, and `.after` could be copied from `dplyr`.