### PR TITLE
Can use `filter(f(<x>))` on a summarised variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* Fixed an issue when using `filter()` on a summarised variable (@mgirlich, #1128).
+
 * `across()` and `pick()` can be used (again) in `distinct()` (@mgirlich, #1125).
 
 * The rank functions (`row_number()`, `min_rank()`, `rank()`, `dense_rank()`,

--- a/R/verb-filter.R
+++ b/R/verb-filter.R
@@ -115,7 +115,7 @@ filter_can_use_having <- function(lazy_query, dots_use_window_fun) {
 
 filter_via_having <- function(lazy_query, dots) {
   names <- lazy_query$select$name
-  exprs <- lazy_query$select$expr
+  exprs <- purrr::map_if(lazy_query$select$expr, is_quosure, quo_get_expr)
   dots <- purrr::map(dots, replace_sym, names, exprs)
 
   lazy_query$having <- c(lazy_query$having, dots)

--- a/tests/testthat/_snaps/verb-filter.md
+++ b/tests/testthat/_snaps/verb-filter.md
@@ -115,6 +115,16 @@
       GROUP BY `g`, `h`
       HAVING (`g` = 1.0) AND (`h` = 2.0)
 
+# `HAVING` supports expressions #1128
+
+    Code
+      lf %>% summarise(x_sum = sum(x, na.rm = TRUE)) %>% filter(!is.na(x_sum))
+    Output
+      <SQL>
+      SELECT SUM(`x`) AS `x_sum`
+      FROM `df`
+      HAVING (NOT(((SUM(`x`)) IS NULL)))
+
 # filter() after mutate() does not use `HAVING`
 
     Code


### PR DESCRIPTION
Fixes #1128.