### PR TITLE
Improve function translation docs

### DIFF
--- a/man/translate_sql.Rd
+++ b/man/translate_sql.Rd
@@ -3,7 +3,7 @@
 \name{translate_sql}
 \alias{translate_sql}
 \alias{translate_sql_}
-\title{Translate an expression to sql}
+\title{Translate an expression to SQL}
 \usage{
 translate_sql(
   ...,
@@ -45,31 +45,14 @@ SQL for a grouped summary.}
 \item{context}{Use to carry information for special translation cases. For example, MS SQL needs a different conversion for is.na() in WHERE vs. SELECT clauses.  Expects a list.}
 }
 \description{
-Translate an expression to sql
-}
-\section{Base translation}{
-
-The base translator, \code{base_sql}, provides custom mappings for for
-commonly used base functions including logical (\code{!}, \code{&}, \code{|}),
-arithmetic (\code{^}), and comparison (\code{!=}) operators, as well as common
-summary (\code{mean()}, \code{var()}) and manipulation functions.
-
-All other functions will be preserved as is. R's infix functions
+dbplyr translates commonly used base functions including logical
+(\code{!}, \code{&}, \code{|}), arithmetic (\code{^}), and comparison (\code{!=}) operators, as well
+as common summary (\code{mean()}, \code{var()}), and transformation (\code{log()})
+functions.  All other functions will be preserved as is. R's infix functions
 (e.g. \verb{\%like\%}) will be converted to their SQL equivalents (e.g. \code{LIKE}).
-You can use this to access SQL string concatenation: \code{||} is mapped to
-\code{OR}, but \verb{\%||\%} is mapped to \code{||}. To suppress this behaviour, and force
-errors immediately when dplyr doesn't know how to translate a function it
-encounters, using set the \code{dplyr.strict_sql} option to \code{TRUE}.
 
-You can also use \code{\link[=sql]{sql()}} to insert a raw sql string.
+Learn more in \code{vignette("translation-function")}.
 }
-
-\section{SQLite translation}{
-
-The SQLite variant currently only adds one additional function: a mapping
-from \code{sd()} to the SQL aggregation function \code{STDEV}.
-}
-
 \examples{
 # Regular maths is translated in a very straightforward way
 translate_sql(x + 1)

--- a/tests/testthat/_snaps/translate-sql.md
+++ b/tests/testthat/_snaps/translate-sql.md
@@ -1,3 +1,16 @@
+# dplyr.strict_sql = TRUE prevents auto conversion
+
+    Code
+      translate_sql(blah(x))
+    Condition
+      Error in `blah()`:
+      ! Don't know how to translate blah()
+    Code
+      translate_sql(x %blah% y)
+    Condition
+      Error in `x %blah% y`:
+      ! Don't know how to translate %blah%
+
 # namespace calls are translated
 
     Code

--- a/tests/testthat/test-translate-sql.R
+++ b/tests/testthat/test-translate-sql.R
@@ -1,9 +1,11 @@
 test_that("dplyr.strict_sql = TRUE prevents auto conversion", {
-  old <- options(dplyr.strict_sql = TRUE)
-  on.exit(options(old))
+  withr::local_options(dplyr.strict_sql = TRUE)
 
   expect_equal(translate_sql(1 + 2), sql("1.0 + 2.0"))
-  expect_error(translate_sql(blah(x)), "could not find function")
+  expect_snapshot(error = TRUE, {
+    translate_sql(blah(x))
+    translate_sql(x %blah% y)
+  })
 })
 
 test_that("namespace calls are translated", {

--- a/vignettes/sql.Rmd
+++ b/vignettes/sql.Rmd
@@ -40,9 +40,7 @@ In general, it's much easier to work iteratively in dbplyr. You can easily give 
 
 ## What happens when dbplyr fails?
 
-dbplyr aims to translate the most common R functions to their SQL equivalents, allowing you to ignore the vagaries of the SQL dialect that you're working with, so you can focus on the data analysis problem at hand. But different backends have different capabilities, and sometimes there are SQL functions that don't have exact equivalents in R. In those cases, you'll need to write SQL code directly. This section shows you how you can do so.
-
-### Prefix functions
+dbplyr aims to translate the most common R functions to their SQL equivalents, allowing you to ignore the vagaries of the SQL dialect that you're working with, so you can focus on the data analysis problem at hand. But different backends have different capabilities, and sometimes there are SQL functions that don't have exact equivalents in R. In those cases, you'll need to write SQL code directly. 
 
 Any function that dbplyr doesn't know about will be left as is:
 
@@ -50,35 +48,11 @@ Any function that dbplyr doesn't know about will be left as is:
 mf %>% 
   mutate(z = foofify(x, y)) %>% 
   show_query()
-```
 
-Because SQL functions are general case insensitive, I recommend using upper case when you're using SQL functions in R code. That makes it easier to spot that you're doing something unusual:
-
-```{r}
-mf %>% 
-  mutate(z = FOOFIFY(x, y)) %>% 
-  show_query()
-```
-
-### Infix functions
-
-As well as prefix functions (where the name of the function comes before the arguments), dbplyr also translates infix functions. That allows you to use expressions like `LIKE` which does a limited form of pattern matching:
-
-```{r}
 mf %>% 
   filter(x %LIKE% "%foo%") %>% 
   show_query()
 ```
-
-Or use `||` for string concatenation (note that backends should translate `paste()` and `paste0()` for you):
-
-```{r}
-mf %>% 
-  transmute(z = x %||% y) %>% 
-  show_query()
-```
-
-### Special forms
 
 SQL functions tend to have a greater variety of syntax than R. That means there are a number of expressions that can't be translated directly from R code. To insert these in your own queries, you can use literal SQL inside `sql()`:
 
@@ -92,10 +66,4 @@ mf %>%
   show_query()
 ```
 
-Note that you can use `sql()` at any depth inside the expression:
-
-```{r}
-mf %>% 
-  filter(x == sql("ANY VALUES(1, 2, 3)")) %>% 
-  show_query()
-```
+Learn more in `vignette("translation-function")`.

--- a/vignettes/translation-function.Rmd
+++ b/vignettes/translation-function.Rmd
@@ -14,7 +14,6 @@ options(tibble.print_min = 4L, tibble.print_max = 4L)
 
 There are two parts to dbplyr SQL translation: translating dplyr verbs, and translating expressions within those verbs. This vignette describes how individual expressions (function calls) are translated; `vignette("translation-verb")` describes how entire verbs are translated.
 
-
 ```{r, message = FALSE}
 library(dbplyr)
 library(dplyr)
@@ -131,14 +130,67 @@ translate_sql(switch(x, a = 1L, b = 2L, 3L))
 
 ## Unknown functions
 
-Any function that dplyr doesn't know how to convert is left as is. This means that database functions that are not covered by dplyr can be used directly via `translate_sql()`. Here a couple of examples that will work with [SQLite](https://www.sqlite.org/lang_corefunc.html):
+Any function that dplyr doesn't know how to convert is left as is. This means that database functions that are not covered by dplyr can often be used directly via `translate_sql()`. 
+
+### Prefix functions
+
+Any function that dbplyr doesn't know about will be left as is:
 
 ```{r}
-translate_sql(glob(x, y))
-translate_sql(x %like% "ab%")
+translate_sql(foofify(x, y))
 ```
 
-See `vignette("sql")` for more details.
+Because SQL functions are general case insensitive, I recommend using upper case when you're using SQL functions in R code. That makes it easier to spot that you're doing something unusual:
+
+```{r}
+translate_sql(FOOFIFY(x, y))
+```
+
+### Infix functions
+
+As well as prefix functions (where the name of the function comes before the arguments), dbplyr also translates infix functions. That allows you to use expressions like `LIKE` which does a limited form of pattern matching:
+
+```{r}
+translate_sql(x %LIKE% "%foo%")
+```
+
+Or use `||` for string concatenation (although most backends will translate `paste()` and `paste0()` for you):
+
+```{r}
+translate_sql(x %||% y)
+```
+
+### Special forms
+
+SQL functions tend to have a greater variety of syntax than R. That means there are a number of expressions that can't be translated directly from R code. To insert these in your own queries, you can use literal SQL inside `sql()`:
+
+```{r}
+translate_sql(sql("x!"))
+translate_sql(x == sql("ANY VALUES(1, 2, 3)"))
+```
+
+This gives you a lot of freedom to generate the SQL you need: 
+
+```{r}
+mf <- memdb_frame(x = 1, y = 2)
+
+mf %>% 
+  transmute(factorial = sql("x!")) %>% 
+  show_query()
+
+mf %>% 
+  transmute(factorial = sql("CAST(x AS FLOAT)")) %>% 
+  show_query()
+```
+
+### Error for unknown translations
+
+If needed, you can also force dbplyr to error if it doesn't know how to translate a function with the `dplyr.strict_sql` option:
+
+```{r, error = TRUE}
+options(dplyr.strict_sql = TRUE)
+translate_sql(glob(x, y))
+```
 
 ## Window functions
 

--- a/vignettes/translation-function.Rmd
+++ b/vignettes/translation-function.Rmd
@@ -25,7 +25,7 @@ library(dplyr)
 translate_sql((x + y) / 2)
 ```
 
-`translate_sql()` takes an optional `con` parameter. If not supplied, this causes dplyr to generate (approximately) SQL-92 compliant SQL. If supplied, dplyr uses `sql_translate_env()` to look up a custom environment which makes it possible for different databases to generate slightly different SQL: see `vignette("new-backend")` for more details.  You can use the various simulate helpers to see the translations used by different backends:
+`translate_sql()` takes an optional `con` parameter. If not supplied, this causes dplyr to generate (approximately) SQL-92 compliant SQL. If supplied, dplyr uses `sql_translation()` to look up a custom environment which makes it possible for different databases to generate slightly different SQL: see `vignette("new-backend")` for more details.  You can use the various simulate helpers to see the translations used by different backends:
 
 ```{r}
 translate_sql(x ^ 2L)


### PR DESCRIPTION
This started out as a simple fix for #782, but then I discovered:

* The `translate_sql()` docs were rather out of date, and should mostly just point to `vignette("function-translation")`
* That vignette would also be a more appropriate place to mention `dplyr.strict_sql`.
* The current error in strict mode wasn't very informative and could easily be made better.
* `vignette("SQL")` went into way too much detail about what happens when functions couldn't be translated, and that would also be more appropriate `vignette("function-translation")`.