### PR TITLE
Shim for redshift values table support

### DIFF
--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -256,9 +256,14 @@ sql_values_subquery_column_alias <- function(con, df, lvl) {
 sql_values_clause <- function(con, df, row = FALSE) {
   escaped_values <- purrr::map(df, escape, con = con, collapse = NULL, parens = FALSE)
   rows <- rlang::exec(paste, !!!escaped_values, sep = ", ")
-  rows_sql <- sql(paste0(if (row) "ROW", "(", rows, ")"))
 
-  list(sql_clause("VALUES", rows_sql))
+  if (inherits(con, "Redshift")) {
+    rows_sql <- sql(paste0("SELECT ", rows, collapse = " UNION ALL "))
+    list(sql_clause("", rows_sql))
+  } else {
+    rows_sql <- sql(paste0(if (row) "ROW", "(", rows, ")"))
+    list(sql_clause("VALUES", rows_sql))
+  }
 }
 
 sql_values_zero_rows <- function(con, df, lvl) {


### PR DESCRIPTION
fixes #949 

```r
copy_inline(con, head(mtcars[c("mpg", "cyl", "disp")])) %>% show_query()
```

before:
```sql
<SQL>
SELECT
  CAST("mpg" AS FLOAT) AS "mpg",
  CAST("cyl" AS FLOAT) AS "cyl",
  CAST("disp" AS FLOAT) AS "disp"
FROM (
  (
    SELECT NULL AS "mpg", NULL AS "cyl", NULL AS "disp"
    WHERE (0 = 1)
  )
  UNION ALL
  (
  VALUES
    (21.0, 6.0, 160.0),
    (21.0, 6.0, 160.0),
    (22.8, 4.0, 108.0),
    (21.4, 6.0, 258.0),
    (18.7, 8.0, 360.0),
    (18.1, 6.0, 225.0)
  )
) "values_table"
```


after:
```sql
<SQL>
SELECT
  CAST("mpg" AS FLOAT) AS "mpg",
  CAST("cyl" AS FLOAT) AS "cyl",
  CAST("disp" AS FLOAT) AS "disp"
FROM (
  (
    SELECT NULL AS "mpg", NULL AS "cyl", NULL AS "disp"
    WHERE (0 = 1)
  )
  UNION ALL
  ( SELECT 21.0, 6.0, 160.0 UNION ALL SELECT 21.0, 6.0, 160.0 UNION ALL SELECT 22.8, 4.0, 108.0 UNION ALL SELECT 21.4, 6.0, 258.0 UNION ALL SELECT 18.7, 8.0, 360.0 UNION ALL SELECT 18.1, 6.0, 225.0)
) "values_table"
```