### PR TITLE
Across evaluated lists

### DIFF
--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -28,6 +28,8 @@ across_funs <- function(funs, env, data, dots, names_spec, fn, evaluated = FALSE
   if (is.null(funs)) {
     fns <- list(`1` = function(x, ...) x)
     names_spec <- names_spec %||% "{.col}"
+  } else if (is_quosure(funs)) {
+    return(across_funs(quo_squash(funs), env, data, dots, names_spec, fn, evaluated = evaluated))
   } else if (is_symbol(funs) || is_function(funs) ||
              is_call(funs, "~") || is_call(funs, "function")) {
     fns <- list(`1` = across_fun(funs, env, data, dots = dots, fn = fn))

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -32,6 +32,11 @@ across_funs <- function(funs, env, data, dots, names_spec, fn, evaluated = FALSE
     return(across_funs(quo_squash(funs), env, data, dots, names_spec, fn, evaluated = evaluated))
   } else if (is_symbol(funs) || is_function(funs) ||
              is_call(funs, "~") || is_call(funs, "function")) {
+    if (is_symbol(funs) && exists(funs, env) && is.list(get(funs, envir = env))) {
+      funs <- eval(funs, env)
+      return(across_funs(funs, env, data, dots, names_spec, fn, evaluated = evaluated))
+    }
+
     fns <- list(`1` = across_fun(funs, env, data, dots = dots, fn = fn))
     names_spec <- names_spec %||% "{.col}"
   } else if (is_call(funs, "list")) {

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -321,6 +321,33 @@ test_that("across() translates evaluated lists", {
   )
 })
 
+test_that("across() translates evaluated quosures", {
+  lf <- lazy_frame(a = 1, b = 2)
+
+  expect_equal(
+    capture_across(lf, across(a:b, !!quo(list(log)))),
+    exprs(
+      a_1 = log(a),
+      b_1 = log(b)
+    )
+  )
+
+  expect_equal(
+    capture_across(lf, across(a:b, !!quo(~ log(.x, 2)))),
+    exprs(
+      a = log(a, 2),
+      b = log(b, 2)
+    )
+  )
+
+  expect_equal(
+    capture_across(lf, across(a:b, !!quo(list(log2 = ~ log(.x, 2))))),
+    exprs(
+      a_log2 = log(a, 2),
+      b_log2 = log(b, 2)
+    )
+  )
+})
 # if_all ------------------------------------------------------------------
 
 test_that("if_all() translates functions", {

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -348,6 +348,23 @@ test_that("across() translates evaluated quosures", {
     )
   )
 })
+
+test_that("across() searches for list in environment", {
+  lf <- lazy_frame(a = 1, b = 2)
+  list_formula <- list(~ log(.x), sum)
+
+  expect_equal(
+    capture_across(lf, across(a:b, list_formula)),
+    exprs(
+      a_1 = log(a),
+      a_2 = sum(a),
+      b_1 = log(b),
+      b_2 = sum(b)
+    )
+  )
+})
+
+
 # if_all ------------------------------------------------------------------
 
 test_that("if_all() translates functions", {


### PR DESCRIPTION
Fixes #660.
Translating lists from the environment could theoretically be a breaking change:

```r
lf %>% mutate(across(a:b, list_formula))

# Before
#> SELECT list_formula(`a`) AS `a`, list_formula(`b`) AS `b`
#> FROM `df`

# After
#> SELECT
#>   `a`,
#>   `b`,
#>   LN(`a`) AS `a_1`,
#>   SUM(`a`) OVER () AS `a_2`,
#>   LN(`b`) AS `b_1`,
#>   SUM(`b`) OVER () AS `b_2`
#> FROM `df`
```

But this should be quite an irrelevant corner case and the new behaviour is like in dplyr.