### PR TITLE
Use `local_db_table()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -99,6 +99,25 @@ local_methods <- function(..., .frame = caller_env()) {
   local_bindings(..., .env = global_env(), .frame = .frame)
 }
 
+local_db_table <- function(con, value, name, ..., temporary = TRUE, envir = parent.frame()) {
+  if (inherits(con, "Microsoft SQL Server") && temporary) {
+    rm_name <- paste0("#", name)
+  } else {
+    rm_name <- name
+  }
+
+  withr::defer(DBI::dbRemoveTable(con, rm_name), envir = envir)
+  copy_to(con, value, name, temporary = temporary, ...)
+  tbl(con, name)
+}
+
+local_sqlite_connection <- function(envir = parent.frame()) {
+  withr::local_db_connection(
+    DBI::dbConnect(RSQLite::SQLite(), ":memory:"),
+    .local_envir = envir
+  )
+}
+
 check_list <- function(x, ..., allow_null = FALSE, arg = caller_arg(x), call = caller_env()) {
   if (vctrs::vec_is_list(x)) {
     return()

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,12 +101,10 @@ local_methods <- function(..., .frame = caller_env()) {
 
 local_db_table <- function(con, value, name, ..., temporary = TRUE, envir = parent.frame()) {
   if (inherits(con, "Microsoft SQL Server") && temporary) {
-    rm_name <- paste0("#", name)
-  } else {
-    rm_name <- name
+    name <- paste0("#", name)
   }
 
-  withr::defer(DBI::dbRemoveTable(con, rm_name), envir = envir)
+  withr::defer(DBI::dbRemoveTable(con, name), envir = envir)
   copy_to(con, value, name, temporary = temporary, ...)
   tbl(con, name)
 }

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -37,10 +37,13 @@ if (test_srcs$length() == 0) {
   }
 }
 
-sqlite_con_with_aux <- function() {
+local_sqlite_con_with_aux <- function(envir = parent.frame()) {
   tmp <- tempfile()
 
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  con <- withr::local_db_connection(
+    DBI::dbConnect(RSQLite::SQLite(), ":memory:"),
+    .local_envir = envir
+  )
   DBI::dbExecute(con, paste0("ATTACH '", tmp, "' AS aux"))
 
   con

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -343,12 +343,10 @@ test_that("can insert", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1L, b = 11L, c = 1L, d = "a")
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_insert(
@@ -371,12 +369,10 @@ test_that("can insert with returning", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1L, b = 11L, c = 1L, d = "a")
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_insert(
@@ -400,12 +396,10 @@ test_that("can append", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1L, b = 11L, c = 1L, d = "a")
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 1:3, b = 11:13, c = -(2:4), d = c("y", "z", "w"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_append(
@@ -426,12 +420,10 @@ test_that("can append with returning", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1L, b = 11L, c = 1L, d = "a")
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 1:3, b = 11:13, c = -(2:4), d = c("y", "z", "w"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_append(
@@ -453,12 +445,10 @@ test_that("can update", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1:3, b = 11:13, c = 1:3, d = c("a", "b", "c"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_update(
@@ -481,12 +471,10 @@ test_that("can update with returning", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1:3, b = 11:13, c = 1:3, d = c("a", "b", "c"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_update(
@@ -510,12 +498,10 @@ test_that("can upsert", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1:2, b = 11:12, c = 1:2, d = c("a", "b"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_upsert(
@@ -537,12 +523,10 @@ test_that("can upsert with returning", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1:2, b = 11:12, c = 1:2, d = c("a", "b"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
 
   expect_equal(
     rows_upsert(
@@ -566,11 +550,9 @@ test_that("can delete", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1:3, b = 11:13, c = 1:3, d = c("a", "b", "c"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
+  y <- local_db_table(con, df_y, "df_y")
 
   expect_equal(
     rows_delete(
@@ -593,11 +575,9 @@ test_that("can delete with returning", {
   con <- src_test("mssql")
 
   df_x <- tibble(a = 1:3, b = 11:13, c = 1:3, d = c("a", "b", "c"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_x")))
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("#df_y")))
+  y <- local_db_table(con, df_y, "df_y")
 
   expect_equal(
     rows_delete(

--- a/tests/testthat/test-backend-mysql.R
+++ b/tests/testthat/test-backend-mysql.R
@@ -98,9 +98,9 @@ test_that("can update", {
   con <- src_test("MariaDB")
 
   df_x <- tibble(a = 1:3, b = 11:13, c = 1:3, d = c("a", "b", "c"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
+  x <- local_db_table(con, df_x, "df_x")
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
 
   # `RETURNING` in an `UPDATE` clause is not (yet) supported for MariaDB

--- a/tests/testthat/test-backend-postgres-old.R
+++ b/tests/testthat/test-backend-postgres-old.R
@@ -1,12 +1,14 @@
 test_that("RPostgreSQL backend", {
   skip_if_not(identical(Sys.getenv("GITHUB_POSTGRES"), "true"))
 
-  src <- DBI::dbConnect(
-    RPostgreSQL::PostgreSQL(),
-    dbname = "test",
-    user = "postgres",
-    password = "password",
-    host = "127.0.0.1"
+  src <- withr::local_db_connection(
+    DBI::dbConnect(
+      RPostgreSQL::PostgreSQL(),
+      dbname = "test",
+      user = "postgres",
+      password = "password",
+      host = "127.0.0.1"
+    )
   )
 
   copy_to(src, mtcars, "mtcars", overwrite = TRUE, temporary = FALSE)

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -159,7 +159,7 @@ test_that("can explain", {
 test_that("can overwrite temp tables", {
   src <- src_test("postgres")
   copy_to(src, mtcars, "mtcars", overwrite = TRUE)
-  on.exit(DBI::dbRemoveTable(src, "mtcars"))
+  withr::defer(DBI::dbRemoveTable(src, "mtcars"))
   expect_error(copy_to(src, mtcars, "mtcars", overwrite = TRUE), NA)
 })
 

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -159,6 +159,7 @@ test_that("can explain", {
 test_that("can overwrite temp tables", {
   src <- src_test("postgres")
   copy_to(src, mtcars, "mtcars", overwrite = TRUE)
+  on.exit(DBI::dbRemoveTable(src, "mtcars"))
   expect_error(copy_to(src, mtcars, "mtcars", overwrite = TRUE), NA)
 })
 
@@ -180,13 +181,11 @@ test_that("can insert with returning", {
   con <- src_test("postgres")
 
   df_x <- tibble(a = 1L, b = 11L, c = 1L, d = "a")
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("df_x")))
+  x <- local_db_table(con, df_x, "df_x")
 
   df_y <- tibble(a = 1:3, b = 11:13, c = -(1:3), d = c("x", "y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("df_y")))
 
   # This errors because there is no unique constraint on (`a`, `b`)
   expect_snapshot(error = TRUE, {
@@ -212,8 +211,8 @@ test_that("can insert with returning", {
     NA
   )
 
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  db_create_index(con, "df_x", columns = c("a", "b"), unique = TRUE)
+  x <- local_db_table(con, df_x, "df_x2", overwrite = TRUE)
+  db_create_index(con, "df_x2", columns = c("a", "b"), unique = TRUE)
 
   expect_equal(
     rows_insert(
@@ -242,8 +241,7 @@ test_that("can insert with returning", {
 test_that("can use `rows_*()` inside a transaction #1183", {
   con <- src_test("postgres")
 
-  DBI::dbWriteTable(con, "df_x", tibble(a = 1:2e3, b = 2, x = "a"), temporary = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("df_x")))
+  local_db_table(con, tibble(a = 1:2e3, b = 2, x = "a"), "df_x")
 
   expect_no_error(
     DBI::dbWithTransaction(
@@ -259,17 +257,12 @@ test_that("casts `y` column for local df", {
   con <- src_test("postgres")
 
   DBI::dbExecute(con, "CREATE SCHEMA dbplyr_test_schema")
+  withr::defer(DBI::dbExecute(con, "DROP SCHEMA dbplyr_test_schema"))
   df <- tibble(id = 1L, val = 10L, arr = "{1,2}")
   types <- c(id = "bigint", val = "bigint", arr = "integer[]")
-  DBI::dbWriteTable(con, "df_x", value = df, field.types = types)
+  local_db_table(con, value = df, types = types, temporary = FALSE, "df_x")
   table2 <- DBI::Id(schema = "dbplyr_test_schema", table = "df_x")
-  DBI::dbWriteTable(con, table2, value = df, field.types = types)
-
-  withr::defer({
-    DBI::dbRemoveTable(con, DBI::SQL("df_x"))
-    DBI::dbRemoveTable(con, DBI::Id(schema = "dbplyr_test_schema", table = "df_x"))
-    DBI::dbExecute(con, "DROP SCHEMA dbplyr_test_schema")
-  })
+  local_db_table(con, value = df, types = types, temporary = FALSE, table2)
 
   y <- tibble(
     id = "2",
@@ -311,13 +304,11 @@ test_that("can upsert with returning", {
   con <- src_test("postgres")
 
   df_x <- tibble(a = 1:2, b = 11:12, c = 1:2, d = c("a", "b"))
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("df_x")))
+  x <- local_db_table(con, df_x, "df_x")
 
   df_y <- tibble(a = 2:3, b = c(12L, 13L), c = -(2:3), d = c("y", "z"))
-  y <- copy_to(con, df_y, "df_y", temporary = TRUE, overwrite = TRUE) %>%
+  y <- local_db_table(con, df_y, "df_y") %>%
     mutate(c = c + 1)
-  withr::defer(DBI::dbRemoveTable(con, DBI::SQL("df_y")))
 
   # Errors because there is no unique index
   expect_snapshot(error = TRUE, {
@@ -342,8 +333,8 @@ test_that("can upsert with returning", {
     NA
   )
 
-  x <- copy_to(con, df_x, "df_x", temporary = TRUE, overwrite = TRUE)
-  db_create_index(con, "df_x", columns = c("a", "b"), unique = TRUE)
+  x <- local_db_table(con, df_x, "df_x2")
+  db_create_index(con, "df_x2", columns = c("a", "b"), unique = TRUE)
 
   expect_equal(
     rows_upsert(

--- a/tests/testthat/test-db-io.R
+++ b/tests/testthat/test-db-io.R
@@ -1,7 +1,6 @@
 test_that("db_copy_to() wraps DBI errors", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con))
-  DBI::dbWriteTable(con, "tmp", data.frame(x = 1), overwrite = TRUE, temporary = TRUE)
+  con <- local_sqlite_connection()
+  local_db_table(con, data.frame(x = 1), "tmp")
 
   # error when writing
   expect_snapshot(

--- a/tests/testthat/test-db-sql.R
+++ b/tests/testthat/test-db-sql.R
@@ -21,8 +21,7 @@ test_that("sql_query_rows() works", {
 })
 
 test_that("handles DBI error", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con))
+  con <- local_sqlite_connection()
 
   expect_snapshot({
     (expect_error(db_analyze(con, "tbl")))

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -155,9 +155,8 @@ test_that("`rows_insert()` with `in_place = TRUE` and `returning`", {
 })
 
 test_that("rows_get_or_execute() gives error context", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con))
-  DBI::dbWriteTable(con, "mtcars", tibble(x = 1, y = 1), overwrite = TRUE, temporary = TRUE)
+  con <- local_sqlite_connection()
+  local_db_table(con, tibble(x = 1, y = 1), "mtcars", overwrite = TRUE)
   DBI::dbExecute(con, "CREATE UNIQUE INDEX `mtcars_x` ON `mtcars` (`x`)")
 
   expect_snapshot({

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -12,8 +12,7 @@ test_that("escaped as needed", {
 })
 
 test_that("can copy and collect with schema or Id", {
-  con <- sqlite_con_with_aux()
-  on.exit(dbDisconnect(con))
+  con <- local_sqlite_con_with_aux()
   df <- tibble(x = 1:10)
 
   db <- copy_to(con, df, in_schema("aux", "db1"), temporary = FALSE)

--- a/tests/testthat/test-tbl-sql.R
+++ b/tests/testthat/test-tbl-sql.R
@@ -6,9 +6,8 @@ test_that("tbl_sql() works with string argument", {
 })
 
 test_that("same_src distinguishes srcs", {
-  con1 <- DBI::dbConnect(RSQLite::SQLite(), ":memory:", create = TRUE)
-  con2 <- DBI::dbConnect(RSQLite::SQLite(), ":memory:", create = TRUE)
-  on.exit({dbDisconnect(con1); dbDisconnect(con2)}, add = TRUE)
+  con1 <- local_sqlite_connection()
+  con2 <- local_sqlite_connection()
 
   db1 <- copy_to(con1, iris[1:3, ], 'data1', temporary = FALSE)
   db2 <- copy_to(con2, iris[1:3, ], 'data2', temporary = FALSE)
@@ -37,8 +36,7 @@ test_that("sql tbl can be printed", {
 })
 
 test_that("can refer to default schema explicitly", {
-  con <- sqlite_con_with_aux()
-  on.exit(DBI::dbDisconnect(con))
+  con <- local_sqlite_con_with_aux()
   DBI::dbExecute(con, "CREATE TABLE t1 (x)")
 
   expect_equal(as.character(tbl_vars(tbl(con, "t1"))), "x")
@@ -46,8 +44,7 @@ test_that("can refer to default schema explicitly", {
 })
 
 test_that("can distinguish 'schema.table' from 'schema'.'table'", {
-  con <- sqlite_con_with_aux()
-  on.exit(DBI::dbDisconnect(con))
+  con <- local_sqlite_con_with_aux()
   DBI::dbExecute(con, "CREATE TABLE aux.t1 (x, y, z)")
   DBI::dbExecute(con, "CREATE TABLE 'aux.t1' (a, b, c)")
 

--- a/tests/testthat/test-verb-compute.R
+++ b/tests/testthat/test-verb-compute.R
@@ -94,7 +94,7 @@ test_that("compute can handle named name", {
 
 test_that("compute can handle schema", {
   df <- memdb_frame(x = 1:10)
-  on.exit(DBI::dbRemoveTable(remote_con(df), "db1"))
+  withr::defer(DBI::dbRemoveTable(remote_con(df), "db1"))
 
   expect_equal(
     df %>%

--- a/tests/testthat/test-verb-copy-to.R
+++ b/tests/testthat/test-verb-copy-to.R
@@ -1,7 +1,6 @@
 test_that("can copy to from remote sources", {
   df <- tibble(x = 1:10)
-  con1 <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con1), add = TRUE)
+  con1 <- local_sqlite_connection()
   df_1 <- copy_to(con1, df, "df1")
 
   # Create from tbl in same database
@@ -9,8 +8,7 @@ test_that("can copy to from remote sources", {
   expect_equal(collect(df_2), df)
 
   # Create from tbl in another data
-  con2 <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con2), add = TRUE)
+  con2 <- local_sqlite_connection()
   df_3 <- copy_to(con2, df_1, "df3")
   expect_equal(collect(df_3), df)
 })
@@ -30,17 +28,15 @@ test_that("NAs in character fields handled by db sources (#2256)", {
 })
 
 test_that("only overwrite existing table if explicitly requested", {
-  con <- DBI::dbConnect(RSQLite::SQLite())
-  on.exit(DBI::dbDisconnect(con))
-  DBI::dbWriteTable(con, "df", data.frame(x = 1:5))
+  con <- local_sqlite_connection()
+  local_db_table(con, data.frame(x = 1:5), "df")
 
   expect_error(copy_to(con, data.frame(x = 1), name = "df"), "exists")
   expect_silent(copy_to(con, data.frame(x = 1), name = "df", overwrite = TRUE))
 })
 
 test_that("can create a new table in non-default schema", {
-  con <- sqlite_con_with_aux()
-  on.exit(DBI::dbDisconnect(con))
+  con <- local_sqlite_con_with_aux()
 
   df1 <- tibble(x = 1)
   df2 <- tibble(x = 2)
@@ -54,8 +50,7 @@ test_that("can create a new table in non-default schema", {
 })
 
 test_that("df must be a local or remote table", {
-  con <- DBI::dbConnect(RSQLite::SQLite())
-  on.exit(DBI::dbDisconnect(con))
+  con <- local_sqlite_connection()
 
   expect_snapshot(error = TRUE, copy_to(con, list(x = 1), name = "df"))
 })
@@ -63,8 +58,7 @@ test_that("df must be a local or remote table", {
 # copy_inline() -----------------------------------------------------------
 
 test_that("can translate a table", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  con <- local_sqlite_connection()
   df <- tibble(
     lgl = TRUE,
     int = 1L,
@@ -96,8 +90,7 @@ test_that("can translate a table", {
 })
 
 test_that("can translate 1-column tables", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  con <- local_sqlite_connection()
   expect_snapshot(
     copy_inline(con, tibble(dbl = 1.5)) %>%
       remote_query()
@@ -105,8 +98,7 @@ test_that("can translate 1-column tables", {
 })
 
 test_that("zero row table works", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  con <- local_sqlite_connection()
   expect_snapshot(
     copy_inline(con, tibble(dbl = numeric(), chr = character())) %>%
       remote_query()
@@ -119,8 +111,7 @@ test_that("zero row table works", {
 })
 
 test_that("types argument works", {
-  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-  on.exit(DBI::dbDisconnect(con), add = TRUE)
+  con <- local_sqlite_connection()
 
   df <- tibble(x = "1", y = 2L)
   expect_equal(copy_inline(con, df) %>% collect(), df)


### PR DESCRIPTION
Closes #1151.

This PR adds

* `local_sqlite_connection()`
* `local_db_table()`
* `local_sqlite_con_with_aux()`

to get rid of the `on.exit()` calls in tests.