### PR TITLE
Add default value for collapse arg for str_flatten

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,9 @@
 
 * `pivot_wider()` works again for MS SQL (@mgirlich, #929).
 
+* `str_flatten()` uses `collapse = ""` by default, consistent with `stringr`,
+  for Snowflake, Redshift, Postgres, and MySQL (@fh-afrachioni, #993).
+
 # dbplyr 2.2.1
 
 * Querying Oracle databases works again. Unfortunately, the fix requires every

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -80,7 +80,7 @@ sql_translation.MariaDBConnection <- function(con) {
     sql_translator(.parent = base_agg,
       sd =  sql_aggregate("STDDEV_SAMP", "sd"),
       var = sql_aggregate("VAR_SAMP", "var"),
-      str_flatten = function(x, collapse) {
+      str_flatten = function(x, collapse = "") {
         sql_expr(group_concat(!!x %separator% !!collapse))
       }
     ),

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -208,7 +208,9 @@ sql_translation.PqConnection <- function(con) {
       var = sql_aggregate("VAR_SAMP", "var"),
       all = sql_aggregate("BOOL_AND", "all"),
       any = sql_aggregate("BOOL_OR", "any"),
-      str_flatten = function(x, collapse) sql_expr(string_agg(!!x, !!collapse))
+      str_flatten = function(x, collapse = "") {
+        sql_expr(string_agg(!!x, !!collapse))
+      }
     ),
     sql_translator(.parent = base_win,
       cor = win_aggregate_2("CORR"),
@@ -217,7 +219,7 @@ sql_translation.PqConnection <- function(con) {
       var = win_aggregate("VAR_SAMP"),
       all = win_aggregate("BOOL_AND"),
       any = win_aggregate("BOOL_OR"),
-      str_flatten = function(x, collapse) {
+      str_flatten = function(x, collapse = "") {
         win_over(
           sql_expr(string_agg(!!x, !!collapse)),
           partition = win_current_group(),

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -58,7 +58,7 @@ sql_translation.RedshiftConnection <- function(con) {
     ),
     sql_translator(.parent = postgres$aggregate,
       # https://docs.aws.amazon.com/redshift/latest/dg/r_LISTAGG.html
-      str_flatten = function(x, collapse){
+      str_flatten = function(x, collapse = "") {
         sql_expr(LISTAGG(!!x, !!collapse))
       }
     ),
@@ -82,7 +82,7 @@ sql_translation.RedshiftConnection <- function(con) {
         )
       },
       # https://docs.aws.amazon.com/redshift/latest/dg/r_LISTAGG.html
-      str_flatten = function(x, collapse) {
+      str_flatten = function(x, collapse = "") {
         order <- win_current_order()
         if(length(order) > 0){
           sql <- build_sql(sql_expr(LISTAGG(!!x, !!collapse)),

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -194,7 +194,9 @@ sql_translation.Snowflake <- function(con) {
       all = sql_aggregate("BOOLAND_AGG", "all"),
       any = sql_aggregate("BOOLOR_AGG", "any"),
       sd = sql_aggregate("STDDEV", "sd"),
-      str_flatten = function(x, collapse) sql_expr(LISTAGG(!!x, !!collapse))
+      str_flatten = function(x, collapse = "") {
+        sql_expr(LISTAGG(!!x, !!collapse))
+      }
     ),
     sql_translator(
       .parent = base_win,
@@ -203,7 +205,7 @@ sql_translation.Snowflake <- function(con) {
       all = win_aggregate("BOOLAND_AGG"),
       any = win_aggregate("BOOLOR_AGG"),
       sd = win_aggregate("STDDEV"),
-      str_flatten = function(x, collapse) {
+      str_flatten = function(x, collapse = "") {
         win_over(
           sql_expr(LISTAGG(!!x, !!collapse)),
           partition = win_current_group(),

--- a/tests/testthat/test-test-backend-snowflake.R
+++ b/tests/testthat/test-test-backend-snowflake.R
@@ -17,7 +17,7 @@ test_that("pasting translated correctly", {
 
   expect_error(translate_sql(paste0(x, collapse = "")), "`collapse` not supported")
 
-  expect_error(translate_sql(str_flatten(x)), 'argument "collapse" is missing, with no default')
+  expect_equal(translate_sql(str_flatten(x), window = TRUE), sql("LISTAGG(`x`, '') OVER ()"))
   expect_equal(translate_sql(str_flatten(x, collapse = "|"), window = TRUE), sql("LISTAGG(`x`, '|') OVER ()"))
   expect_equal(translate_sql(str_flatten(x, collapse = "|"), window = FALSE), sql("LISTAGG(`x`, '|')"))
 })


### PR DESCRIPTION
Adds `collapse = ''` as the default for `str_flatten` for postgres, snowflake, redshift, and mysql.  This is the behavior of `stringr::str_flatten`.