### PR TITLE
Highlight keywords in `show_query()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Depends:
 Imports: 
     assertthat (>= 0.2.0),
     blob (>= 1.2.0),
+    cli,
     DBI (>= 1.0.0),
     dplyr (>= 1.0.6),
     glue (>= 1.2.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     tibble (>= 1.4.2),
     tidyselect (>= 0.2.4),
     utils,
-    vctrs (>= 0.4.0),
+    vctrs (>= 0.4.1),
     withr
 Suggests:
     bit64,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* `show_query()` now creates more readable queries by printing the most common
+  keywords in blue (@mgirlich, #644).
+
 * `mutate()` and `transmute()` now automatically use named windows if a window
   definition is used at least twice and the backend supports named windows
   (@mgirlich, #624).

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -77,14 +77,11 @@ last_value_sql.Hive <- function(con, x) {
 sql_query_set_op.Hive <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   # SQLite does not allow parentheses
   method <- paste0(method, if (all) " ALL")
-  if (dbplyr_use_colour()) {
-    method <- cli::col_blue(method)
-  }
   # `x` and `y` already have the correct indent, so use `build_sql()` instead
   # of `sql_format_clauses()`
   build_sql(
     x, "\n",
-    indent_lvl(method, lvl = lvl), "\n",
+    indent_lvl(style_kw(method), lvl = lvl), "\n",
     y,
     con = con
   )

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -77,6 +77,9 @@ last_value_sql.Hive <- function(con, x) {
 sql_query_set_op.Hive <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   # SQLite does not allow parentheses
   method <- paste0(method, if (all) " ALL")
+  if (dbplyr_use_colour()) {
+    method <- cli::col_blue(method)
+  }
   # `x` and `y` already have the correct indent, so use `build_sql()` instead
   # of `sql_format_clauses()`
   build_sql(

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -409,9 +409,7 @@ sql_query_set_op <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
 #' @export
 sql_query_set_op.DBIConnection <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   method <- paste0(method, if (all) " ALL")
-  if (dbplyr_use_colour()) {
-    method <- cli::col_blue(method)
-  }
+  method <- style_kw(method)
   lines <- list(
     sql_indent_subquery(x, con = con, lvl = lvl),
     sql(method),

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -409,6 +409,9 @@ sql_query_set_op <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
 #' @export
 sql_query_set_op.DBIConnection <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
   method <- paste0(method, if (all) " ALL")
+  if (dbplyr_use_colour()) {
+    method <- cli::col_blue(method)
+  }
   lines <- list(
     sql_indent_subquery(x, con = con, lvl = lvl),
     sql(method),

--- a/R/escape.R
+++ b/R/escape.R
@@ -174,10 +174,7 @@ names_to_as <- function(x, names = names2(x), con = NULL) {
   }
 
   names_esc <- sql_escape_ident(con, names)
-  as_sql <- " AS "
-  if (dbplyr_use_colour()) {
-    as_sql <- cli::col_blue(as_sql)
-  }
+  as_sql <- style_kw(" AS ")
   as <- ifelse(names == "" | names_esc == x, "", paste0(as_sql, names_esc))
 
   paste0(x, as)

--- a/R/escape.R
+++ b/R/escape.R
@@ -174,7 +174,11 @@ names_to_as <- function(x, names = names2(x), con = NULL) {
   }
 
   names_esc <- sql_escape_ident(con, names)
-  as <- ifelse(names == "" | names_esc == x, "", paste0(" AS ", names_esc))
+  as_sql <- " AS "
+  if (dbplyr_use_colour()) {
+    as_sql <- cli::col_blue(as_sql)
+  }
+  as <- ifelse(names == "" | names_esc == x, "", paste0(as_sql, names_esc))
 
   paste0(x, as)
 }

--- a/R/explain.R
+++ b/R/explain.R
@@ -1,6 +1,7 @@
 #' @importFrom dplyr show_query
 #' @export
 show_query.tbl_lazy <- function(x, ..., cte = FALSE) {
+  withr::local_options(list(dbplyr_use_colour = TRUE))
   sql <- remote_query(x, cte = cte)
   cat_line("<SQL>")
   cat_line(sql)

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -96,10 +96,7 @@ cte_render <- function(query_list, con) {
   )
   cte_query <- sql_vector(unname(ctes), parens = FALSE, collapse = ",\n", con = con)
 
-  with_sql <- "WITH "
-  if (dbplyr_use_colour()) {
-    with_sql <- cli::col_blue(with_sql)
-  }
+  with_sql <- style_kw("WITH ")
   build_sql(sql(with_sql), cte_query, "\n", query_list[[n]], con = con)
 }
 

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -96,7 +96,11 @@ cte_render <- function(query_list, con) {
   )
   cte_query <- sql_vector(unname(ctes), parens = FALSE, collapse = ",\n", con = con)
 
-  build_sql("WITH ", cte_query, "\n", query_list[[n]], con = con)
+  with_sql <- "WITH "
+  if (dbplyr_use_colour()) {
+    with_sql <- cli::col_blue(with_sql)
+  }
+  build_sql(sql(with_sql), cte_query, "\n", query_list[[n]], con = con)
 }
 
 get_subquery_name <- function(x, query_list) {

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -91,7 +91,7 @@ cte_render <- function(query_list, con) {
 
   ctes <- purrr::imap(query_list[-n],
     function(query, name) {
-      build_sql(ident(name), " AS (\n", sql(query), "\n)", con = con)
+      build_sql(ident(name), sql(style_kw(" AS")), " (\n", sql(query), "\n)", con = con)
     }
   )
   cte_query <- sql_vector(unname(ctes), parens = FALSE, collapse = ",\n", con = con)

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -112,8 +112,8 @@ sql_format_clause <- function(x, lvl, con, nchar_max = 80) {
   lvl <- lvl + x$lvl
 
   # check length without starting a new line
-  if (dbplyr_use_colour() && x$sep == " AND") {
-    x$sep <- cli::col_blue(x$sep)
+  if (x$sep == " AND") {
+    x$sep <- style_kw(x$sep)
   }
 
   fields_same_line <- escape(x$parts, collapse = paste0(x$sep, " "), con = con)
@@ -121,9 +121,7 @@ sql_format_clause <- function(x, lvl, con, nchar_max = 80) {
     fields_same_line <- paste0("(", fields_same_line, ")")
   }
 
-  if (dbplyr_use_colour()) {
-    x$kw <- cli::col_blue(x$kw)
-  }
+  x$kw <- style_kw(x$kw)
   same_line_clause <- paste0(x$kw, " ", fields_same_line)
   nchar_same_line <- cli::ansi_nchar(lvl_indent(lvl)) + cli::ansi_nchar(same_line_clause)
 

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -112,12 +112,20 @@ sql_format_clause <- function(x, lvl, con, nchar_max = 80) {
   lvl <- lvl + x$lvl
 
   # check length without starting a new line
+  if (dbplyr_use_colour() && x$sep == " AND") {
+    x$sep <- cli::col_blue(x$sep)
+  }
+
   fields_same_line <- escape(x$parts, collapse = paste0(x$sep, " "), con = con)
   if (x$parens) {
     fields_same_line <- paste0("(", fields_same_line, ")")
   }
+
+  if (dbplyr_use_colour()) {
+    x$kw <- cli::col_blue(x$kw)
+  }
   same_line_clause <- paste0(x$kw, " ", fields_same_line)
-  nchar_same_line <- nchar(lvl_indent(lvl)) + nchar(same_line_clause)
+  nchar_same_line <- cli::ansi_nchar(lvl_indent(lvl)) + cli::ansi_nchar(same_line_clause)
 
   if (length(x$parts) == 1 || nchar_same_line <= nchar_max) {
     return(sql(same_line_clause))

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -21,6 +21,14 @@ indent_print <- function(x) {
   indent(utils::capture.output(print(x)))
 }
 
+style_kw <- function(x) {
+  if (dbplyr_use_colour()) {
+    cli::col_blue(x)
+  } else {
+    x
+  }
+}
+
 # function for the thousand separator,
 # returns "," unless it's used for the decimal point, in which case returns "."
 'big_mark' <- function(x, ...) {

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -27,3 +27,7 @@ indent_print <- function(x) {
   mark <- if (identical(getOption("OutDec"), ",")) "." else ","
   formatC(x, big.mark = mark, ...)
 }
+
+dbplyr_use_colour <- function() {
+  getOption("dbplyr_use_colour", FALSE) && cli::num_ansi_colors() > 1L
+}

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -50,3 +50,33 @@
       SELECT `x`
       FROM `df`
 
+# 
+
+    Code
+      show_query(out, cte = TRUE)
+    Condition
+      [1m[33mWarning[39m:[22m
+      Missing values are always removed in SQL.
+      Use `AVG(x, na.rm = TRUE)` to silence this warning
+      This warning is displayed only once per session.
+    Output
+      <SQL>
+      [34mWITH [39m`q01`[34m AS[39m (
+        [34mSELECT[39m `x`, AVG(`y`) OVER (PARTITION BY `x`)[34m AS [39m`y`, `z` + 1.0[34m AS [39m`z`
+        [34mFROM[39m `df`
+      ),
+      `q02`[34m AS[39m (
+        [34mSELECT[39m *
+        [34mFROM[39m `q01`
+        [34mWHERE[39m (`z` = 1.0)
+      )
+      [34mSELECT[39m
+        `LHS`.`x`[34m AS [39m`x`,
+        `LHS`.`y`[34m AS [39m`y.x`,
+        `LHS`.`z`[34m AS [39m`z.x`,
+        `RHS`.`y`[34m AS [39m`y.y`,
+        `RHS`.`z`[34m AS [39m`z.y`
+      [34mFROM[39m `q02`[34m AS [39m`LHS`
+      [34mLEFT JOIN[39m `df`[34m AS [39m`RHS`
+        [34mON[39m (`LHS`.`x` = `RHS`.`x`)
+

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -122,7 +122,7 @@ test_that("mutate collapses over nested select", {
   expect_snapshot(lf %>% mutate(a = 1, b = 2) %>% select(x))
 })
 
-test_that("", {
+test_that("output is styled", {
   local_reproducible_output(crayon = TRUE)
 
   lf <- lazy_frame(x = 1, y = 1, z = 1)

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -122,6 +122,19 @@ test_that("mutate collapses over nested select", {
   expect_snapshot(lf %>% mutate(a = 1, b = 2) %>% select(x))
 })
 
+test_that("", {
+  local_reproducible_output(crayon = TRUE)
+
+  lf <- lazy_frame(x = 1, y = 1, z = 1)
+  out <- lf %>%
+    group_by(x) %>%
+    mutate(y = mean(y), z = z + 1) %>%
+    filter(z == 1) %>%
+    left_join(lf, by = "x")
+
+  expect_snapshot(show_query(out, cte = TRUE))
+})
+
 # sql_build -------------------------------------------------------------
 
 test_that("select picks variables", {


### PR DESCRIPTION
Closes #644.
It uses a global option to avoid having to add an argument `colour` to lots of functions (as proposed by Hadley https://github.com/tidyverse/dbplyr/issues/644#issuecomment-1095590348). Probably, this misses some places but I like how simple this was to add.