### PR TITLE
`compute()` can handle schema

### DIFF
--- a/R/verb-compute.R
+++ b/R/verb-compute.R
@@ -39,7 +39,9 @@ compute.tbl_sql <- function(x,
                             analyze = TRUE,
                             ...,
                             cte = FALSE) {
-  name <- unname(name)
+  if (is_bare_character(x) || is.ident(x) || is.sql(x)) {
+    name <- unname(name)
+  }
   vars <- op_vars(x)
   assert_that(all(unlist(indexes) %in% vars))
   assert_that(all(unlist(unique_indexes) %in% vars))
@@ -55,7 +57,7 @@ compute.tbl_sql <- function(x,
     ...
   )
 
-  tbl_src_dbi(x$src, as.sql(name), colnames(x)) %>%
+  tbl_src_dbi(x$src, as.sql(name, x$src$con), colnames(x)) %>%
     group_by(!!!syms(op_grps(x))) %>%
     window_order(!!!op_sort(x))
 }

--- a/tests/testthat/test-verb-compute.R
+++ b/tests/testthat/test-verb-compute.R
@@ -84,6 +84,18 @@ test_that("compute can handle named name", {
   )
 })
 
+test_that("compute can handle schema", {
+  df <- memdb_frame(x = 1:10)
+  on.exit(DBI::dbRemoveTable(remote_con(df), "db1"))
+
+  expect_equal(
+    df %>%
+      compute(name = in_schema("main", "db1"), temporary = FALSE) %>%
+      collect(),
+    tibble(x = 1:10)
+  )
+})
+
 # ops ---------------------------------------------------------------------
 
 test_that("sorting preserved across compute and collapse", {


### PR DESCRIPTION
Fixes #938.