### PR TITLE
Fix `copy_inline()` for MariaDB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `copy_inline()` now works for MariaDB (@mgirlich, #1188).
+
 * `*_join()` after `full_join()` works again (@mgirlich, #1178).
 
 * The `rows_*()` functions now also work inside a transaction for Postgres

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -138,15 +138,18 @@ sql_expr_matches.MySQL <- sql_expr_matches.MariaDBConnection
 #' @export
 sql_expr_matches.MySQLConnection <- sql_expr_matches.MariaDBConnection
 
+# https://modern-sql.com/blog/2018-08/whats-new-in-mariadb-10.3#3.values
+# MariaDB doesn't accept `ROW` unlike MySQL
 #' @export
-sql_values_subquery.MariaDBConnection <- function(con, df, types, lvl = 0, ...) {
-  sql_values_subquery_default(con, df, types = types, lvl = lvl, row = TRUE)
-}
+sql_values_subquery.MariaDBConnection <- sql_values_subquery.DBIConnection
 
 #' @export
-sql_values_subquery.MySQL <- sql_values_subquery.MariaDBConnection
+sql_values_subquery.MySQL <-function(con, df, types, lvl = 0, ...) {
+  # https://dev.mysql.com/doc/refman/8.0/en/values.html
+  sql_values_subquery_default(con, df, types = types, lvl = lvl, row = TRUE)
+}
 #' @export
-sql_values_subquery.MySQLConnection <- sql_values_subquery.MariaDBConnection
+sql_values_subquery.MySQLConnection <- sql_values_subquery.MySQL
 
 #' @export
 sql_random.MariaDBConnection <- function(con) {

--- a/tests/testthat/_snaps/backend-mysql.md
+++ b/tests/testthat/_snaps/backend-mysql.md
@@ -1,14 +1,14 @@
 # generates custom sql
 
     Code
-      sql_table_analyze(con, in_schema("schema", "tbl"))
+      sql_table_analyze(con_maria, in_schema("schema", "tbl"))
     Output
       <SQL> ANALYZE TABLE `schema`.`tbl`
 
 ---
 
     Code
-      sql_query_explain(con, sql("SELECT * FROM table"))
+      sql_query_explain(con_maria, sql("SELECT * FROM table"))
     Output
       <SQL> EXPLAIN SELECT * FROM table
 
@@ -47,7 +47,22 @@
 ---
 
     Code
-      copy_inline(con, tibble(x = 1:2, y = letters[1:2])) %>% remote_query()
+      copy_inline(con_maria, tibble(x = 1:2, y = letters[1:2])) %>% remote_query()
+    Output
+      <SQL> SELECT CAST(`x` AS INTEGER) AS `x`, CAST(`y` AS CHAR) AS `y`
+      FROM (
+        (
+          SELECT NULL AS `x`, NULL AS `y`
+          WHERE (0 = 1)
+        )
+        UNION ALL
+        (VALUES (1, 'a'), (2, 'b'))
+      ) `values_table`
+
+---
+
+    Code
+      copy_inline(con_mysql, tibble(x = 1:2, y = letters[1:2])) %>% remote_query()
     Output
       <SQL> SELECT CAST(`x` AS INTEGER) AS `x`, CAST(`y` AS CHAR) AS `y`
       FROM (

--- a/tests/testthat/test-backend-mysql.R
+++ b/tests/testthat/test-backend-mysql.R
@@ -34,18 +34,21 @@ test_that("custom stringr functions translated correctly", {
 # verbs -------------------------------------------------------------------
 
 test_that("generates custom sql", {
-  con <- simulate_mysql()
+  con_maria <- simulate_mysql()
 
-  expect_snapshot(sql_table_analyze(con, in_schema("schema", "tbl")))
-  expect_snapshot(sql_query_explain(con, sql("SELECT * FROM table")))
+  expect_snapshot(sql_table_analyze(con_maria, in_schema("schema", "tbl")))
+  expect_snapshot(sql_query_explain(con_maria, sql("SELECT * FROM table")))
 
-  lf <- lazy_frame(x = 1, con = con)
+  lf <- lazy_frame(x = 1, con = con_maria)
   expect_snapshot(left_join(lf, lf, by = "x", na_matches = "na"))
   expect_snapshot(error = TRUE, full_join(lf, lf, by = "x"))
 
   expect_snapshot(slice_sample(lf, n = 1))
 
-  expect_snapshot(copy_inline(con, tibble(x = 1:2, y = letters[1:2])) %>% remote_query())
+  expect_snapshot(copy_inline(con_maria, tibble(x = 1:2, y = letters[1:2])) %>% remote_query())
+
+  con_mysql <- simulate_dbi("MySQLConnection")
+  expect_snapshot(copy_inline(con_mysql, tibble(x = 1:2, y = letters[1:2])) %>% remote_query())
 })
 
 test_that("`sql_query_update_from()` is correct", {


### PR DESCRIPTION
Fixes #1188.