### PR TITLE
Fix too strict check of `frame` in `lazy_query()`

### DIFF
--- a/R/lazy-query.R
+++ b/R/lazy-query.R
@@ -8,7 +8,7 @@ lazy_query <- function(query_type,
                        frame = op_frame(x)) {
   # stopifnot(is.null(group_vars) || (is.character(group_vars) && is.null(names(group_vars))))
   stopifnot(is_lazy_sql_part(order_vars), is.null(names(order_vars)))
-  stopifnot(is.null(frame) || is_integerish(frame$range, n = 2, finite = TRUE))
+  stopifnot(is.null(frame) || is_integerish(frame$range, n = 2))
 
   structure(
     list(

--- a/tests/testthat/_snaps/translate-sql-window.md
+++ b/tests/testthat/_snaps/translate-sql-window.md
@@ -24,6 +24,19 @@
       SELECT `x`, `y`, SUM(`y`) OVER (ORDER BY `x` ROWS 3 PRECEDING) AS `z`
       FROM `df`
 
+---
+
+    Code
+      lf %>% window_frame(-3) %>% window_order(x) %>% mutate(z = sum(y)) %>%
+        show_query()
+    Output
+      <SQL>
+      SELECT
+        `x`,
+        `y`,
+        SUM(`y`) OVER (ORDER BY `x` ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING) AS `z`
+      FROM `df`
+
 # window_frame() checks arguments
 
     Code

--- a/tests/testthat/test-translate-sql-window.R
+++ b/tests/testthat/test-translate-sql-window.R
@@ -144,6 +144,14 @@ test_that("window_frame()", {
       mutate(z = sum(y)) %>%
       show_query()
   )
+
+  expect_snapshot(
+    lf %>%
+      window_frame(-3) %>%
+      window_order(x) %>%
+      mutate(z = sum(y)) %>%
+      show_query()
+  )
 })
 
 test_that("window_frame() checks arguments", {


### PR DESCRIPTION
It checks that `frame` is finite but this is not necessarily the case. There was no test yet but I stumbled over it when working on support for `HAVING`.