### PR TITLE
Link to _Reprexes for dbplyr_ in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -5,7 +5,7 @@ about: Describe a bug you've seen or make a case for a new feature
 
 Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
 
-Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>. You can use the examples in [Reprexes for dbplyr](https://dbplyr.tidyverse.org/articles/reprex.html) as a starting point for your reprex.
 
 Brief description of the problem
 


### PR DESCRIPTION
I was trying to debug something with dbplyr and thought: _wouldn't it be great if packages like dbplyr included small examples that could be used for reprexes?_ And I was thrilled to see that dbplyr has exactly this kind of article!

This PR modifies the issue template to link out to that article to increase the likelihood that someone with an issue will find it.