### PR TITLE
Use copy_inline() by default in memdb_frame()

### DIFF
--- a/R/memdb.R
+++ b/R/memdb.R
@@ -4,8 +4,9 @@
 #' data frame in R, it creates a table in [src_memdb()].
 #'
 #' @inheritParams tibble::tibble
-#' @param name,.name Name of table in database: defaults to a random name that's
-#'   unlikely to conflict with an existing table.
+#' @param name,.name Name of table in database: if provided, [copy_to()]
+#'   will be used to create the table, otherwise [copy_inline()] creates
+#'   an anonymous table.
 #' @param df Data frame to copy
 #' @export
 #' @examples
@@ -16,8 +17,12 @@
 #'
 #' mtcars_db <- tbl_memdb(mtcars)
 #' mtcars_db %>% group_by(cyl) %>% summarise(n = n()) %>% show_query()
-memdb_frame <- function(..., .name = unique_table_name()) {
-  x <- copy_to(src_memdb(), tibble(...), name = .name)
+memdb_frame <- function(..., .name = NULL) {
+  if (is.null(.name)) {
+    x <- copy_inline(src_memdb()$con, tibble(...))
+  } else {
+    x <- copy_to(src_memdb(), tibble(...), name = .name)
+  }
   x
 }
 

--- a/man/memdb_frame.Rd
+++ b/man/memdb_frame.Rd
@@ -6,7 +6,7 @@
 \alias{src_memdb}
 \title{Create a database table in temporary in-memory database.}
 \usage{
-memdb_frame(..., .name = unique_table_name())
+memdb_frame(..., .name = NULL)
 
 tbl_memdb(df, name = deparse(substitute(df)))
 
@@ -27,8 +27,9 @@ named \code{.data}.}
 
 \item{df}{Data frame to copy}
 
-\item{name, .name}{Name of table in database: defaults to a random name that's
-unlikely to conflict with an existing table.}
+\item{name, .name}{Name of table in database: if provided, \code{\link[=copy_to]{copy_to()}}
+will be used to create the table, otherwise \code{\link[=copy_inline]{copy_inline()}} creates
+an anonymous table.}
 }
 \description{
 \code{memdb_frame()} works like \code{\link[tibble:tibble]{tibble::tibble()}}, but instead of creating a new

--- a/tests/testthat/test-query-select.R
+++ b/tests/testthat/test-query-select.R
@@ -65,7 +65,7 @@ test_that("trivial subqueries are collapsed", {
     arrange()
 
   qry <- lf %>% sql_build()
-  expect_s3_class(qry$from, "ident")
+  expect_s3_class(qry$from, "sql")
   expect_true(qry$distinct)
 
   # And check that it returns the correct value

--- a/tests/testthat/test-tbl-sql.R
+++ b/tests/testthat/test-tbl-sql.R
@@ -22,14 +22,14 @@ test_that("same_src distinguishes srcs", {
 
 test_that("can generate sql tbls with raw sql", {
   mf1 <- memdb_frame(x = 1:3, y = 3:1)
-  mf2 <- tbl(mf1$src, build_sql("SELECT * FROM ", mf1$lazy_query$x, con = simulate_dbi()))
+  mf2 <- tbl(mf1$src, build_sql("SELECT * FROM (", mf1$lazy_query$x, ")", con = simulate_dbi()))
 
   expect_equal(collect(mf1), collect(mf2))
 })
 
 test_that("sql tbl can be printed", {
   mf1 <- memdb_frame(x = 1:3, y = 3:1)
-  mf2 <- tbl(mf1$src, build_sql("SELECT * FROM ", mf1$lazy_query$x, con = simulate_dbi()))
+  mf2 <- tbl(mf1$src, build_sql("SELECT * FROM (", mf1$lazy_query$x, ")", con = simulate_dbi()))
 
   expect_snapshot(mf2, transform = function(x) {
     gsub("sqlite .* \\[:memory:\\]", "sqlite ?.?.? [:memory:]", x)

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -42,7 +42,7 @@ test_that("queries are not nested unnecessarily", {
     sql_build()
 
   expect_s3_class(sql$from, "select_query")
-  expect_s3_class(sql$from$from, "ident")
+  expect_s3_class(sql$from$from, "sql")
 })
 
 test_that("maintains order of existing columns (#3216, #3223)", {
@@ -294,9 +294,9 @@ test_that(".keep= always retains grouping variables (#5582)", {
 # sql_render --------------------------------------------------------------
 
 test_that("quoting for rendering mutated grouped table", {
-  out <- memdb_frame(x = 1, y = 2) %>% mutate(y = x)
-  expect_match(out %>% sql_render, "^SELECT `x`, `x` AS `y`\nFROM `[^`]*`$")
-  expect_equal(out %>% collect, tibble(x = 1, y = 1))
+  out <- memdb_frame(x = 1, y = 2, .name = unique_table_name()) %>% mutate(y = x)
+  expect_match(out %>% sql_render(), "^SELECT `x`, `x` AS `y`\nFROM `[^`]*`$")
+  expect_equal(out %>% collect(), tibble(x = 1, y = 1))
 })
 
 test_that("mutate generates subqueries as needed", {


### PR DESCRIPTION
Should `auto_copy.tbl_sql()` also use `copy_inline()` ?