### PR TITLE
Add option to control keyword highlighting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dbplyr (development version)
 
+* The keyword highlighting can now be customised via the option `dbplyr_highlight`.
+  Turn it off via `options(dbplyr_highlight = FALSE)` or pass a custom ansi
+  style, e.g. `options(dbplyr_highlight = cli::combine_ansi_styles("bold", "cyan"))`
+  (@mgirlich, #974).
+
 * Querying Teradata databases works again. Unfortunately, the fix requires every
   column to be explicitly selected again (@mgirlich, #966).
 

--- a/R/explain.R
+++ b/R/explain.R
@@ -1,7 +1,6 @@
 #' @importFrom dplyr show_query
 #' @export
 show_query.tbl_lazy <- function(x, ..., cte = FALSE) {
-  withr::local_options(list(dbplyr_use_colour = TRUE))
   sql <- remote_query(x, cte = cte)
   cat_line("<SQL>")
   cat_line(sql)

--- a/R/explain.R
+++ b/R/explain.R
@@ -1,6 +1,7 @@
 #' @importFrom dplyr show_query
 #' @export
 show_query.tbl_lazy <- function(x, ..., cte = FALSE) {
+  withr::local_options(list(dbplyr_use_colour = TRUE))
   sql <- remote_query(x, cte = cte)
   cat_line("<SQL>")
   cat_line(sql)

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -22,11 +22,12 @@ indent_print <- function(x) {
 }
 
 style_kw <- function(x) {
-  if (dbplyr_use_colour()) {
-    cli::col_blue(x)
-  } else {
-    x
+  highlight <- dbplyr_highlight()
+  if (is_false(highlight)) {
+    return(x)
   }
+
+  highlight(x)
 }
 
 # function for the thousand separator,
@@ -36,6 +37,21 @@ style_kw <- function(x) {
   formatC(x, big.mark = mark, ...)
 }
 
-dbplyr_use_colour <- function() {
-  getOption("dbplyr_use_colour", FALSE)
+dbplyr_highlight <- function() {
+  highlight <- getOption("dbplyr_highlight", cli::combine_ansi_styles("blue"))
+
+  if (is_true(highlight)) {
+    highlight <- cli::combine_ansi_styles("blue")
+  }
+
+  if (is_false(highlight)) {
+    return(FALSE)
+  }
+
+  if (!inherits(highlight, "cli_ansi_style")) {
+    msg <- "{.envvar dbplyr_highlight} must be `NULL`, `FALSE` or a {.cls cli_ansi_style}."
+    cli::cli_abort(msg)
+  }
+
+  highlight
 }

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -22,6 +22,10 @@ indent_print <- function(x) {
 }
 
 style_kw <- function(x) {
+  if (!dbplyr_use_colour()) {
+    return(x)
+  }
+
   highlight <- dbplyr_highlight()
   if (is_false(highlight)) {
     return(x)
@@ -35,6 +39,10 @@ style_kw <- function(x) {
 'big_mark' <- function(x, ...) {
   mark <- if (identical(getOption("OutDec"), ",")) "." else ","
   formatC(x, big.mark = mark, ...)
+}
+
+dbplyr_use_colour <- function() {
+  getOption("dbplyr_use_colour", FALSE)
 }
 
 dbplyr_highlight <- function() {

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -248,6 +248,7 @@ test_that("mutate collapses over nested select", {
 
 test_that("output is styled", {
   local_reproducible_output(crayon = TRUE)
+  withr::local_options(dbplyr_highlight = cli::combine_ansi_styles("blue"))
 
   lf <- lazy_frame(x = 1, y = 1, z = 1)
   out <- lf %>%


### PR DESCRIPTION
Fixes #974.

It would be even nicer if we could detect a dark theme ourselves but cli does not export `detect_dark_theme()`.
Where should this be documented so that users can easily find it?