### PR TITLE
Add parentheses to snowflake grepl pattern

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,10 +11,6 @@
     `str_remove_all()`, `str_trim()`, `str_squish()` and `str_flatten()`
     (@fh-afrachioni, #860).
 
-* New translations for Teradata: `as.Date()`, `week()`, `quarter()`, `paste()`,
-  `startsWith()`, `row_number()`, `weighted.mean()`, `lead()`, `lag()`, and
-  `cumsum()` (@overmar, #913).
-
 * `copy_inline()` now works for Hana (#950), Oracle (#972), and Redshift
   (#949, thanks to @ejneer for an initial implementation).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
     `str_remove_all()`, `str_trim()`, `str_squish()` and `str_flatten()`
     (@fh-afrachioni, #860).
 
-`as.Date()`, `week()`, `quarter()`, `paste()`,
+* New translations for Teradata: `as.Date()`, `week()`, `quarter()`, `paste()`,
   `startsWith()`, `row_number()`, `weighted.mean()`, `lead()`, `lag()`, and
   `cumsum()` (@overmar, #913).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # dbplyr (development version)
 
+* New translations for Snowflake:
+  * numeric functions: `all()`, `any()`, `log10()`, `round()`, `cor()`, `cov()`
+    and `sd()`.
+  * date functions: `day()`, `mday()`, `wday()`, `yday()`, `week()`,
+    `isoweek()`, `month()`, `quarter()`, `isoyear()`, `seconds()`, `minutes()`,
+    `hours()`, `days()`, `weeks()`, `months()`, `years()` and `floor_date()`.
+  * string functions: `grepl()`, `paste()`, `paste0()`, `str_c()`, `str_locate()`,
+    `str_detect()`, `str_replace()`, `str_replace_all()`, `str_remove()`,
+    `str_remove_all()`, `str_trim()`, `str_squish()` and `str_flatten()`
+    (@fh-afrachioni, #860).
+
+`as.Date()`, `week()`, `quarter()`, `paste()`,
+  `startsWith()`, `row_number()`, `weighted.mean()`, `lead()`, `lag()`, and
+  `cumsum()` (@overmar, #913).
+
 * `copy_inline()` now works for Hana (#950), Oracle (#972), and Redshift
   (#949, thanks to @ejneer for an initial implementation).
 

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -232,7 +232,7 @@ snowflake_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed
   # REGEXP on Snowflaake "implicitly anchors a pattern at both ends", which
   # grepl does not.  Left- and right-pad `pattern` with .* to get grepl-like
   # behavior
-  sql_expr(((!!x)) %REGEXP% (".*" || (!!pattern) || ".*"))
+  sql_expr(((!!x)) %REGEXP% (".*" || !!paste0('(', pattern, ')') || ".*"))
 }
 snowflake_round <- function(x, digits = 0L) {
   digits <- as.integer(digits)

--- a/tests/testthat/test-test-backend-snowflake.R
+++ b/tests/testthat/test-test-backend-snowflake.R
@@ -2,7 +2,7 @@ test_that("custom scalar translated correctly", {
   local_con(simulate_snowflake())
   expect_equal(translate_sql(log10(x)), sql("LOG(10.0, `x`)"))
   expect_equal(translate_sql(round(x, digits = 1.1)), sql("ROUND((`x`) :: FLOAT, 1)"))
-  expect_equal(translate_sql(grepl("exp", x)),        sql("(`x`) REGEXP ('.*' || 'exp' || '.*')"))
+  expect_equal(translate_sql(grepl("exp", x)),        sql("(`x`) REGEXP ('.*' || '(exp)' || '.*')"))
   expect_error(translate_sql(grepl("exp", x, ignore.case = TRUE)),
                "`perl`, `fixed`, `useBytes`, and `ignore.case` parameters are unsupported.")
 })


### PR DESCRIPTION
Surrounds `pattern` with parentheses for `snowflake_grepl`, due to `.*` on either end.  Fixes patterns like `'a|b'`, which should match `'cabbage'` but do not (translates to `REGEXP ('.*' || ('a|b') || '.*)` instead of `REGEXP ('.*' || '(a|b)' || '.*')`