### PR TITLE
Wrap DBI errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* Errors produced by the database, e.g. in `collect()` or `rows_*()`, now show
+  the verb where the error happened (@mgirlich).
+
 * Using a named `across()` now gives a clear error message (@mgirlich, #761).
 
 * `cur_column()` is now supported (@mgirlich, #951).

--- a/R/rows.R
+++ b/R/rows.R
@@ -775,12 +775,19 @@ rows_insert_prep <- function(con, x_name, y, by, lvl = 0) {
   out
 }
 
-rows_get_or_execute <- function(x, sql, returning_cols) {
+rows_get_or_execute <- function(x, sql, returning_cols, call = caller_env()) {
   con <- remote_con(x)
+  msg <- "Can't modify database table {.val {remote_name(x)}}."
   if (is_empty(returning_cols)) {
-    dbExecute(con, sql, immediate = TRUE)
+    safe_db_execute(con, sql, immediate = TRUE, .msg = msg, .call = call)
   } else {
-    returned_rows <- dbGetQuery(con, sql, immediate = TRUE)
+    returned_rows <- safe_db_get_query(
+      con = con,
+      sql = sql,
+      immediate = TRUE,
+      .msg = msg,
+      .call = call
+    )
     x <- set_returned_rows(x, returned_rows)
   }
 

--- a/R/verb-compute.R
+++ b/R/verb-compute.R
@@ -81,6 +81,12 @@ collect.tbl_sql <- function(x, ..., n = Inf, warn_incomplete = TRUE, cte = FALSE
   }
 
   sql <- db_sql_render(x$src$con, x, cte = cte)
-  out <- db_collect(x$src$con, sql, n = n, warn_incomplete = warn_incomplete)
+  call <- current_env()
+  tryCatch(
+    out <- db_collect(x$src$con, sql, n = n, warn_incomplete = warn_incomplete),
+    error = function(cnd) {
+      cli_abort("Can't collect lazy table.", parent = cnd, call = call)
+    }
+  )
   dplyr::grouped_df(out, intersect(op_grps(x), names(out)))
 }

--- a/tests/testthat/_snaps/backend-postgres.md
+++ b/tests/testthat/_snaps/backend-postgres.md
@@ -102,7 +102,9 @@
       rows_insert(x, y, by = c("a", "b"), in_place = TRUE, conflict = "ignore",
       returning = everything(), method = "on_conflict")
     Condition
-      Error:
+      Error in `rows_insert()`:
+      ! Can't modify database table "df_x".
+      Caused by error:
       ! Failed to fetch row: ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 
 # can upsert with returning
@@ -111,6 +113,8 @@
       rows_upsert(x, y, by = c("a", "b"), in_place = TRUE, returning = everything(),
       method = "on_conflict")
     Condition
-      Error:
+      Error in `rows_upsert()`:
+      ! Can't modify database table "df_x".
+      Caused by error:
       ! Failed to fetch row: ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
 

--- a/tests/testthat/test-db-sql.R
+++ b/tests/testthat/test-db-sql.R
@@ -19,3 +19,14 @@ test_that("sql_query_rows() works", {
     sql("SELECT COUNT(*) FROM `abc` AS `master`")
   )
 })
+
+test_that("handles DBI error", {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+
+  expect_error(db_analyze(con, "tbl"), class = "dbplyr_error_dbi")
+  expect_error(db_create_index(con, "tbl", "col"), class = "dbplyr_error_dbi")
+
+  expect_error(db_explain(con, "invalid sql"), class = "dbplyr_error_dbi")
+  expect_error(db_query_fields(con, "does not exist"), class = "dbplyr_error_dbi")
+  expect_error(db_save_query(con, "invalid sql", "tbl"), class = "dbplyr_error_dbi")
+})

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -42,4 +42,3 @@ test_that("can retrieve query, src and con metadata", {
   expect_s3_class(remote_query(mf), "sql")
   expect_type(remote_query_plan(mf), "character")
 })
-

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -154,6 +154,34 @@ test_that("`rows_insert()` with `in_place = TRUE` and `returning`", {
   expect_equal(df_inserted %>% collect(), tibble(x = 1:4, y = c(11:13, 24L)))
 })
 
+test_that("rows_get_or_execute() gives error context", {
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbWriteTable(con, "mtcars", tibble(x = 1, y = 1), overwrite = TRUE, temporary = TRUE)
+  DBI::dbExecute(con, "CREATE UNIQUE INDEX `mtcars_x` ON `mtcars` (`x`)")
+
+  expect_error(
+    rows_append(
+      tbl(con, "mtcars"),
+      tibble(x = 1),
+      copy = TRUE,
+      in_place = TRUE
+    ),
+    class = "dbplyr_error_dbi"
+  )
+
+  expect_error(
+    rows_append(
+      tbl(con, "mtcars"),
+      tibble(x = 1),
+      copy = TRUE,
+      in_place = TRUE,
+      returning = x
+    ),
+    class = "dbplyr_error_dbi"
+  )
+})
+
 test_that("`sql_query_insert()` works", {
   df_y <- lazy_frame(
     a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"),

--- a/tests/testthat/test-verb-compute.R
+++ b/tests/testthat/test-verb-compute.R
@@ -96,6 +96,14 @@ test_that("compute can handle schema", {
   )
 })
 
+test_that("collect() handles DBI error", {
+  mf <- memdb_frame(x = 1)
+  expect_error(
+    mf %>% mutate(a = sql("invalid sql")) %>% collect(),
+    regexp = "Can't collect lazy table"
+  )
+})
+
 # ops ---------------------------------------------------------------------
 
 test_that("sorting preserved across compute and collapse", {


### PR DESCRIPTION
This PR catches errors produced by the database (i.e. by `dbGetQuery()` and `dbExecute()`) and wraps them to produce more informative errors.

``` r
library(dbplyr)
library(dplyr, warn.conflicts = FALSE)

con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")

DBI::dbWriteTable(con, "mtcars", tibble(x = 1, y = 1))
DBI::dbExecute(con, sql_table_index(con, "mtcars", "x", unique = TRUE))
#> [1] 0

rows_append(
  tbl(con, "mtcars"),
  tibble(x = 1),
  copy = TRUE,
  in_place = TRUE
)
# Before
#> Error: UNIQUE constraint failed: mtcars.x

# After
#> Error in `rows_append()`:
#> ! Can't modify database table "mtcars".
#> Caused by error:
#> ! UNIQUE constraint failed: mtcars.x
```

<sup>Created on 2022-08-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>