### PR TITLE
Evaluate `sql()` locally

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* A call to `sql()` is now translated differently. The `...` are now evaluated
+  locally instead of being translated with `translate_sql()` (@mgirlich, #952).
+
 * Fixed an installation issue due to missing namespace for `setOldClass()`
   (@mgirlich, #927).
 

--- a/R/backend-.R
+++ b/R/backend-.R
@@ -164,7 +164,6 @@ base_scalar <- sql_translator(
   switch = function(x, ...) sql_switch(x, ...),
   case_when = function(...) sql_case_when(...),
 
-  sql = function(...) sql(...),
   `(` = function(x) {
     sql_expr(((!!x)))
   },

--- a/R/translate-sql.R
+++ b/R/translate-sql.R
@@ -177,6 +177,12 @@ sql_data_mask <- function(expr, variant, con, window = FALSE,
     }
   }
 
+  special_calls2$sql <- function(...) {
+    dots <- exprs(...)
+    dots <- purrr::map(dots, eval_tidy, env = top_env)
+    exec(sql, !!!dots)
+  }
+
   # Existing symbols in expression
   names <- all_names(expr)
   idents <- lapply(names, ident)

--- a/tests/testthat/test-translate-sql.R
+++ b/tests/testthat/test-translate-sql.R
@@ -76,6 +76,18 @@ test_that("user infix functions are translated", {
   expect_equal(translate_sql(x %like% y), sql("`x` like `y`"))
 })
 
+test_that("sql() evaluates input locally", {
+  a <- "x"
+  expect_equal(translate_sql(a), sql("`a`"))
+  expect_equal(translate_sql(sql(a)), sql("x"))
+
+  f <- function() {
+    a <- "y"
+    translate_sql(sql(paste0(a)))
+  }
+  expect_equal(f(), sql("y"))
+})
+
 # casts -------------------------------------------------------------------
 
 test_that("casts as expected", {


### PR DESCRIPTION
Fixes #952.

``` r
library(dbplyr)
library(dplyr, warn.conflicts = FALSE)

lazy_frame(x = 1) %>% 
  mutate(x = sql(paste0("x")))

# Before
#> <SQL>
#> SELECT CONCAT_WS('', 'x') AS `x`
#> FROM `df`

# After
#> <SQL>
#> SELECT x AS `x`
#> FROM `df`
```