### PR TITLE
Fix `as.Date()` translation for Oracle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* Fix translation of `as.Date()` for Oracle (@mgirlich, #661).
+
 * Added translation for `cut()` (@mgirlich, #697).
 
 * Fix translation of `str_flatten()` for Redshift (@hdplsa, #804) 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -67,8 +67,8 @@ sql_translation.Oracle <- function(con) {
 
       # https://stackoverflow.com/questions/1171196
       as.character  = sql_cast("VARCHAR2(255)"),
-      # https://docs.oracle.com/cd/E17952_01/mysql-5.7-en/date-and-time-functions.html#function_date
-      as.Date = function(x) sql_expr(DATE(!!x)),
+      # https://oracle-base.com/articles/misc/oracle-dates-timestamps-and-intervals
+      as.Date = function(x) build_sql("DATE ", x),
       # bit64::as.integer64 can translate to BIGINT for some
       # vendors, which is equivalent to NUMBER(19) in Oracle
       # https://docs.oracle.com/cd/B19306_01/gateways.102/b14270/apa.htm

--- a/tests/testthat/test-backend-oracle.R
+++ b/tests/testthat/test-backend-oracle.R
@@ -4,6 +4,7 @@ test_that("custom scalar functions translated correctly", {
   expect_equal(translate_sql(as.character(x)), sql("CAST(`x` AS VARCHAR2(255))"))
   expect_equal(translate_sql(as.integer64(x)), sql("CAST(`x` AS NUMBER(19))"))
   expect_equal(translate_sql(as.double(x)),    sql("CAST(`x` AS NUMBER)"))
+  expect_equal(translate_sql(as.Date(x)),    sql("DATE `x`"))
 })
 
 test_that("paste and paste0 translate correctly", {


### PR DESCRIPTION
Fixes #661.