### PR TITLE
Improve error message in `group_by()`

### DIFF
--- a/R/verb-group_by.R
+++ b/R/verb-group_by.R
@@ -36,7 +36,7 @@ group_by.tbl_lazy <- function(.data, ..., .add = FALSE, add = NULL, .drop = TRUE
     abort("`.drop` is not supported with database backends")
   }
 
-  groups <- dplyr::group_by_prepare(.data, !!!dots, .add = .add)
+  groups <- dplyr::group_by_prepare(.data, !!!dots, .add = .add, error_call = current_call())
   names <- purrr::map_chr(groups$groups, as_string)
 
   same_groups <- setequal(groups$group_names, group_vars(.data))

--- a/tests/testthat/_snaps/verb-group_by.md
+++ b/tests/testthat/_snaps/verb-group_by.md
@@ -6,3 +6,13 @@
       Error in `group_by()`:
       ! `.drop` is not supported with database backends
 
+# informative errors for missing variables
+
+    Code
+      (expect_error(lazy_frame(x = 1:3) %>% group_by(y)))
+    Output
+      <error/rlang_error>
+      Error in `group_by.tbl_lazy()`:
+      ! Must group by variables found in `.data`.
+      x Column `y` is not found.
+

--- a/tests/testthat/test-verb-group_by.R
+++ b/tests/testthat/test-verb-group_by.R
@@ -23,6 +23,12 @@ test_that("errors for .drop = FALSE", {
   )
 })
 
+test_that("informative errors for missing variables", {
+  expect_snapshot({
+    (expect_error(lazy_frame(x = 1:3) %>% group_by(y)))
+  })
+})
+
 test_that("collect, collapse and compute preserve grouping", {
   g <- memdb_frame(x = 1:3, y = 1:3) %>% group_by(x, y)
 


### PR DESCRIPTION
Fixes #818.

The new error message is

```r
lazy_frame(x = 1) %>% 
  group_by(y)
#> Error in `group_by.tbl_lazy()`:
#> ! Must group by variables found in `.data`.
#> x Column `y` is not found
```