### PR TITLE
Refactor `add_select()`

### DIFF
--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -82,16 +82,6 @@ new_lazy_select <- function(vars, group_vars = character(), order_vars = NULL, f
   )
 }
 
-update_lazy_select <- function(select, vars) {
-  vctrs::vec_as_names(names(vars), repair = "check_unique")
-
-  sel_vars <- purrr::map_chr(vars, as_string)
-  idx <- vctrs::vec_match(sel_vars, select$name)
-  select <- vctrs::vec_slice(select, idx)
-  select$name <- names(vars)
-  select
-}
-
 # projection = only select (including rename) from parent query
 # identity = selects exactly the same variable as the parent query
 is_lazy_select_query_simple <- function(x,

--- a/R/verb-mutate.R
+++ b/R/verb-mutate.R
@@ -101,9 +101,6 @@ add_mutate <- function(.data, vars) {
 
   # drop NULLs
   vars <- purrr::discard(vars, ~ (is_quosure(.x) && quo_is_null(.x)) || is.null(.x))
-  if (is_identity(vars, names(vars), op_vars(.data))) {
-    return(lazy_query)
-  }
 
   if (is_projection(vars)) {
     sel_vars <- purrr::map_chr(vars, as_string)

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -104,7 +104,7 @@ summarise_bind_error <- function(cur_data, dots, i, error_env) {
     summarise_bind_error1(error_env, dot_name)
     # remove variable from `cur_data` so that `partial_eval_sym()` evaluates
     # variable in `error_env`
-    cur_data$lazy_query <- add_select(cur_data, set_names(list(NULL), dot_name), "select")
+    cur_data$lazy_query <- add_select(cur_data, set_names(setdiff(colnames(cur_data), dot_name)))
   }
 
   cur_data


### PR DESCRIPTION
The logic in `add_select()` mixed `mutate()` and `select()` and was therefore more complicated than it actually had to be.