### PR TITLE
Fix `semi/anti_join()` for Spark

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `semi_join()` and `anti_join()` work again for Spark (@mgirlich, #915).
+
 * `sd()`, `var()`, `cor()` and `cov()` now give clear error messages on 
   databases that don't support them.
   

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -383,9 +383,6 @@ sql_query_semi_join.DBIConnection <- function(con, x, y, anti = FALSE, by = NULL
   x <- dbplyr_sql_subquery(con, x, name = by$x_as)
   y <- dbplyr_sql_subquery(con, y, name = by$y_as)
 
-  lhs <- escape(ident(by$x_as), con = con)
-  rhs <- escape(ident(by$y_as), con = con)
-
   on <- sql_join_tbls(con, by)
 
   lines <- list(

--- a/dbplyr.Rproj
+++ b/dbplyr.Rproj
@@ -17,6 +17,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source --install-tests
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Fixes #915.