### PR TITLE
Wrap call as list before applying `map()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     magrittr,
     methods,
     pillar (>= 1.5.0),
-    purrr (>= 0.3.5),
+    purrr (>= 1.0.0),
     R6 (>= 2.2.2),
     rlang (>= 1.0.6),
     tibble (>= 1.4.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* Compatibility with purrr 1.0.0 (@mgirlich, #1085).
+
 ## New features
 
 * `stringr::str_like()` (new in 1.5.0) is translated to the closest `LIKE` 

--- a/R/optimise-utils.R
+++ b/R/optimise-utils.R
@@ -21,5 +21,5 @@ expr_uses_var <- function(x, vars) {
     return(is_symbol(x, vars))
   }
 
-  any(purrr::map_lgl(x[-1], expr_uses_var, vars))
+  any(purrr::map_lgl(as.list(x[-1]), expr_uses_var, vars))
 }

--- a/tests/testthat/_snaps/escape.md
+++ b/tests/testthat/_snaps/escape.md
@@ -3,7 +3,9 @@
     Code
       lf %>% filter(a == input$x) %>% show_query()
     Condition
-      Error:
+      Error in `purrr::map_chr()`:
+      i In index: 1.
+      Caused by error:
       ! Cannot translate shiny inputs to SQL.
       i Do you want to force evaluation in R with (e.g.) `!!input$x` or `local(input$x)`?
 

--- a/tests/testthat/_snaps/verb-expand.md
+++ b/tests/testthat/_snaps/verb-expand.md
@@ -97,7 +97,9 @@
     Code
       tidyr::expand(memdb_frame(x = 1, y = 1), nesting(x, x = x + 1))
     Condition
-      Error in `tidyr::expand()`:
+      Error in `purrr::map()`:
+      i In index: 1.
+      Caused by error in `tidyr::expand()`:
       ! Names must be unique.
       x These names are duplicated:
         * "x" at locations 1 and 2.

--- a/tests/testthat/_snaps/verb-pivot-longer.md
+++ b/tests/testthat/_snaps/verb-pivot-longer.md
@@ -111,7 +111,11 @@
       (expect_error(tidyr::pivot_longer(df, x, values_transform = 1)))
     Output
       <error/rlang_error>
-      Error in `dbplyr_pivot_longer_spec()`:
+      Error in `purrr::map()`:
+      i In index: 1.
+      Caused by error in `map2()`:
+      i In index: 1.
+      Caused by error in `dbplyr_pivot_longer_spec()`:
       ! Can't convert to a function.
     Code
       (expect_error(tidyr::pivot_longer(df, x, values_transform = list(~.x))))

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -60,7 +60,9 @@
 
 ---
 
-    Can't convert to a function.
+    i In index: 2.
+    Caused by error in `dbplyr_pivot_wider_spec()`:
+    ! Can't convert to a function.
 
 # values_fn cannot be NULL
 
@@ -76,7 +78,9 @@
       (expect_error(tidyr::pivot_wider(df, id_cols = id, unused_fn = 1)))
     Output
       <error/rlang_error>
-      Error in `dbplyr_pivot_wider_spec()`:
+      Error in `map2()`:
+      i In index: 1.
+      Caused by error in `dbplyr_pivot_wider_spec()`:
       ! Can't convert to a function.
 
 # can fill in missing cells


### PR DESCRIPTION
Using `map()` on calls has been deprecated.