### PR TITLE
Reuse query for joins and set ops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* When using common table expressions the results of joins and set operations
+  are now reused (@mgirlich, #978).
+
 * Querying Teradata databases works again. Unfortunately, the fix requires every
   column to be explicitly selected again (@mgirlich, #966).
 

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -144,12 +144,7 @@ flatten_query.join_query <- function(qry, query_list) {
   query_list_y <- flatten_query(y, query_list_x)
   qry$y <- get_subquery_name(y, query_list_y)
 
-  name <- unique_subquery_name()
-  wrapped_query <- set_names(list(qry), name)
-
-  query_list$queries <- c(query_list_y$queries, wrapped_query)
-  query_list$name <- name
-  query_list
+  querylist_reuse_query(qry, query_list_y)
 }
 
 #' @export

--- a/tests/testthat/_snaps/verb-joins.md
+++ b/tests/testthat/_snaps/verb-joins.md
@@ -98,3 +98,21 @@
       Error in `inner_join()`:
       ! `suffix` must have size 2, not size 1.
 
+# joins reuse queries in cte mode
+
+    Code
+      left_join(lf, lf) %>% remote_query(cte = TRUE)
+    Message
+      Joining, by = "x"
+    Output
+      <SQL> WITH `q01` AS (
+        SELECT `lf1_LHS`.`x` AS `x`
+        FROM `lf1` AS `lf1_LHS`
+        INNER JOIN `lf1` AS `lf1_RHS`
+          ON (`lf1_LHS`.`x` = `lf1_RHS`.`x`)
+      )
+      SELECT `LHS`.`x` AS `x`
+      FROM `q01` AS `LHS`
+      LEFT JOIN `q01` AS `RHS`
+        ON (`LHS`.`x` = `RHS`.`x`)
+

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -625,6 +625,20 @@ test_that("full_join() does not use *", {
   )
 })
 
+test_that("joins reuse queries in cte mode", {
+  lf1 <- lazy_frame(x = 1, .name = "lf1")
+  lf <- lf1 %>%
+    inner_join(lf1, by = "x")
+
+  expect_snapshot(
+    left_join(
+      lf,
+      lf
+    ) %>%
+      remote_query(cte = TRUE)
+  )
+})
+
 # ops ---------------------------------------------------------------------
 
 test_that("joins get vars from both left and right", {


### PR DESCRIPTION
Fixes #978. The logic was already used for `select_query`. It seems I simply forgot to use it for joins and set op queries.