### PR TITLE
Make example data generators return invisibly

### DIFF
--- a/R/data-lahman.R
+++ b/R/data-lahman.R
@@ -71,7 +71,7 @@ copy_lahman <- function(con, ...) {
     copy_to(con, df, table, indexes = ids, temporary = FALSE)
   }
 
-  con
+  invisble(con)
 }
 # Get list of all non-label data frames in package
 lahman_tables <- function() {

--- a/R/data-nycflights13.R
+++ b/R/data-nycflights13.R
@@ -75,6 +75,6 @@ copy_nycflights13 <- function(con, ...) {
       temporary = FALSE
     )
   }
-  con
+  invisible(con)
 }
 # nocov end


### PR DESCRIPTION
Since these are called primarily for their side-effects they should return their first argument invisibly. Fixes #862