### PR TITLE
Add ellipsis to generic

### DIFF
--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -132,7 +132,7 @@ sql_expr_matches.MySQL <- sql_expr_matches.MariaDBConnection
 sql_expr_matches.MySQLConnection <- sql_expr_matches.MariaDBConnection
 
 #' @export
-sql_values.MariaDBConnection <- function(con, df) {
+sql_values.MariaDBConnection <- function(con, df, ...) {
   sql_values_clause(con, df, row = TRUE)
 }
 

--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -132,17 +132,18 @@ copy_inline <- function(con, df) {
   )
 }
 
-sql_values <- function(con, df) {
+sql_values <- function(con, df, ...) {
+  check_dots_empty()
   UseMethod("sql_values")
 }
 
 #' @export
-sql_values.DBIConnection <- function(con, df) {
+sql_values.DBIConnection <- function(con, df, ...) {
   sql_values_clause(con, df)
 }
 
 #' @export
-sql_values.SQLiteConnection <- function(con, df) {
+sql_values.SQLiteConnection <- function(con, df, ...) {
   needs_escape <- purrr::map_lgl(df, ~ is(.x, "Date") || inherits(.x, "POSIXct"))
   purrr::modify_if(df, needs_escape, ~ escape(.x, con = con, parens = FALSE, collapse = NULL)) %>%
     sql_values_clause(con = con)


### PR DESCRIPTION
Adding it "after the fact" is very painful. Even if the generic isn't exported yet, adding it now makes sure we don't forget to add it later.

Should we scout for other generics that don't have an ellipsis yet?