### PR TITLE
Use `tbl()` in `tbl_src_dbi()`

### DIFF
--- a/R/src_dbi.R
+++ b/R/src_dbi.R
@@ -89,8 +89,8 @@ tbl.src_dbi <- function(src, from, ...) {
 # The former may query the database for column names if `vars` is omitted,
 # the latter always requires `vars`.
 tbl_src_dbi <- function(src, from, vars) {
-  subclass <- class(src$con)[[1]] # prefix added by dplyr::make_tbl
-  tbl_sql_impl(c(subclass, "dbi"), src, from, vars)
+  force(vars)
+  tbl(src, from, vars = vars)
 }
 
 


### PR DESCRIPTION
Fixes #889.
It still makes sense to use `tbl_src_dbi()` to make sure the `vars` argument is provided but we should keep the dispatch via `tbl()`.