### PR TITLE
Avoid sql_escape_ident() in sql_table_prefix()

### DIFF
--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -110,21 +110,9 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
-    if (is.null(name)) {
-      ident_name <- NULL
-    } else if (!is.ident(name)) {
-      ident_name <- ident(name)
-    } else {
-      ident_name <- name
-    }
-    build_sql("(", from, ") ", ident_name, con = con)
+    build_sql("(", from, ") ", as_subquery_name(name, default = NULL), con = con)
   } else {
-    ident_name <- name %||% unique_subquery_name()
-    if (!is.ident(ident_name)) {
-      ident_name <- ident(ident_name)
-    }
-
-    build_sql(sql_indent_subquery(from, con, lvl), " ", ident_name, con = con)
+    build_sql(sql_indent_subquery(from, con, lvl), " ", as_subquery_name(name), con = con)
   }
 }
 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -110,9 +110,21 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
-    build_sql("(", from, ") ", if (!is.null(name)) ident(name), con = con)
+    if (is.null(name)) {
+      ident_name <- NULL
+    } else if (!is.ident(name)) {
+      ident_name <- ident(name)
+    } else {
+      ident_name <- name
+    }
+    build_sql("(", from, ") ", ident_name, con = con)
   } else {
-    build_sql(sql_indent_subquery(from, con, lvl), " ", ident(name %||% unique_subquery_name()), con = con)
+    ident_name <- name %||% unique_subquery_name()
+    if (!is.ident(ident_name)) {
+      ident_name <- ident(ident_name)
+    }
+
+    build_sql(sql_indent_subquery(from, con, lvl), " ", ident_name, con = con)
   }
 }
 

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -129,7 +129,11 @@ sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_na
     if (is.null(name)) {
       build_sql(sql_indent_subquery(from, con, lvl), con = con)
     } else {
-      build_sql(sql_indent_subquery(from, con, lvl), " AS ", ident(name), con = con)
+      ident_name <- name %||% unique_subquery_name()
+      if (!is.ident(ident_name)) {
+        ident_name <- ident(ident_name)
+      }
+      build_sql(sql_indent_subquery(from, con, lvl), " AS ", ident_name, con = con)
     }
   }
 }

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -129,11 +129,7 @@ sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_na
     if (is.null(name)) {
       build_sql(sql_indent_subquery(from, con, lvl), con = con)
     } else {
-      ident_name <- name %||% unique_subquery_name()
-      if (!is.ident(ident_name)) {
-        ident_name <- ident(ident_name)
-      }
-      build_sql(sql_indent_subquery(from, con, lvl), " AS ", ident_name, con = con)
+      build_sql(sql_indent_subquery(from, con, lvl), " AS ", as_subquery_name(name), con = con)
     }
   }
 }

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -195,11 +195,17 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
   } else if (is.schema(from)) {
     setNames(as.sql(from, con), name)
   } else {
-    ident_name <- name %||% unique_subquery_name()
-    if (!is.ident(ident_name)) {
-      ident_name <- ident(ident_name)
-    }
-    build_sql(sql_indent_subquery(from, con, lvl), " ", ident_name, con = con)
+    build_sql(sql_indent_subquery(from, con, lvl), " ", as_subquery_name(name), con = con)
+  }
+}
+
+as_subquery_name <- function(x, default = ident(unique_subquery_name())) {
+  if (is.ident(x)) {
+    x
+  } else if (is.null(x)) {
+    default
+  } else {
+    ident(x)
   }
 }
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -195,7 +195,10 @@ sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(
   } else if (is.schema(from)) {
     setNames(as.sql(from, con), name)
   } else {
-    ident_name <- ident(name %||% unique_subquery_name())
+    ident_name <- name %||% unique_subquery_name()
+    if (!is.ident(ident_name)) {
+      ident_name <- ident(ident_name)
+    }
     build_sql(sql_indent_subquery(from, con, lvl), " ", ident_name, con = con)
   }
 }

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -45,7 +45,7 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl 
 # SQL generation ----------------------------------------------------------
 
 
-sql_join_vars <- function(con, vars, x_as = "LHS", y_as = "RHS") {
+sql_join_vars <- function(con, vars, x_as = ident("LHS"), y_as = ident("RHS")) {
   join_vars_list <- mapply(
     FUN = sql_join_var,
     alias = vars$alias,
@@ -103,7 +103,7 @@ sql_table_prefix <- function(con, var, table = NULL) {
   var <- sql_escape_ident(con, var)
 
   if (!is.null(table)) {
-    table <- sql_escape_ident(con, table)
+    table <- escape(table, con = con)
     sql(paste0(table, ".", var))
   } else {
     var

--- a/R/verb-joins.R
+++ b/R/verb-joins.R
@@ -232,8 +232,8 @@ add_join <- function(x, y, type, by = NULL, sql_on = NULL, copy = FALSE,
   } else {
     by <- dplyr::common_by(by, x, y)
   }
-  by$x_as <- x_as
-  by$y_as <- y_as
+  by$x_as <- ident(x_as)
+  by$y_as <- ident(y_as)
 
   y <- auto_copy(
     x, y,
@@ -264,8 +264,8 @@ add_semi_join <- function(x, y, anti = FALSE, by = NULL, sql_on = NULL, copy = F
   } else {
     by <- dplyr::common_by(by, x, y)
   }
-  by$x_as <- x_as
-  by$y_as <- y_as
+  by$x_as <- ident(x_as)
+  by$y_as <- ident(y_as)
 
   y <- auto_copy(
     x, y, copy,


### PR DESCRIPTION
This helps #748: without this change, updating dm to be compatible with the new `rows_*()` implementation will be hard.