### PR TITLE
`pivot_*()` upkeep

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* Catch unsupported argument `pivot_wider(id_expand = TRUE)` and
+  `pivot_longer(cols_vary)` (@mgirlich, #1109).
+
 * Fixed an issue when using a window function after a `summarise()` and
   `select()` (@mgirlich, #1104).
 

--- a/R/verb-pivot-longer.R
+++ b/R/verb-pivot-longer.R
@@ -60,6 +60,7 @@
 #'   tidyr::pivot_longer(-id)
 pivot_longer.tbl_lazy <- function(data,
                                   cols,
+                                  ...,
                                   names_to = "name",
                                   names_prefix = NULL,
                                   names_sep = NULL,
@@ -70,8 +71,7 @@ pivot_longer.tbl_lazy <- function(data,
                                   values_to = "value",
                                   values_drop_na = FALSE,
                                   values_ptypes,
-                                  values_transform = NULL,
-                                  ...) {
+                                  values_transform = NULL) {
   if (!is_missing(values_ptypes)) {
     cli_abort("The {.arg values_ptypes} argument is not supported for remote back-ends")
   }

--- a/R/verb-pivot-longer.R
+++ b/R/verb-pivot-longer.R
@@ -30,6 +30,8 @@
 #'
 #' @param data A data frame to pivot.
 #' @param cols Columns to pivot into longer format.
+#' @param ... Additional arguments passed on to methods.
+#' @param cols_vary Unsupported; included for compatibility with the generic.
 #' @param names_to A string specifying the name of the column to create
 #'   from the data stored in the column names of `data`.
 #' @param names_prefix A regular expression used to remove matching text
@@ -47,7 +49,6 @@
 #' @param names_transform,values_transform A list of column name-function pairs.
 #' @param names_ptypes A list of column name-prototype pairs.
 #' @param values_ptypes Not supported.
-#' @param ... Additional arguments passed on to methods.
 #' @examplesIf rlang::is_installed("tidyr", version = "1.0.0")
 #' # See vignette("pivot") for examples and explanation
 #'
@@ -61,6 +62,7 @@
 pivot_longer.tbl_lazy <- function(data,
                                   cols,
                                   ...,
+                                  cols_vary,
                                   names_to = "name",
                                   names_prefix = NULL,
                                   names_sep = NULL,
@@ -74,6 +76,9 @@ pivot_longer.tbl_lazy <- function(data,
                                   values_transform = NULL) {
   if (!is_missing(values_ptypes)) {
     cli_abort("The {.arg values_ptypes} argument is not supported for remote back-ends")
+  }
+  if (!is_missing(cols_vary)) {
+    cli_abort("The {.arg cols_vary} argument is not supported for remote back-ends.")
   }
 
   rlang::check_dots_empty()

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -99,6 +99,7 @@
 #'     values_from = value
 #'   )
 pivot_wider.tbl_lazy <- function(data,
+                                 ...,
                                  id_cols = NULL,
                                  names_from = name,
                                  names_prefix = "",
@@ -111,9 +112,7 @@ pivot_wider.tbl_lazy <- function(data,
                                  values_from = value,
                                  values_fill = NULL,
                                  values_fn = ~ max(.x, na.rm = TRUE),
-                                 unused_fn = NULL,
-                                 ...
-                                 ) {
+                                 unused_fn = NULL) {
   rlang::check_dots_empty()
   names_from <- enquo(names_from)
   values_from <- enquo(values_from)

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -33,6 +33,7 @@
 #'
 #' @param data A lazy data frame backed by a database query.
 #' @param id_cols A set of columns that uniquely identifies each observation.
+#' @param id_expand Unused; included for compatibility with the generic.
 #' @param names_from,values_from A pair of
 #'   arguments describing which column (or columns) to get the name of the
 #'   output column (`names_from`), and which column (or columns) to get the
@@ -101,6 +102,7 @@
 pivot_wider.tbl_lazy <- function(data,
                                  ...,
                                  id_cols = NULL,
+                                 id_expand = FALSE,
                                  names_from = name,
                                  names_prefix = "",
                                  names_sep = "_",
@@ -114,6 +116,10 @@ pivot_wider.tbl_lazy <- function(data,
                                  values_fn = ~ max(.x, na.rm = TRUE),
                                  unused_fn = NULL) {
   rlang::check_dots_empty()
+  if (!is_false(id_expand)) {
+    cli_abort("{.code id_expand = TRUE} isn't supported by dbplyr.")
+  }
+
   names_from <- enquo(names_from)
   values_from <- enquo(values_from)
 

--- a/man/pivot_longer.tbl_lazy.Rd
+++ b/man/pivot_longer.tbl_lazy.Rd
@@ -7,6 +7,7 @@
 \method{pivot_longer}{tbl_lazy}(
   data,
   cols,
+  ...,
   names_to = "name",
   names_prefix = NULL,
   names_sep = NULL,
@@ -17,14 +18,15 @@
   values_to = "value",
   values_drop_na = FALSE,
   values_ptypes,
-  values_transform = NULL,
-  ...
+  values_transform = NULL
 )
 }
 \arguments{
 \item{data}{A data frame to pivot.}
 
 \item{cols}{Columns to pivot into longer format.}
+
+\item{...}{Additional arguments passed on to methods.}
 
 \item{names_to}{A string specifying the name of the column to create
 from the data stored in the column names of \code{data}.}
@@ -51,8 +53,6 @@ existing column names.}
 in the \code{value_to} column.}
 
 \item{values_ptypes}{Not supported.}
-
-\item{...}{Additional arguments passed on to methods.}
 }
 \description{
 \code{pivot_longer()} "lengthens" data, increasing the number of rows and

--- a/man/pivot_longer.tbl_lazy.Rd
+++ b/man/pivot_longer.tbl_lazy.Rd
@@ -8,6 +8,7 @@
   data,
   cols,
   ...,
+  cols_vary,
   names_to = "name",
   names_prefix = NULL,
   names_sep = NULL,
@@ -27,6 +28,8 @@
 \item{cols}{Columns to pivot into longer format.}
 
 \item{...}{Additional arguments passed on to methods.}
+
+\item{cols_vary}{Unsupported; included for compatibility with the generic.}
 
 \item{names_to}{A string specifying the name of the column to create
 from the data stored in the column names of \code{data}.}

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -8,6 +8,7 @@
   data,
   ...,
   id_cols = NULL,
+  id_expand = FALSE,
   names_from = name,
   names_prefix = "",
   names_sep = "_",
@@ -28,6 +29,8 @@
 \item{...}{Unused; included for compatibility with generic.}
 
 \item{id_cols}{A set of columns that uniquely identifies each observation.}
+
+\item{id_expand}{Unused; included for compatibility with the generic.}
 
 \item{names_from, values_from}{A pair of
 arguments describing which column (or columns) to get the name of the

--- a/man/pivot_wider.tbl_lazy.Rd
+++ b/man/pivot_wider.tbl_lazy.Rd
@@ -6,6 +6,7 @@
 \usage{
 \method{pivot_wider}{tbl_lazy}(
   data,
+  ...,
   id_cols = NULL,
   names_from = name,
   names_prefix = "",
@@ -18,12 +19,13 @@
   values_from = value,
   values_fill = NULL,
   values_fn = ~max(.x, na.rm = TRUE),
-  unused_fn = NULL,
-  ...
+  unused_fn = NULL
 )
 }
 \arguments{
 \item{data}{A lazy data frame backed by a database query.}
+
+\item{...}{Unused; included for compatibility with generic.}
 
 \item{id_cols}{A set of columns that uniquely identifies each observation.}
 
@@ -87,8 +89,6 @@ all unspecified columns will be considered \code{id_cols}.
 
 This is similar to grouping by the \code{id_cols} then summarizing the
 unused columns using \code{unused_fn}.}
-
-\item{...}{Unused; included for compatibility with generic.}
 }
 \description{
 \code{pivot_wider()} "widens" data, increasing the number of columns and

--- a/tests/testthat/_snaps/verb-mutate.md
+++ b/tests/testthat/_snaps/verb-mutate.md
@@ -1,3 +1,16 @@
+# can use window function after summarise and pure projection #1104
+
+    Code
+      (expect_no_error(lf %>% mutate(r = row_number())))
+    Output
+      <SQL>
+      SELECT *, ROW_NUMBER() OVER () AS `r`
+      FROM (
+        SELECT `g`
+        FROM `df`
+        GROUP BY `g`
+      ) `q01`
+
 # can refer to fresly created values
 
     Code

--- a/tests/testthat/_snaps/verb-pivot-longer.md
+++ b/tests/testthat/_snaps/verb-pivot-longer.md
@@ -185,3 +185,11 @@
       Error in `tidyr::pivot_longer()`:
       ! The `values_ptypes` argument is not supported for remote back-ends
 
+# cols_vary is not supported
+
+    Code
+      lazy_frame(x = 1:2, y = 3:4) %>% tidyr::pivot_longer(x:y, cols_vary = "fastest")
+    Condition
+      Error in `tidyr::pivot_longer()`:
+      ! The `cols_vary` argument is not supported for remote back-ends.
+

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -168,3 +168,12 @@
       Error in `dbplyr_build_wider_spec()`:
       ! `values_from` must select at least one column.
 
+# `id_expand` must be FALSE
+
+    Code
+      (expect_error(tidyr::pivot_wider(df, id_expand = TRUE)))
+    Output
+      <error/rlang_error>
+      Error in `tidyr::pivot_wider()`:
+      ! `id_expand = TRUE` isn't supported by dbplyr.
+

--- a/tests/testthat/test-verb-pivot-longer.R
+++ b/tests/testthat/test-verb-pivot-longer.R
@@ -254,3 +254,11 @@ test_that("values_ptype is not supported", {
       tidyr::pivot_longer(x:y, values_ptypes = character())
   )
 })
+
+test_that("cols_vary is not supported", {
+  expect_snapshot(
+    error = TRUE,
+    lazy_frame(x = 1:2, y = 3:4) %>%
+      tidyr::pivot_longer(x:y, cols_vary = "fastest")
+  )
+})

--- a/tests/testthat/test-verb-pivot-wider.R
+++ b/tests/testthat/test-verb-pivot-wider.R
@@ -480,3 +480,10 @@ test_that("`values_from` must identify at least 1 column (#1240)", {
     (expect_error(tidyr::pivot_wider(df, names_from = key, values_from = starts_with("foo"))))
   )
 })
+
+test_that("`id_expand` must be FALSE", {
+  df <- lazy_frame(name = "x", value = 1)
+  expect_snapshot(
+    (expect_error(tidyr::pivot_wider(df, id_expand = TRUE)))
+  )
+})


### PR DESCRIPTION
Move dots, add unsupported arguments `cols_vary` and `id_expand` for better error messages.