### PR TITLE
Error when using predicates in `across()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* Using predicates, e.g. `where(is.integer)`, in `across()` now produces an
+  error as they never worked anyway (@mgirlich, #1169).
+
 * `sql()` now evaluates its arguments locally also when used in `across()` (@mgirlich, #1039).
 
 * The rank functions (`row_number()`, `min_rank()`, `rank()`, `dense_rank()`,

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -186,8 +186,8 @@ across_setup <- function(data,
                          fn,
                          error_call) {
   grps <- group_vars(data)
-  tbl <- ungroup(tidyselect_data_proxy(data))
-  tbl <- tbl[setdiff(colnames(tbl), grps)]
+  tbl <- ungroup(data)
+  tbl <- select(tbl, -all_of(grps))
 
   .cols <- call$.cols %||% expr(everything())
   locs <- tidyselect::eval_select(

--- a/tests/testthat/_snaps/tidyeval-across.md
+++ b/tests/testthat/_snaps/tidyeval-across.md
@@ -114,6 +114,14 @@
       ! `.unpack = TRUE` isn't supported on database backends.
       i It must be FALSE instead.
 
+# where() isn't suppored
+
+    Code
+      capture_across(lf, across(where(is.integer), as.character))
+    Condition
+      Error in `across()`:
+      ! This tidyselect interface doesn't support predicates.
+
 # if_all() gives informative errors
 
     Code

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -173,6 +173,14 @@
       Caused by error:
       ! object 'non_existent' not found
 
+# where() isn't suppored
+
+    Code
+      lf %>% select(where(is.integer))
+    Condition
+      Error in `select()`:
+      ! This tidyselect interface doesn't support predicates.
+
 # multiple selects are collapsed
 
     Code

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -373,6 +373,13 @@ test_that("across() throws error if unpack = TRUE", {
   )
 })
 
+test_that("where() isn't suppored", {
+  lf <- lazy_frame(x = 1)
+  expect_snapshot(error = TRUE, {
+    capture_across(lf, across(where(is.integer), as.character))
+  })
+})
+
 
 # if_all ------------------------------------------------------------------
 

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -277,6 +277,13 @@ test_that("select() produces nice error messages", {
   })
 })
 
+test_that("where() isn't suppored", {
+  lf <- lazy_frame(x = 1)
+  expect_snapshot(error = TRUE, {
+    lf %>% select(where(is.integer))
+  })
+})
+
 # sql_render --------------------------------------------------------------
 
 test_that("multiple selects are collapsed", {


### PR DESCRIPTION
Fixes #1169.