### PR TITLE
Add `...` to generics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-gb
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Collate: 
     'utils.R'
     'sql.R'

--- a/R/backend-.R
+++ b/R/backend-.R
@@ -11,7 +11,7 @@
 NULL
 
 #' @export
-sql_translation.DBIConnection <- function(con) {
+sql_translation.DBIConnection <- function(con, ...) {
   sql_variant(
     base_scalar,
     base_agg,
@@ -492,7 +492,7 @@ base_no_win <- sql_translator(
 )
 
 #' @export
-sql_random.DBIConnection <- function(con) {
+sql_random.DBIConnection <- function(con, ...) {
   sql_expr(RANDOM())
 }
 

--- a/R/backend-access.R
+++ b/R/backend-access.R
@@ -57,7 +57,7 @@ sql_query_select.ACCESS <- function(con, select, from,
 }
 
 #' @export
-sql_translation.ACCESS <- function(con) {
+sql_translation.ACCESS <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_scalar,
       # Much of this translation comes from: https://www.techonthenet.com/access/functions/
@@ -164,7 +164,7 @@ sql_table_analyze.ACCESS <- function(con, table, ...) {
 # Util -------------------------------------------
 
 #' @export
-sql_escape_logical.ACCESS <- function(con, x) {
+sql_escape_logical.ACCESS <- function(con, x, ...) {
   # Access uses a convention of -1 as True and 0 as False
   y <- ifelse(x, -1, 0)
   y[is.na(x)] <- "NULL"
@@ -172,7 +172,7 @@ sql_escape_logical.ACCESS <- function(con, x) {
 }
 
 #' @export
-sql_escape_date.ACCESS <-  function(con, x) {
+sql_escape_date.ACCESS <-  function(con, x, ...) {
   # Access delimits dates using octothorpes, and uses YYYY-MM-DD
   y <- format(x, "#%Y-%m-%d#")
   y[is.na(x)] <- "NULL"
@@ -180,7 +180,7 @@ sql_escape_date.ACCESS <-  function(con, x) {
 }
 
 #' @export
-sql_escape_datetime.ACCESS <-  function(con, x) {
+sql_escape_datetime.ACCESS <-  function(con, x, ...) {
   # Access delimits datetimes using octothorpes, and uses YYYY-MM-DD HH:MM:SS
   # Timezones are not supported in Access
   y <- format(x, "#%Y-%m-%d %H:%M:%S#")
@@ -189,7 +189,7 @@ sql_escape_datetime.ACCESS <-  function(con, x) {
 }
 
 #' @export
-supports_window_clause.ACCESS <- function(con) {
+supports_window_clause.ACCESS <- function(con, ...) {
   TRUE
 }
 

--- a/R/backend-hana.R
+++ b/R/backend-hana.R
@@ -33,7 +33,7 @@ dbplyr_edition.HDB <- function(con) {
 }
 
 #' @export
-sql_translation.HDB <- function(con) {
+sql_translation.HDB <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_scalar,
       as.character = sql_cast("SHORTTEXT"),
@@ -57,7 +57,7 @@ sql_translation.HDB <- function(con) {
 
 # nocov start
 #' @export
-db_table_temporary.HDB <- function(con, table, temporary) {
+db_table_temporary.HDB <- function(con, table, temporary, ...) {
   if (temporary && substr(table, 1, 1) != "#") {
     table <- hash_temp(table)
   }

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -32,7 +32,7 @@ dbplyr_edition.Hive <- function(con) {
 }
 
 #' @export
-sql_translation.Hive <- function(con) {
+sql_translation.Hive <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_odbc_scalar,
       bitwShiftL    = sql_prefix("SHIFTLEFT", 2),
@@ -88,7 +88,7 @@ sql_query_set_op.Hive <- function(con, x, y, method, ..., all = FALSE, lvl = 0) 
 }
 
 #' @export
-supports_window_clause.Hive <- function(con) {
+supports_window_clause.Hive <- function(con, ...) {
   TRUE
 }
 

--- a/R/backend-impala.R
+++ b/R/backend-impala.R
@@ -28,7 +28,7 @@ dbplyr_edition.Impala <- function(con) {
 }
 
 #' @export
-sql_translation.Impala <- function(con) {
+sql_translation.Impala <- function(con, ...) {
   sql_variant(
     scalar = sql_translator(.parent = base_odbc_scalar,
       bitwNot       = sql_prefix("BITNOT", 1),

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -201,7 +201,7 @@ simulate_mssql <- function(version = "15.0") {
 }
 
 #' @export
-`sql_translation.Microsoft SQL Server` <- function(con) {
+`sql_translation.Microsoft SQL Server` <- function(con, ...) {
   mssql_scalar <-
     sql_translator(.parent = base_odbc_scalar,
 
@@ -384,7 +384,7 @@ mssql_version <- function(con) {
 }
 
 #' @export
-`sql_escape_raw.Microsoft SQL Server` <- function(con, x) {
+`sql_escape_raw.Microsoft SQL Server` <- function(con, x, ...) {
   # SQL Server binary constants should be prefixed with 0x
   # https://docs.microsoft.com/en-us/sql/t-sql/data-types/constants-transact-sql?view=sql-server-ver15#binary-constants
   paste0(c("0x", format(x)), collapse = "")
@@ -400,7 +400,7 @@ mssql_version <- function(con) {
 # temporary table names with #
 # <https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms177399%28v%3dsql.105%29#temporary-tables>
 #' @export
-`db_table_temporary.Microsoft SQL Server` <- function(con, table, temporary) {
+`db_table_temporary.Microsoft SQL Server` <- function(con, table, temporary, ...) {
   if (temporary && substr(table, 1, 1) != "#") {
     table <- hash_temp(table)
   }
@@ -427,7 +427,7 @@ mssql_version <- function(con) {
 `sql_values_subquery.Microsoft SQL Server` <- sql_values_subquery_column_alias
 
 #' @export
-`sql_random.Microsoft SQL Server` <- function(con) {
+`sql_random.Microsoft SQL Server` <- function(con, ...) {
   sql_expr(RAND())
 }
 
@@ -506,7 +506,7 @@ mssql_case_when <- function(...) {
 }
 
 #' @export
-`sql_escape_logical.Microsoft SQL Server` <- function(con, x) {
+`sql_escape_logical.Microsoft SQL Server` <- function(con, x, ...) {
   if (mssql_needs_bit()) {
     y <- ifelse(x, "1", "0")
   } else {

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -36,7 +36,7 @@ dbplyr_edition.MySQL <- dbplyr_edition.MariaDBConnection
 dbplyr_edition.MySQLConnection <- dbplyr_edition.MariaDBConnection
 
 #' @export
-db_connection_describe.MariaDBConnection <- function(con) {
+db_connection_describe.MariaDBConnection <- function(con, ...) {
   info <- dbGetInfo(con)
 
   paste0(
@@ -51,7 +51,7 @@ db_connection_describe.MySQL <- db_connection_describe.MariaDBConnection
 db_connection_describe.MySQLConnection <- db_connection_describe.MariaDBConnection
 
 #' @export
-sql_translation.MariaDBConnection <- function(con) {
+sql_translation.MariaDBConnection <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_scalar,
       as.logical = function(x) {
@@ -122,7 +122,7 @@ sql_query_join.MySQLConnection <- sql_query_join.MariaDBConnection
 
 
 #' @export
-sql_expr_matches.MariaDBConnection <- function(con, x, y) {
+sql_expr_matches.MariaDBConnection <- function(con, x, y, ...) {
   # https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_equal-to
   build_sql(x, " <=> ", y, con = con)
 }
@@ -142,7 +142,7 @@ sql_values_subquery.MySQL <- sql_values_subquery.MariaDBConnection
 sql_values_subquery.MySQLConnection <- sql_values_subquery.MariaDBConnection
 
 #' @export
-sql_random.MariaDBConnection <- function(con) {
+sql_random.MariaDBConnection <- function(con, ...) {
   sql_expr(RAND())
 }
 #' @export
@@ -174,7 +174,7 @@ sql_query_update_from.MySQLConnection <- sql_query_update_from.MariaDBConnection
 sql_query_update_from.MySQL <- sql_query_update_from.MariaDBConnection
 
 #' @export
-supports_window_clause.MariaDBConnection <- function(con) {
+supports_window_clause.MariaDBConnection <- function(con, ...) {
   TRUE
 }
 #' @export

--- a/R/backend-odbc.R
+++ b/R/backend-odbc.R
@@ -29,7 +29,7 @@ dbplyr_edition.OdbcConnection <- function(con) {
 }
 
 #' @export
-sql_translation.OdbcConnection <- function(con) {
+sql_translation.OdbcConnection <- function(con, ...) {
   sql_variant(
     base_odbc_scalar,
     base_odbc_agg,
@@ -66,7 +66,7 @@ base_odbc_win <- sql_translator(
 
 # nocov start
 #' @export
-db_connection_describe.OdbcConnection <- function(con) {
+db_connection_describe.OdbcConnection <- function(con, ...) {
   info <- DBI::dbGetInfo(con)
 
   host <- if (info$servername == "") "localhost" else info$servername

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -98,7 +98,7 @@ sql_query_upsert.Oracle <- function(con,
 }
 
 #' @export
-sql_translation.Oracle <- function(con) {
+sql_translation.Oracle <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_odbc_scalar,
       # Data type conversions are mostly based on this article
@@ -179,18 +179,18 @@ setdiff.tbl_Oracle <- function(x, y, copy = FALSE, ...) {
 }
 
 #' @export
-sql_expr_matches.Oracle <- function(con, x, y) {
+sql_expr_matches.Oracle <- function(con, x, y, ...) {
   # https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions040.htm
   build_sql("decode(", x, ", ", y, ", 0, 1) = 0", con = con)
 }
 
 #' @export
-supports_star_without_alias.Oracle <- function(con) {
+supports_star_without_alias.Oracle <- function(con, ...) {
   FALSE
 }
 
 #' @export
-sql_random.Oracle <- function(con) {
+sql_random.Oracle <- function(con, ...) {
   sql_expr(dbms_random.RANDOM())
 }
 

--- a/R/backend-postgres-old.R
+++ b/R/backend-postgres-old.R
@@ -58,7 +58,7 @@ sql_expr_matches.PostgreSQLConnection <- sql_expr_matches.PqConnection
 sql_query_explain.PostgreSQLConnection <- sql_query_explain.PqConnection
 
 #' @export
-supports_window_clause.PostgreSQLConnection <- function(con) {
+supports_window_clause.PostgreSQLConnection <- function(con, ...) {
   TRUE
 }
 

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -37,7 +37,7 @@ dbplyr_edition.PostgreSQL <- function(con) {
 dbplyr_edition.PqConnection <- dbplyr_edition.PostgreSQL
 
 #' @export
-db_connection_describe.PqConnection <- function(con) {
+db_connection_describe.PqConnection <- function(con, ...) {
   info <- dbGetInfo(con)
   host <- if (info$host == "") "localhost" else info$host
 
@@ -65,7 +65,7 @@ postgres_round <- function(x, digits = 0L) {
 }
 
 #' @export
-sql_translation.PqConnection <- function(con) {
+sql_translation.PqConnection <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_scalar,
       bitwXor = sql_infix("#"),
@@ -233,7 +233,7 @@ sql_translation.PqConnection <- function(con) {
 sql_translation.PostgreSQL <- sql_translation.PqConnection
 
 #' @export
-sql_expr_matches.PqConnection <- function(con, x, y) {
+sql_expr_matches.PqConnection <- function(con, x, y, ...) {
   # https://www.postgresql.org/docs/current/functions-comparison.html
   build_sql(x, " IS NOT DISTINCT FROM ", y, con = con)
 }
@@ -342,12 +342,12 @@ sql_values_subquery.PqConnection <- sql_values_subquery_column_alias
 sql_values_subquery.PostgreSQL <- sql_values_subquery.PqConnection
 
 #' @export
-supports_window_clause.PqConnection <- function(con) {
+supports_window_clause.PqConnection <- function(con, ...) {
   TRUE
 }
 
 #' @export
-supports_window_clause.PostgreSQL <- function(con) {
+supports_window_clause.PostgreSQL <- function(con, ...) {
   TRUE
 }
 

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -35,7 +35,7 @@ redshift_round <- function(x, digits = 0L) {
 }
 
 #' @export
-sql_translation.RedshiftConnection <- function(con) {
+sql_translation.RedshiftConnection <- function(con, ...) {
   postgres <- sql_translation.PostgreSQL(con)
 
   sql_variant(
@@ -134,7 +134,7 @@ sql_values_subquery.Redshift <- function(con, df, types, lvl = 0, ...) {
 sql_values_subquery.RedshiftConnection <- sql_values_subquery.Redshift
 
 #' @export
-supports_window_clause.Redshift <- function(con) {
+supports_window_clause.Redshift <- function(con, ...) {
   FALSE
 }
 

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -17,7 +17,7 @@
 NULL
 
 #' @export
-sql_translation.Snowflake <- function(con) {
+sql_translation.Snowflake <- function(con, ...) {
   sql_variant(
     sql_translator(
       .parent = base_odbc_scalar,

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -33,7 +33,7 @@ dbplyr_edition.SQLiteConnection <- function(con) {
 }
 
 #' @export
-db_connection_describe.SQLiteConnection <- function(con) {
+db_connection_describe.SQLiteConnection <- function(con, ...) {
   paste0("sqlite ", sqlite_version(), " [", con@dbname, "]")
 }
 
@@ -55,7 +55,7 @@ sqlite_version <- function() {
 # SQL methods -------------------------------------------------------------
 
 #' @export
-sql_translation.SQLiteConnection <- function(con) {
+sql_translation.SQLiteConnection <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_scalar,
       as.numeric = sql_cast("REAL"),
@@ -108,7 +108,7 @@ sql_translation.SQLiteConnection <- function(con) {
 }
 
 #' @export
-sql_escape_logical.SQLiteConnection <- function(con, x){
+sql_escape_logical.SQLiteConnection <- function(con, x, ...){
   y <- as.character(as.integer(x))
   y[is.na(x)] <- "NULL"
   y
@@ -129,7 +129,7 @@ sql_query_wrap.SQLiteConnection <- function(con, from, name = NULL, ..., lvl = 0
 }
 
 #' @export
-sql_expr_matches.SQLiteConnection <- function(con, x, y) {
+sql_expr_matches.SQLiteConnection <- function(con, x, y, ...) {
   # https://sqlite.org/lang_expr.html#isisnot
   build_sql(x, " IS ", y, con = con)
 }
@@ -188,7 +188,7 @@ values_prepare.SQLiteConnection <- function(con, df) {
 }
 
 #' @export
-supports_window_clause.SQLiteConnection <- function(con) {
+supports_window_clause.SQLiteConnection <- function(con, ...) {
   TRUE
 }
 

--- a/R/backend-teradata.R
+++ b/R/backend-teradata.R
@@ -53,7 +53,7 @@ sql_query_select.Teradata <- function(con, select, from, where = NULL,
 }
 
 #' @export
-sql_translation.Teradata <- function(con) {
+sql_translation.Teradata <- function(con, ...) {
   sql_variant(
     sql_translator(.parent = base_odbc_scalar,
       `!=`          = sql_infix("<>"),
@@ -165,7 +165,7 @@ sql_table_analyze.Teradata <- function(con, table, ...) {
 }
 
 #' @export
-supports_star_without_alias.Teradata <- function(con) {
+supports_star_without_alias.Teradata <- function(con, ...) {
   FALSE
 }
 

--- a/R/db-escape.R
+++ b/R/db-escape.R
@@ -20,11 +20,11 @@ NULL
 
 #' @rdname db-quote
 #' @export
-sql_escape_logical <- function(con, x) {
+sql_escape_logical <- function(con, x, ...) {
   UseMethod("sql_escape_logical")
 }
 #' @export
-sql_escape_logical.DBIConnection <- function(con, x) {
+sql_escape_logical.DBIConnection <- function(con, x, ...) {
   y <- as.character(x)
   y[is.na(x)] <- "NULL"
   y
@@ -32,32 +32,32 @@ sql_escape_logical.DBIConnection <- function(con, x) {
 
 #' @export
 #' @rdname db-quote
-sql_escape_date <- function(con, x) {
+sql_escape_date <- function(con, x, ...) {
   UseMethod("sql_escape_date")
 }
 #' @export
-sql_escape_date.DBIConnection <- function(con, x) {
+sql_escape_date.DBIConnection <- function(con, x, ...) {
   sql_escape_string(con, as.character(x))
 }
 
 #' @export
 #' @rdname db-quote
-sql_escape_datetime <- function(con, x) {
+sql_escape_datetime <- function(con, x, ...) {
   UseMethod("sql_escape_datetime")
 }
 #' @export
-sql_escape_datetime.DBIConnection <- function(con, x) {
+sql_escape_datetime.DBIConnection <- function(con, x, ...) {
   x <- strftime(x, "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")
   sql_escape_string(con, x)
 }
 
 #' @export
 #' @rdname db-quote
-sql_escape_raw <- function(con, x) {
+sql_escape_raw <- function(con, x, ...) {
   UseMethod("sql_escape_raw")
 }
 #' @export
-sql_escape_raw.DBIConnection <- function(con, x) {
+sql_escape_raw.DBIConnection <- function(con, x, ...) {
   # SQL-99 standard for BLOB literals
   # https://crate.io/docs/sql-99/en/latest/chapters/05.html#blob-literal-s
   paste0(c("X'", format(x), "'"), collapse = "")

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -156,10 +156,10 @@ db_write_table.DBIConnection <- function(con,
 
 # Utility functions ------------------------------------------------------------
 
-dbi_quote <- function(x, con) UseMethod("dbi_quote")
-dbi_quote.ident <- function(x, con) DBI::dbQuoteIdentifier(con, as.character(x))
-dbi_quote.character <- function(x, con) DBI::dbQuoteString(con, x)
-dbi_quote.sql <- function(x, con) DBI::SQL(as.character(x)) # nocov
+dbi_quote <- function(x, con, ...) UseMethod("dbi_quote")
+dbi_quote.ident <- function(x, con, ...) DBI::dbQuoteIdentifier(con, as.character(x))
+dbi_quote.character <- function(x, con, ...) DBI::dbQuoteString(con, x)
+dbi_quote.sql <- function(x, con, ...) DBI::SQL(as.character(x)) # nocov
 
 create_indexes <- function(con, table, indexes = NULL, unique = FALSE, ...) {
   if (is.null(indexes)) {
@@ -189,11 +189,11 @@ with_transaction <- function(con, in_transaction, code) {
 
 #' @export
 #' @rdname db-io
-db_table_temporary <- function(con, table, temporary) {
+db_table_temporary <- function(con, table, temporary, ...) {
   UseMethod("db_table_temporary")
 }
 #' @export
-db_table_temporary.DBIConnection <- function(con, table, temporary) {
+db_table_temporary.DBIConnection <- function(con, table, temporary, ...) {
   list(
     table = table,
     temporary = temporary

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -93,12 +93,12 @@ NULL
 
 #' @export
 #' @rdname db-sql
-sql_expr_matches <- function(con, x, y) {
+sql_expr_matches <- function(con, x, y, ...) {
   UseMethod("sql_expr_matches")
 }
 # https://modern-sql.com/feature/is-distinct-from
 #' @export
-sql_expr_matches.DBIConnection <- function(con, x, y) {
+sql_expr_matches.DBIConnection <- function(con, x, y, ...) {
   build_sql(
     "CASE WHEN (", x, " = ", y, ") OR (", x, " IS NULL AND ", y, " IS NULL) ",
     "THEN 0 ",
@@ -110,22 +110,22 @@ sql_expr_matches.DBIConnection <- function(con, x, y) {
 
 #' @export
 #' @rdname db-sql
-sql_translation <- function(con) {
+sql_translation <- function(con, ...) {
   UseMethod("sql_translation")
 }
 # sql_translation.DBIConnection lives in backend-.R
-dbplyr_sql_translation <- function(con) {
+dbplyr_sql_translation <- function(con, ...) {
   dbplyr_fallback(con, "sql_translate_env")
 }
 #' @importFrom dplyr sql_translate_env
 #' @export
-sql_translate_env.DBIConnection <- function(con) {
+sql_translate_env.DBIConnection <- function(con, ...) {
   sql_translation(con)
 }
 
 #' @export
 #' @rdname db-sql
-sql_random <- function(con) {
+sql_random <- function(con, ...) {
   UseMethod("sql_random")
 }
 
@@ -253,23 +253,23 @@ sql_query_rows.DBIConnection <- function(con, sql, ...) {
 
 #' @rdname db-sql
 #' @export
-supports_window_clause <- function(con) {
+supports_window_clause <- function(con, ...) {
   UseMethod("supports_window_clause")
 }
 
 #' @export
-supports_window_clause.DBIConnection <- function(con) {
+supports_window_clause.DBIConnection <- function(con, ...) {
   FALSE
 }
 
 #' @rdname db-sql
 #' @export
-supports_star_without_alias <- function(con) {
+supports_star_without_alias <- function(con, ...) {
   UseMethod("supports_star_without_alias")
 }
 
 #' @export
-supports_star_without_alias.DBIConnection <- function(con) {
+supports_star_without_alias.DBIConnection <- function(con, ...) {
   TRUE
 }
 

--- a/R/db.R
+++ b/R/db.R
@@ -31,12 +31,12 @@ db_desc.DBIConnection <- function(x) {
 }
 #' @export
 #' @rdname db-misc
-db_connection_describe <- function(con) {
+db_connection_describe <- function(con, ...) {
   UseMethod("db_connection_describe")
 }
 # nocov start
 #' @export
-db_connection_describe.DBIConnection <- function(con) {
+db_connection_describe.DBIConnection <- function(con, ...) {
   class(con)[[1]]
 }
 # nocov end

--- a/R/lazy-join-query.R
+++ b/R/lazy-join-query.R
@@ -135,11 +135,11 @@ print.lazy_semi_join_query <- function(x, ...) {
 }
 
 #' @export
-op_vars.lazy_join_query <- function(op) {
+op_vars.lazy_join_query <- function(op, ...) {
   op$vars$alias
 }
 #' @export
-op_vars.lazy_semi_join_query <- function(op) {
+op_vars.lazy_semi_join_query <- function(op, ...) {
   op$vars$name
 }
 

--- a/R/lazy-ops.R
+++ b/R/lazy-ops.R
@@ -69,31 +69,31 @@ sql_build.lazy_base_local_query <- function(op, con, ...) {
 
 #' @export
 #' @rdname lazy_ops
-op_grps <- function(op) UseMethod("op_grps")
+op_grps <- function(op, ...) UseMethod("op_grps")
 #' @export
-op_grps.tbl_lazy <- function(op) op_grps(op$lazy_query)
+op_grps.tbl_lazy <- function(op, ...) op_grps(op$lazy_query)
 #' @export
-op_grps.lazy_query <- function(op) op$group_vars %||% character()
+op_grps.lazy_query <- function(op, ...) op$group_vars %||% character()
 
 # op_vars -----------------------------------------------------------------
 
 #' @export
 #' @rdname lazy_ops
-op_vars <- function(op) UseMethod("op_vars")
+op_vars <- function(op, ...) UseMethod("op_vars")
 #' @export
-op_vars.tbl_lazy <- function(op) op_vars(op$lazy_query)
+op_vars.tbl_lazy <- function(op, ...) op_vars(op$lazy_query)
 #' @export
-op_vars.lazy_base_query <- function(op) op$vars
+op_vars.lazy_base_query <- function(op, ...) op$vars
 
 # op_sort -----------------------------------------------------------------
 
 #' @export
 #' @rdname lazy_ops
-op_sort <- function(op) UseMethod("op_sort")
+op_sort <- function(op, ...) UseMethod("op_sort")
 #' @export
-op_sort.tbl_lazy <- function(op) op_sort(op$lazy_query)
+op_sort.tbl_lazy <- function(op, ...) op_sort(op$lazy_query)
 #' @export
-op_sort.lazy_query <- function(op) {
+op_sort.lazy_query <- function(op, ...) {
   # Renaming (like for groups) cannot be done because:
   # * `order_vars` is a list of quosures
   # * variables needed in sorting can be dropped
@@ -104,11 +104,11 @@ op_sort.lazy_query <- function(op) {
 
 #' @export
 #' @rdname lazy_ops
-op_frame <- function(op) UseMethod("op_frame")
+op_frame <- function(op, ...) UseMethod("op_frame")
 #' @export
-op_frame.tbl_lazy <- function(op) op_frame(op$lazy_query)
+op_frame.tbl_lazy <- function(op, ...) op_frame(op$lazy_query)
 #' @export
-op_frame.lazy_query <- function(op) op$frame
+op_frame.lazy_query <- function(op, ...) op$frame
 
 # Description -------------------------------------------------------------
 
@@ -123,10 +123,10 @@ op_cols <- function(op) {
   length(op_vars(op))
 }
 
-op_desc <- function(op) UseMethod("op_desc")
+op_desc <- function(op, ...) UseMethod("op_desc")
 
 #' @export
-op_desc.lazy_base_remote_query <- function(op) {
+op_desc.lazy_base_remote_query <- function(op, ...) {
   if (is.ident(op$x)) {
     paste0("table<", op$x, ">")
   } else {

--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -167,12 +167,12 @@ named_commas2 <- function(x) {
 }
 
 #' @export
-op_vars.lazy_query <- function(op) {
+op_vars.lazy_query <- function(op, ...) {
   op$select$name
 }
 
 #' @export
-op_desc.lazy_query <- function(op) {
+op_desc.lazy_query <- function(op, ...) {
   "SQL"
 }
 

--- a/R/lazy-set-op-query.R
+++ b/R/lazy-set-op-query.R
@@ -31,7 +31,7 @@ print.lazy_set_op_query <- function(x, ..., con = NULL) {
 }
 
 #' @export
-op_vars.lazy_set_op_query <- function(op) {
+op_vars.lazy_set_op_query <- function(op, ...) {
   union(op_vars(op$x), op_vars(op$y))
 }
 

--- a/R/remote.R
+++ b/R/remote.R
@@ -37,27 +37,27 @@ remote_name <- function(x) {
   lq$x$x
 }
 
-query_name <- function(x) {
+query_name <- function(x, ...) {
   UseMethod("query_name")
 }
 
 #' @export
-query_name.tbl_lazy <- function(x) {
+query_name.tbl_lazy <- function(x, ...) {
   query_name(x$lazy_query)
 }
 
 #' @export
-query_name.lazy_base_remote_query <- function(x) {
+query_name.lazy_base_remote_query <- function(x, ...) {
   x$x
 }
 
 #' @export
-query_name.lazy_base_local_query <- function(x) {
+query_name.lazy_base_local_query <- function(x, ...) {
   ident(x$name)
 }
 
 #' @export
-query_name.lazy_query <- function(x) {
+query_name.lazy_query <- function(x, ...) {
   NULL
 }
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -780,7 +780,7 @@ rows_auto_copy <- function(x, y, copy, call = caller_env()) {
   auto_copy(x, y, copy = copy, types = x_types)
 }
 
-get_col_types <- function(con, name, call) {
+get_col_types <- function(con, name, call, ...) {
   if (is_null(name)) {
     return(NULL)
   }
@@ -789,17 +789,17 @@ get_col_types <- function(con, name, call) {
 }
 
 #' @export
-get_col_types.TestConnection <- function(con, name, call) {
+get_col_types.TestConnection <- function(con, name, call, ...) {
   NULL
 }
 
 #' @export
-get_col_types.DBIConnection <- function(con, name, call) {
+get_col_types.DBIConnection <- function(con, name, call, ...) {
   NULL
 }
 
 #' @export
-get_col_types.PqConnection <- function(con, name, call) {
+get_col_types.PqConnection <- function(con, name, call, ...) {
   res <- DBI::dbSendQuery(con, paste0("SELECT * FROM ", name))
   on.exit(DBI::dbClearResult(res))
   DBI::dbFetch(res, n = 0)

--- a/R/schema.R
+++ b/R/schema.R
@@ -61,12 +61,12 @@ print.dbplyr_catalog <- function(x, ...) {
 }
 
 #' @export
-as.sql.dbplyr_schema <- function(x, con) {
+as.sql.dbplyr_schema <- function(x, con, ...) {
   ident_q(paste0(escape(x$schema, con = con), ".", escape(x$table, con = con)))
 }
 
 #' @export
-as.sql.dbplyr_catalog <- function(x, con) {
+as.sql.dbplyr_catalog <- function(x, con, ...) {
   ident_q(paste0(
     escape(x$catalog, con = con), ".", escape(x$schema, con = con), ".", escape(x$table, con = con)
   ))
@@ -79,7 +79,7 @@ is_catalog <- function(x) inherits(x, "dbplyr_catalog")
 # Support for DBI::Id() ---------------------------------------------------
 
 #' @export
-as.sql.Id <- function(x, con) ident_q(dbQuoteIdentifier(con, x))
+as.sql.Id <- function(x, con, ...) ident_q(dbQuoteIdentifier(con, x))
 
 # Old dbplyr approach -----------------------------------------------------
 

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -23,26 +23,26 @@ simulate_dbi <- function(class = character(), ...) {
 dbplyr_edition.TestConnection <- function(con) 2L
 
 
-sql_escape_ident <- function(con, x) {
+sql_escape_ident <- function(con, x, ...) {
   UseMethod("sql_escape_ident")
 }
 #' @export
-sql_escape_ident.DBIConnection <- function(con, x) {
+sql_escape_ident.DBIConnection <- function(con, x, ...) {
   dbQuoteIdentifier(con, x)
 }
 #' @export
-sql_escape_ident.TestConnection <- function(con, x) {
+sql_escape_ident.TestConnection <- function(con, x, ...) {
   sql_quote(x, "`")
 }
 
-sql_escape_string <- function(con, x) {
+sql_escape_string <- function(con, x, ...) {
   UseMethod("sql_escape_string")
 }
 #' @export
-sql_escape_string.DBIConnection <- function(con, x) {
+sql_escape_string.DBIConnection <- function(con, x, ...) {
   dbQuoteString(con, x)
 }
 #' @export
-sql_escape_string.TestConnection <- function(con, x) {
+sql_escape_string.TestConnection <- function(con, x, ...) {
   sql_quote(x, "'")
 }

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -106,12 +106,12 @@ get_subquery_name <- function(x, query_list) {
   ident(query_list$name)
 }
 
-flatten_query <- function(qry, query_list) {
+flatten_query <- function(qry, query_list, ...) {
   UseMethod("flatten_query")
 }
 
 #' @export
-flatten_query.select_query <- function(qry, query_list) {
+flatten_query.select_query <- function(qry, query_list, ...) {
   from <- qry$from
   query_list <- flatten_query(from, query_list)
 
@@ -135,7 +135,7 @@ querylist_reuse_query <- function(qry, query_list) {
 }
 
 #' @export
-flatten_query.join_query <- function(qry, query_list) {
+flatten_query.join_query <- function(qry, query_list, ...) {
   x <- qry$x
   query_list_x <- flatten_query(x, query_list)
   qry$x <- get_subquery_name(x, query_list_x)
@@ -153,12 +153,12 @@ flatten_query.semi_join_query <- flatten_query.join_query
 flatten_query.set_op_query <- flatten_query.join_query
 
 #' @export
-flatten_query.ident <- function(qry, query_list) {
+flatten_query.ident <- function(qry, query_list, ...) {
   query_list
 }
 
 #' @export
-flatten_query.sql <- function(qry, query_list) {
+flatten_query.sql <- function(qry, query_list, ...) {
   query_list
 }
 

--- a/R/sql.R
+++ b/R/sql.R
@@ -59,11 +59,11 @@ format.sql <- function(x, ...) {
 #' @param x Object to coerce
 #' @param con Needed when `x` is directly supplied from the user so that
 #'   schema specifications can be quoted using the correct identifiers.
-as.sql <- function(x, con) UseMethod("as.sql")
+as.sql <- function(x, con, ...) UseMethod("as.sql")
 
 #' @export
-as.sql.ident <- function(x, con) x
+as.sql.ident <- function(x, con, ...) x
 #' @export
-as.sql.sql <- function(x, con) x
+as.sql.sql <- function(x, con, ...) x
 #' @export
-as.sql.character <- function(x, con) ident(x)
+as.sql.character <- function(x, con, ...) ident(x)

--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -175,7 +175,7 @@ flatten_query.lazy_values_query <- function(qry, query_list) {
 }
 
 #' @export
-op_vars.lazy_values_query <- function(op) {
+op_vars.lazy_values_query <- function(op, ...) {
   colnames(op$x)
 }
 
@@ -371,62 +371,61 @@ sql_values_cast_clauses <- function(con, df, types, na) {
   sql_vector(typed_cols, parens = FALSE, collapse = NULL, con = con)
 }
 
-values_prepare <- function(con, df) {
+values_prepare <- function(con, df, ...) {
   UseMethod("values_prepare")
 }
 
 #' @export
-values_prepare.DBIConnection <- function(con, df) {
+values_prepare.DBIConnection <- function(con, df, ...) {
   df
 }
 
-# This
-sql_cast_dispatch <- function(x) {
+sql_cast_dispatch <- function(x, ...) {
   UseMethod("sql_cast_dispatch")
 }
 
 #' @export
-sql_cast_dispatch.sql <- function(x) {
+sql_cast_dispatch.sql <- function(x, ...) {
   expr(as.character)
 }
 
 #' @export
-sql_cast_dispatch.logical <- function(x) {
+sql_cast_dispatch.logical <- function(x, ...) {
   expr(as.logical)
 }
 
 #' @export
-sql_cast_dispatch.integer <- function(x) {
+sql_cast_dispatch.integer <- function(x, ...) {
   expr(as.integer)
 }
 
 #' @export
-sql_cast_dispatch.numeric <- function(x) {
+sql_cast_dispatch.numeric <- function(x, ...) {
   expr(as.numeric)
 }
 
 #' @export
-sql_cast_dispatch.character <- function(x) {
+sql_cast_dispatch.character <- function(x, ...) {
   expr(as.character)
 }
 
 #' @export
-sql_cast_dispatch.factor <- function(x) {
+sql_cast_dispatch.factor <- function(x, ...) {
   expr(as.character)
 }
 
 #' @export
-sql_cast_dispatch.Date <- function(x) {
+sql_cast_dispatch.Date <- function(x, ...) {
   expr(as.Date)
 }
 
 #' @export
-sql_cast_dispatch.POSIXct <- function(x) {
+sql_cast_dispatch.POSIXct <- function(x, ...) {
   expr(as.POSIXct)
 }
 
 #' @export
-sql_cast_dispatch.integer64 <- function(x) {
+sql_cast_dispatch.integer64 <- function(x, ...) {
   expr(as.integer64)
 }
 

--- a/R/verb-fill.R
+++ b/R/verb-fill.R
@@ -64,7 +64,7 @@ fill.tbl_lazy <- function(.data, ..., .direction = c("down", "up")) {
   )
 }
 
-dbplyr_fill0 <- function(.con, .data, cols_to_fill, order_by_cols, .direction) {
+dbplyr_fill0 <- function(.con, .data, cols_to_fill, order_by_cols, .direction, ...) {
   UseMethod("dbplyr_fill0")
 }
 
@@ -76,10 +76,11 @@ dbplyr_fill0 <- function(.con, .data, cols_to_fill, order_by_cols, .direction) {
 # * teradata: https://docs.teradata.com/r/756LNiPSFdY~4JcCCcR5Cw/V~t1FC7orR6KCff~6EUeDQ
 #' @export
 dbplyr_fill0.DBIConnection <- function(.con,
-                                          .data,
-                                          cols_to_fill,
-                                          order_by_cols,
-                                          .direction) {
+                                       .data,
+                                       cols_to_fill,
+                                       order_by_cols,
+                                       .direction,
+                                       ...) {
   # strategy:
   # 1. construct a window
   # * from the first row to the current row
@@ -190,17 +191,17 @@ dbplyr_fill0.MySQLConnection <- dbplyr_fill0.SQLiteConnection
 dbplyr_fill0.MySQL <- dbplyr_fill0.SQLiteConnection
 
 
-last_value_sql <- function(con, x) {
+last_value_sql <- function(con, x, ...) {
   UseMethod("last_value_sql")
 }
 
 #' @export
-last_value_sql.DBIConnection <- function(con, x) {
+last_value_sql.DBIConnection <- function(con, x, ...) {
   build_sql("LAST_VALUE(", ident(as.character(x)), " IGNORE NULLS)", con = con)
 }
 
 #' @export
-`last_value_sql.Microsoft SQL Server` <- function(con, x) {
+`last_value_sql.Microsoft SQL Server` <- function(con, x, ...) {
   build_sql("LAST_VALUE(", ident(as.character(x)), ") IGNORE NULLS", con = con)
 }
 

--- a/man/db-io.Rd
+++ b/man/db-io.Rd
@@ -34,7 +34,7 @@ db_compute(
 
 db_collect(con, sql, n = -1, warn_incomplete = TRUE, ...)
 
-db_table_temporary(con, table, temporary)
+db_table_temporary(con, table, temporary, ...)
 }
 \description{
 These generics are responsible for getting data into and out of the

--- a/man/db-misc.Rd
+++ b/man/db-misc.Rd
@@ -7,7 +7,7 @@
 \alias{dbplyr_edition}
 \title{Miscellaneous database generics}
 \usage{
-db_connection_describe(con)
+db_connection_describe(con, ...)
 
 sql_join_suffix(con, ...)
 

--- a/man/db-quote.Rd
+++ b/man/db-quote.Rd
@@ -7,13 +7,13 @@
 \alias{sql_escape_raw}
 \title{SQL escaping/quoting generics}
 \usage{
-sql_escape_logical(con, x)
+sql_escape_logical(con, x, ...)
 
-sql_escape_date(con, x)
+sql_escape_date(con, x, ...)
 
-sql_escape_datetime(con, x)
+sql_escape_datetime(con, x, ...)
 
-sql_escape_raw(con, x)
+sql_escape_raw(con, x, ...)
 }
 \description{
 These generics translate individual values into SQL. The core

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -22,11 +22,11 @@
 \alias{sql_returning_cols}
 \title{SQL generation generics}
 \usage{
-sql_expr_matches(con, x, y)
+sql_expr_matches(con, x, y, ...)
 
-sql_translation(con)
+sql_translation(con, ...)
 
-sql_random(con)
+sql_random(con, ...)
 
 sql_table_analyze(con, table, ...)
 
@@ -44,9 +44,9 @@ sql_indent_subquery(from, con, lvl = 0)
 
 sql_query_rows(con, sql, ...)
 
-supports_window_clause(con)
+supports_window_clause(con, ...)
 
-supports_star_without_alias(con)
+supports_star_without_alias(con, ...)
 
 sql_query_select(
   con,

--- a/man/join.tbl_sql.Rd
+++ b/man/join.tbl_sql.Rd
@@ -95,23 +95,30 @@
 \arguments{
 \item{x, y}{A pair of lazy data frames backed by database queries.}
 
-\item{by}{A character vector of variables to join by.
+\item{by}{A character vector of variables to join by or a join specification
+created with \code{\link[dplyr:join_by]{join_by()}}.
 
 If \code{NULL}, the default, \verb{*_join()} will perform a natural join, using all
-variables in common across \code{x} and \code{y}. A message lists the variables so that you
-can check they're correct; suppress the message by supplying \code{by} explicitly.
+variables in common across \code{x} and \code{y}. A message lists the variables so
+that you can check they're correct; suppress the message by supplying \code{by}
+explicitly.
 
-To join by different variables on \code{x} and \code{y}, use a named vector.
-For example, \code{by = c("a" = "b")} will match \code{x$a} to \code{y$b}.
+To join on different variables between \code{x} and \code{y}, use a named vector or a
+\code{\link[dplyr:join_by]{join_by()}} specification. For example, \code{by = c("a" = "b")} and \code{by = join_by(a == b)} will match \code{x$a} to \code{y$b}.
 
-To join by multiple variables, use a vector with length > 1.
-For example, \code{by = c("a", "b")} will match \code{x$a} to \code{y$a} and \code{x$b} to
-\code{y$b}. Use a named vector to match different variables in \code{x} and \code{y}.
-For example, \code{by = c("a" = "b", "c" = "d")} will match \code{x$a} to \code{y$b} and
-\code{x$c} to \code{y$d}.
+To join by multiple variables, use a vector with length >1 or a \code{\link[dplyr:join_by]{join_by()}}
+specification with multiple expressions. For example, \code{by = c("a", "b")}
+and \code{by = join_by(a, b)} will match \code{x$a} to \code{y$a} and \code{x$b} to \code{y$b}. Use
+a named vector to match different variables in \code{x} and \code{y}. For example,
+\code{by = c("a" = "b", "c" = "d")} and \code{by = join_by(a == b, c == d)} will
+match \code{x$a} to \code{y$b} and \code{x$c} to \code{y$d}.
 
-To perform a cross-join, generating all combinations of \code{x} and \code{y},
-use \code{by = character()}.}
+To join on conditions other than equality, like non-equi or rolling joins,
+you'll need to create a join specification with \code{\link[dplyr:join_by]{join_by()}}. See the
+documentation there for details on these types of joins.
+
+To perform a cross-join, generating all combinations of \code{x} and \code{y}, use
+\code{by = character()} or \code{by = join_by()}.}
 
 \item{copy}{If \code{x} and \code{y} are not from the same data source,
 and \code{copy} is \code{TRUE}, then \code{y} will be copied into a

--- a/man/lazy_ops.Rd
+++ b/man/lazy_ops.Rd
@@ -11,13 +11,13 @@
 \usage{
 lazy_base_query(x, vars, class = character(), ...)
 
-op_grps(op)
+op_grps(op, ...)
 
-op_vars(op)
+op_vars(op, ...)
 
-op_sort(op)
+op_sort(op, ...)
 
-op_frame(op)
+op_frame(op, ...)
 }
 \description{
 This set of S3 classes describe the action of dplyr verbs. These are

--- a/man/sql.Rd
+++ b/man/sql.Rd
@@ -10,7 +10,7 @@ sql(...)
 
 is.sql(x)
 
-as.sql(x, con)
+as.sql(x, con, ...)
 }
 \arguments{
 \item{...}{Character vectors that will be combined into a single SQL


### PR DESCRIPTION
Closes #919.

I left out

* `dbplyr_edition()`: simple enough and only one argument
* `simulate_vars()` and `simulate_vars_is_typed()`: they should be removed in the future as we now have `tidyselect_data_has_predicates()` and `tidyselect_data_proxy()`