### PR TITLE
Remove field `last_op`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-gb
 Roxygen: {library(tidyr); list(markdown = TRUE)}
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Collate: 
     'utils.R'
     'sql.R'

--- a/R/lazy-join-query.R
+++ b/R/lazy-join-query.R
@@ -31,7 +31,6 @@ lazy_join_query <- function(x,
     group_vars = group_vars,
     order_vars = order_vars,
     frame = frame,
-    last_op = "join"
   )
 }
 
@@ -71,7 +70,6 @@ lazy_multi_join_query <- function(x,
     joins = joins,
     table_names = table_names,
     vars = vars,
-    last_op = "join",
     group_vars = group_vars,
     order_vars = order_vars,
     frame = frame
@@ -144,8 +142,7 @@ lazy_semi_join_query <- function(x,
     vars = vars,
     group_vars = group_vars,
     order_vars = order_vars,
-    frame = frame,
-    last_op = "semi_join"
+    frame = frame
   )
 }
 

--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -12,7 +12,7 @@ lazy_select_query <- function(x,
                               group_vars = NULL,
                               order_vars = NULL,
                               frame = NULL,
-                              select_operation = c("mutate", "summarise"),
+                              select_operation = c("select", "mutate", "summarise"),
                               message_summarise = NULL) {
   stopifnot(inherits(x, "lazy_query"))
   stopifnot(is_string(last_op))
@@ -24,7 +24,7 @@ lazy_select_query <- function(x,
   stopifnot(is.logical(distinct), length(distinct) == 1L)
 
   select <- select %||% syms(set_names(op_vars(x)))
-  select_operation <- arg_match0(select_operation, c("mutate", "summarise"))
+  select_operation <- arg_match0(select_operation, c("select", "mutate", "summarise"))
 
   stopifnot(is.null(message_summarise) || is_string(message_summarise))
 
@@ -33,7 +33,7 @@ lazy_select_query <- function(x,
   order_vars <- order_vars %||% op_sort(x)
   frame <- frame %||% op_frame(x)
 
-  if (last_op == "mutate") {
+  if (select_operation == "mutate") {
     select <- new_lazy_select(
       select,
       group_vars = group_vars,
@@ -70,7 +70,7 @@ is_lazy_sql_part <- function(x) {
   purrr::every(x, ~ is_quosure(.x) || is_symbol(.x) || is_call(.x))
 }
 
-new_lazy_select <- function(vars, group_vars = NULL, order_vars = NULL, frame = NULL) {
+new_lazy_select <- function(vars, group_vars = character(), order_vars = NULL, frame = NULL) {
   vctrs::vec_as_names(names2(vars), repair = "check_unique")
 
   var_names <- names(vars)

--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -1,7 +1,6 @@
 #' @export
 #' @rdname sql_build
 lazy_select_query <- function(x,
-                              last_op,
                               select = NULL,
                               where = NULL,
                               group_by = NULL,
@@ -15,7 +14,6 @@ lazy_select_query <- function(x,
                               select_operation = c("select", "mutate", "summarise"),
                               message_summarise = NULL) {
   stopifnot(inherits(x, "lazy_query"))
-  stopifnot(is_string(last_op))
   stopifnot(is.null(select) || is_lazy_sql_part(select))
   stopifnot(is_lazy_sql_part(where))
   # stopifnot(is.character(group_by))
@@ -54,7 +52,6 @@ lazy_select_query <- function(x,
     distinct = distinct,
     limit = limit,
     select_operation = select_operation,
-    last_op = last_op,
     message_summarise = message_summarise,
     group_vars = group_vars,
     order_vars = order_vars,

--- a/R/verb-arrange.R
+++ b/R/verb-arrange.R
@@ -52,7 +52,6 @@ add_arrange <- function(.data, dots, .by_group) {
 
   new_lazy_query <- lazy_select_query(
     x = lazy_query,
-    last_op = "arrange",
     order_by = dots,
     order_vars = dots
   )

--- a/R/verb-distinct.R
+++ b/R/verb-distinct.R
@@ -44,7 +44,6 @@ add_distinct <- function(.data) {
 
   out <- lazy_select_query(
     x = lazy_query,
-    last_op = "distinct",
     distinct = TRUE
   )
   # TODO this could also work for joins

--- a/R/verb-filter.R
+++ b/R/verb-filter.R
@@ -60,7 +60,6 @@ add_filter <- function(.data, dots) {
     if (uses_mutated_vars(dots, lazy_query$select)) {
       lazy_select_query(
         x = lazy_query,
-        last_op = "filter",
         where = dots
       )
     } else {
@@ -86,7 +85,6 @@ add_filter <- function(.data, dots) {
     original_vars <- op_vars(.data)
     lazy_select_query(
       x = mutated$lazy_query,
-      last_op = "filter",
       select = syms(set_names(original_vars)),
       where = where$expr
     )

--- a/R/verb-head.R
+++ b/R/verb-head.R
@@ -40,7 +40,6 @@ add_head <- function(x, n) {
   if (!inherits(lazy_query, "lazy_select_query")) {
     lazy_query <- lazy_select_query(
       x = lazy_query,
-      last_op = "head",
       limit = n
     )
 

--- a/R/verb-head.R
+++ b/R/verb-head.R
@@ -47,16 +47,7 @@ add_head <- function(x, n) {
     return(lazy_query)
   }
 
-  if (identical(lazy_query$last_op, "head")) {
-    lazy_query$limit <- min(lazy_query$limit, n)
-  } else {
-    lazy_query <- lazy_select_query(
-      x = lazy_query,
-      last_op = "head",
-      limit = n
-    )
-  }
-
+  lazy_query$limit <- min(lazy_query$limit, n)
   lazy_query
 }
 

--- a/R/verb-select.R
+++ b/R/verb-select.R
@@ -155,7 +155,7 @@ add_select <- function(.data, vars, op = c("select", "mutate")) {
       return(out)
     }
 
-    if (identical(lazy_query$last_op, "select") || identical(lazy_query$last_op, "mutate")) {
+    if (inherits(lazy_query, "lazy_select_query")) {
       out$select <- vctrs::vec_slice(lazy_query$select, idx)
       out$select$name <- names(vars)
 
@@ -163,7 +163,7 @@ add_select <- function(.data, vars, op = c("select", "mutate")) {
     }
   }
 
-  if (identical(lazy_query$last_op, "select") || identical(lazy_query$last_op, "mutate")) {
+  if (inherits(lazy_query, "lazy_select_query")) {
     # Special optimisation when applied to pure projection() - this is
     # conservative and we could expand to any op_select() if combined with
     # the logic in get_mutate_layers()

--- a/R/verb-select.R
+++ b/R/verb-select.R
@@ -186,6 +186,7 @@ add_select <- function(.data, vars, op = c("select", "mutate")) {
   lazy_select_query(
     x = lazy_query,
     last_op = op,
+    select_operation = op,
     select = vars,
     group_vars = grps
   )

--- a/R/verb-select.R
+++ b/R/verb-select.R
@@ -185,7 +185,6 @@ add_select <- function(.data, vars, op = c("select", "mutate")) {
 
   lazy_select_query(
     x = lazy_query,
-    last_op = op,
     select_operation = op,
     select = vars,
     group_vars = grps

--- a/R/verb-set-ops.R
+++ b/R/verb-set-ops.R
@@ -52,7 +52,7 @@ add_set_op <- function(x, y, type, copy = FALSE, ..., all = FALSE, call = caller
     # https://www.sqlite.org/syntax/compound-select-stmt.html
     # https://www.sqlite.org/syntax/select-core.html
 
-    if (identical(x$lazy_query$last_op, "head") || identical(y$lazy_query$last_op, "head")) {
+    if (!is.null(x$lazy_query$limit) || !is.null(y$lazy_query$limit)) {
       cli_abort("SQLite does not support set operations on LIMITs", call = call)
     }
   }

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -153,7 +153,6 @@ add_summarise <- function(.data, dots, .groups, env_caller) {
 
   lazy_select_query(
     x = lazy_query,
-    last_op = "summarise",
     select = select,
     group_by = syms(grps),
     group_vars = groups_out,

--- a/man/sql_build.Rd
+++ b/man/sql_build.Rd
@@ -67,7 +67,6 @@ lazy_query(
 
 lazy_select_query(
   x,
-  last_op,
   select = NULL,
   where = NULL,
   group_by = NULL,
@@ -78,7 +77,7 @@ lazy_select_query(
   group_vars = NULL,
   order_vars = NULL,
   frame = NULL,
-  select_operation = c("mutate", "summarise"),
+  select_operation = c("select", "mutate", "summarise"),
   message_summarise = NULL
 )
 

--- a/tests/testthat/_snaps/lazy-select-query.md
+++ b/tests/testthat/_snaps/lazy-select-query.md
@@ -1,9 +1,9 @@
 # can print lazy_select_query
 
     Code
-      lazy_select_query(x = lazy_query_local(tibble(x = 1, y = 2), "df"), last_op = "select",
-      select = quos(x_mean = mean(x), y2 = y), where = quos(y > 1, x == y - 2),
-      group_by = quos("x"))
+      lazy_select_query(x = lazy_query_local(tibble(x = 1, y = 2), "df"), select = quos(
+        x_mean = mean(x), y2 = y), where = quos(y > 1, x == y - 2), group_by = quos(
+        "x"))
     Output
       <SQL SELECT>
       From:

--- a/tests/testthat/_snaps/verb-arrange.md
+++ b/tests/testthat/_snaps/verb-arrange.md
@@ -37,10 +37,6 @@
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% select(-a) %>% arrange(b)
-    Condition
-      Warning:
-      ORDER BY is ignored in subqueries without LIMIT
-      i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
       <SQL>
       SELECT `b`
@@ -59,7 +55,6 @@
       <SQL>
       SELECT `b`
       FROM `df`
-      ORDER BY `a`
     Code
       # use order
       lf %>% arrange(a) %>% select(-a) %>% mutate(c = lag(b))
@@ -122,10 +117,6 @@
       ORDER BY `a`
     Code
       lf %>% arrange(a) %>% mutate(a = 1) %>% arrange(b)
-    Condition
-      Warning:
-      ORDER BY is ignored in subqueries without LIMIT
-      i Do you need to move arrange() later in the pipeline or use window_order() instead?
     Output
       <SQL>
       SELECT 1.0 AS `a`, `b`

--- a/tests/testthat/test-lazy-select-query.R
+++ b/tests/testthat/test-lazy-select-query.R
@@ -2,7 +2,6 @@ test_that("can print lazy_select_query", {
   expect_snapshot(
     lazy_select_query(
       x = lazy_query_local(tibble(x = 1, y = 2), "df"),
-      last_op = "select",
       select = quos(
         x_mean = mean(x),
         y2 = y

--- a/tests/testthat/test-verb-filter.R
+++ b/tests/testthat/test-verb-filter.R
@@ -302,7 +302,6 @@ test_that("generates correct lazy_select_query", {
       .$lazy_query,
     lazy_select_query(
       x = lf$lazy_query,
-      last_op = "filter",
       select = syms(set_names(colnames(lf))),
       where = list(quo(x > 1))
     ),
@@ -317,7 +316,6 @@ test_that("generates correct lazy_select_query", {
     out,
     lazy_select_query(
       x = out$x,
-      last_op = "filter",
       select = syms(set_names(colnames(lf))),
       where = list(expr(q01 > 1))
     ),
@@ -328,7 +326,6 @@ test_that("generates correct lazy_select_query", {
     out$x,
     lazy_select_query(
       x = lf$lazy_query,
-      last_op = "mutate",
       select_operation = "mutate",
       select = list(x = sym("x"), y = sym("y"), q01 = quo(mean(x, na.rm = TRUE)))
     ),

--- a/tests/testthat/test-verb-filter.R
+++ b/tests/testthat/test-verb-filter.R
@@ -329,6 +329,7 @@ test_that("generates correct lazy_select_query", {
     lazy_select_query(
       x = lf$lazy_query,
       last_op = "mutate",
+      select_operation = "mutate",
       select = list(x = sym("x"), y = sym("y"), q01 = quo(mean(x, na.rm = TRUE)))
     ),
     ignore_formula_env = TRUE

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -188,7 +188,6 @@ test_that("can handle rename", {
     out,
     lazy_select_query(
       x = out$x,
-      last_op = "summarise",
       select = list(ax = sym("ax"), mean_by = quo(mean(by, na.rm = TRUE))),
       group_by = syms("ax"),
       select_operation = "summarise",


### PR DESCRIPTION
The field `last_op` was introduced when switching to the lazy query structure but it was only meant as a temporary helper for optimisations. With some minor modifications it isn't needed anymore. It is a breaking change but I don't expect other packages to actually break.

`revdepcheck()` confirms that there are no new problems.