### PR TITLE
Tweak copy_inline() for MySQL

### DIFF
--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -212,6 +212,8 @@ sql_indent_subquery <- function(from, con, lvl) {
       con = con
     )
   } else {
+    # Strip indent
+    from <- gsub("^ +", "", from)
     build_sql("(", from, ")", con = con)
   }
 }

--- a/tests/testthat/_snaps/backend-mysql.md
+++ b/tests/testthat/_snaps/backend-mysql.md
@@ -56,7 +56,7 @@
           WHERE (0 = 1)
         )
         UNION ALL
-        (  VALUES ROW(1.0, 'a'))
+        (VALUES ROW(1.0, 'a'))
       ) `values_table`
 
 # can explain

--- a/tests/testthat/_snaps/backend-mysql.md
+++ b/tests/testthat/_snaps/backend-mysql.md
@@ -47,16 +47,16 @@
 ---
 
     Code
-      sql_values(con, tibble(x = 1, y = "a"))
+      sql_values(con, tibble(x = 1:2, y = letters[1:2]))
     Output
-      <SQL> SELECT CAST(`x` AS NUMERIC) AS `x`, CAST(`y` AS CHAR) AS `y`
+      <SQL> SELECT CAST(`x` AS INTEGER) AS `x`, CAST(`y` AS CHAR) AS `y`
       FROM (
         (
           SELECT NULL AS `x`, NULL AS `y`
           WHERE (0 = 1)
         )
         UNION ALL
-        (VALUES ROW(1.0, 'a'))
+        (VALUES ROW(1, 'a'), ROW(2, 'b'))
       ) `values_table`
 
 # can explain

--- a/tests/testthat/test-backend-mysql.R
+++ b/tests/testthat/test-backend-mysql.R
@@ -34,7 +34,7 @@ test_that("generates custom sql", {
 
   expect_snapshot(slice_sample(lf, 5))
 
-  expect_snapshot(sql_values(con, tibble(x = 1, y = "a")))
+  expect_snapshot(sql_values(con, tibble(x = 1:2, y = letters[1:2])))
 })
 
 # live database -----------------------------------------------------------


### PR DESCRIPTION
Remove extra spaces in rendered SQL, test with two rows.