### PR TITLE
Use name = NULL default for sql_query_wrap()

### DIFF
--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -107,7 +107,7 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 }
 
 #' @export
-sql_query_wrap.Oracle <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
+sql_query_wrap.Oracle <- function(con, from, name = NULL, ..., lvl = 0) {
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
     build_sql("(", from, ") ", if (!is.null(name)) ident(name), con = con)

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -110,7 +110,7 @@ sql_escape_logical.SQLiteConnection <- function(con, x){
 }
 
 #' @export
-sql_query_wrap.SQLiteConnection <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
+sql_query_wrap.SQLiteConnection <- function(con, from, name = NULL, ..., lvl = 0) {
   if (is.ident(from)) {
     setNames(from, name)
   } else {

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -185,11 +185,11 @@ sql_query_save.DBIConnection <- function(con, sql, name, temporary = TRUE, ...) 
 }
 #' @export
 #' @rdname db-sql
-sql_query_wrap <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
+sql_query_wrap <- function(con, from, name = NULL, ..., lvl = 0) {
   UseMethod("sql_query_wrap")
 }
 #' @export
-sql_query_wrap.DBIConnection <- function(con, from, name = unique_subquery_name(), ..., lvl = 0) {
+sql_query_wrap.DBIConnection <- function(con, from, name = NULL, ..., lvl = 0) {
   if (is.ident(from)) {
     setNames(from, name)
   } else if (is.schema(from)) {

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -35,7 +35,7 @@ sql_query_fields(con, sql, ...)
 
 sql_query_save(con, sql, name, temporary = TRUE, ...)
 
-sql_query_wrap(con, from, name = unique_subquery_name(), ..., lvl = 0)
+sql_query_wrap(con, from, name = NULL, ..., lvl = 0)
 
 sql_indent_subquery(from, con, lvl)
 

--- a/tests/testthat/_snaps/backend-.md
+++ b/tests/testthat/_snaps/backend-.md
@@ -61,7 +61,7 @@
     Code
       sql_query_wrap(con, sql("SELECT * FROM foo"))
     Output
-      <SQL> (SELECT * FROM foo) `q03`
+      <SQL> (SELECT * FROM foo) `q01`
 
 ---
 


### PR DESCRIPTION
`unique_subquery_name()` is private, do we really want to expose it?