### PR TITLE
Use `error_call` arg from `build_*_spec()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     R6 (>= 2.2.2),
     rlang (>= 1.0.6),
     tibble (>= 1.4.2),
+    tidyr (>= 1.2.1.9001),
     tidyselect (>= 1.2.0),
     utils,
     vctrs (>= 0.5.0),
@@ -49,8 +50,7 @@ Suggests:
     RPostgres (>= 1.1.3),
     RPostgreSQL,
     RSQLite (>= 2.1.0),
-    testthat (>= 3.0.2),
-    tidyr (>= 1.2.0)
+    testthat (>= 3.0.2)
 VignetteBuilder: 
     knitr
 Config/Needs/website: tidyverse/tidytemplate
@@ -152,3 +152,5 @@ Collate:
     'verb-uncount.R'
     'verb-window.R'
     'zzz.R'
+Remotes:  
+    tidyverse/tidyr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     R6 (>= 2.2.2),
     rlang (>= 1.0.6),
     tibble (>= 1.4.2),
-    tidyr (>= 1.2.1.9001),
+    tidyr (>= 1.3.0),
     tidyselect (>= 1.2.0),
     utils,
     vctrs (>= 0.5.0),
@@ -152,5 +152,3 @@ Collate:
     'verb-uncount.R'
     'verb-window.R'
     'zzz.R'
-Remotes:  
-    tidyverse/tidyr

--- a/R/verb-pivot-longer.R
+++ b/R/verb-pivot-longer.R
@@ -86,7 +86,8 @@ pivot_longer.tbl_lazy <- function(data,
     names_sep = names_sep,
     names_pattern = names_pattern,
     names_ptypes = names_ptypes,
-    names_transform = names_transform
+    names_transform = names_transform,
+    error_call = current_env()
   )
 
   dbplyr_pivot_longer_spec(data, spec,

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -126,7 +126,8 @@ pivot_wider.tbl_lazy <- function(data,
     names_glue = names_glue,
     names_sort = names_sort,
     names_vary = names_vary,
-    names_expand = names_expand
+    names_expand = names_expand,
+    error_call = current_env()
   )
 
   id_cols <- build_wider_id_cols_expr(
@@ -155,7 +156,8 @@ dbplyr_build_wider_spec <- function(data,
                                     names_glue = NULL,
                                     names_sort = FALSE,
                                     names_vary = "fastest",
-                                    names_expand = FALSE) {
+                                    names_expand = FALSE,
+                                    error_call = current_env()) {
   if (!inherits(data, "tbl_sql")) {
     cli_abort(c(
       "{.fun dbplyr_build_wider_spec} doesn't work with local lazy tibbles.",
@@ -191,7 +193,8 @@ dbplyr_build_wider_spec <- function(data,
     names_glue = names_glue,
     names_sort = names_sort,
     names_vary = names_vary,
-    names_expand = names_expand
+    names_expand = names_expand,
+    error_call = error_call
   )
 }
 


### PR DESCRIPTION
Closes #1090. Wait for release of tidyr 1.3.0 https://github.com/tidyverse/tidyr/issues/1455.