### PR TITLE
Add dots to generics

### DIFF
--- a/R/backend-access.R
+++ b/R/backend-access.R
@@ -165,6 +165,8 @@ sql_translation.ACCESS <- function(con) {
 
 #' @export
 sql_table_analyze.ACCESS <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   # Do nothing. Access doesn't support an analyze / update statistics function
   NULL # nocov
 }

--- a/R/backend-access.R
+++ b/R/backend-access.R
@@ -37,12 +37,20 @@ dbplyr_edition.ACCESS <- function(con) {
 # sql_ generics --------------------------------------------
 
 #' @export
-sql_query_select.ACCESS <- function(con, select, from,
-                              where = NULL,  group_by = NULL,
-                              having = NULL, window = NULL, order_by = NULL,
-                              limit = NULL,  distinct = FALSE, ...,
-                              subquery = FALSE,
-                              lvl = 0) {
+sql_query_select.ACCESS <- function(con,
+                                    select,
+                                    from,
+                                    where = NULL,
+                                    group_by = NULL,
+                                    having = NULL,
+                                    window = NULL,
+                                    order_by = NULL,
+                                    limit = NULL,
+                                    distinct = FALSE,
+                                    ...,
+                                    subquery = FALSE,
+                                    lvl = 0) {
+  check_dots_empty0(...)
 
   sql_select_clauses(con,
     select    = sql_clause_select(con, select, distinct, top = limit),

--- a/R/backend-hana.R
+++ b/R/backend-hana.R
@@ -80,5 +80,6 @@ db_table_temporary.HDB <- function(con, table, temporary, ...) {
 
 #' @export
 sql_values_subquery.HDB <- function(con, df, types, lvl = 0, ...) {
+  check_dots_empty0(...)
   sql_values_subquery_union(con, df, types = types, lvl = lvl, from = "DUMMY")
 }

--- a/R/backend-hana.R
+++ b/R/backend-hana.R
@@ -74,6 +74,8 @@ db_table_temporary.HDB <- function(con, table, temporary, ...) {
 `sql_table_analyze.HDB` <- function(con, table, ...) {
   # CREATE STATISTICS doesn't work for temporary tables, so
   # don't do anything at all
+
+  check_dots_empty0(...)
 }
 
 #' @export

--- a/R/backend-hana.R
+++ b/R/backend-hana.R
@@ -57,7 +57,8 @@ sql_translation.HDB <- function(con) {
 
 # nocov start
 #' @export
-db_table_temporary.HDB <- function(con, table, temporary) {
+db_table_temporary.HDB <- function(con, table, temporary, ...) {
+  check_dots_empty0(...)
   if (temporary && substr(table, 1, 1) != "#") {
     table <- hash_temp(table)
   }

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -88,6 +88,8 @@ sql_translation.Hive <- function(con) {
 
 #' @export
 sql_table_analyze.Hive <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   # https://cwiki.apache.org/confluence/display/Hive/StatsDev
   build_sql(
     "ANALYZE TABLE ", as.sql(table, con = con), " COMPUTE STATISTICS",

--- a/R/backend-hive.R
+++ b/R/backend-hive.R
@@ -97,6 +97,8 @@ sql_table_analyze.Hive <- function(con, table, ...) {
 
 #' @export
 sql_query_set_op.Hive <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
+  check_dots_empty0(...)
+
   # SQLite does not allow parentheses
   method <- paste0(method, if (all) " ALL")
   # `x` and `y` already have the correct indent, so use `build_sql()` instead

--- a/R/backend-impala.R
+++ b/R/backend-impala.R
@@ -48,6 +48,8 @@ sql_translation.Impala <- function(con) {
 
 #' @export
 sql_table_analyze.Impala <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   # Using COMPUTE STATS instead of ANALYZE as recommended in this article
   # https://www.cloudera.com/documentation/enterprise/5-9-x/topics/impala_compute_stats.html
   build_sql("COMPUTE STATS ", as.sql(table, con = con), con = con)

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -458,8 +458,12 @@ mssql_version <- function(con) {
 }
 
 #' @export
-`sql_query_save.Microsoft SQL Server` <- function(con, sql, name,
-                                                  temporary = TRUE, ...){
+`sql_query_save.Microsoft SQL Server` <- function(con,
+                                                  sql,
+                                                  name,
+                                                  temporary = TRUE,
+                                                  ...) {
+  check_dots_empty0(...)
 
   # https://stackoverflow.com/q/16683758/946850
   build_sql(

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -431,7 +431,8 @@ mssql_version <- function(con) {
 # temporary table names with #
 # <https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms177399%28v%3dsql.105%29#temporary-tables>
 #' @export
-`db_table_temporary.Microsoft SQL Server` <- function(con, table, temporary) {
+`db_table_temporary.Microsoft SQL Server` <- function(con, table, temporary, ...) {
+  check_dots_empty0(...)
   if (temporary && substr(table, 1, 1) != "#") {
     table <- hash_temp(table)
   }

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -94,10 +94,16 @@ simulate_mssql <- function(version = "15.0") {
 }
 
 #' @export
-`sql_query_insert.Microsoft SQL Server` <- function(con, x_name, y, by, ...,
+`sql_query_insert.Microsoft SQL Server` <- function(con,
+                                                    x_name,
+                                                    y,
+                                                    by,
+                                                    ...,
                                                     conflict = c("error", "ignore"),
                                                     returning_cols = NULL,
                                                     method = NULL) {
+  check_dots_empty0(...)
+
   method <- method %||% "where_not_exists"
   arg_match(method, "where_not_exists", error_arg = "method")
   # https://stackoverflow.com/questions/25969/insert-into-values-select-from
@@ -119,6 +125,8 @@ simulate_mssql <- function(version = "15.0") {
 #' @export
 `sql_query_append.Microsoft SQL Server` <- function(con, x_name, y, ...,
                                                     returning_cols = NULL) {
+  check_dots_empty0(...)
+
   parts <- rows_prep(con, x_name, y, by = list(), lvl = 0)
   insert_cols <- escape(ident(colnames(y)), collapse = ", ", parens = TRUE, con = con)
 
@@ -136,6 +144,8 @@ simulate_mssql <- function(version = "15.0") {
 `sql_query_update_from.Microsoft SQL Server` <- function(con, x_name, y, by,
                                                          update_values, ...,
                                                          returning_cols = NULL) {
+  check_dots_empty0(...)
+
   # https://stackoverflow.com/a/2334741/946850
   parts <- rows_prep(con, x_name, y, by, lvl = 0)
   update_cols <- sql_escape_ident(con, names(update_values))
@@ -160,6 +170,8 @@ simulate_mssql <- function(version = "15.0") {
                                                     ...,
                                                     returning_cols = NULL,
                                                     method = NULL) {
+  check_dots_empty0(...)
+
   method <- method %||% "merge"
   arg_match(method, "merge", error_arg = "method")
 
@@ -190,6 +202,8 @@ simulate_mssql <- function(version = "15.0") {
 
 #' @export
 `sql_query_delete.Microsoft SQL Server` <- function(con, x_name, y, by, ..., returning_cols = NULL) {
+  check_dots_empty0(...)
+
   parts <- rows_prep(con, x_name, y, by, lvl = 0)
 
   clauses <- list2(

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -72,15 +72,21 @@ simulate_mssql <- function(version = "15.0") {
 }
 
 #' @export
-`sql_query_select.Microsoft SQL Server` <- function(con, select, from, where = NULL,
-                                             group_by = NULL, having = NULL,
-                                             window = NULL,
-                                             order_by = NULL,
-                                             limit = NULL,
-                                             distinct = FALSE,
-                                             ...,
-                                             subquery = FALSE,
-                                             lvl = 0) {
+`sql_query_select.Microsoft SQL Server` <- function(con,
+                                                    select,
+                                                    from,
+                                                    where = NULL,
+                                                    group_by = NULL,
+                                                    having = NULL,
+                                                    window = NULL,
+                                                    order_by = NULL,
+                                                    limit = NULL,
+                                                    distinct = FALSE,
+                                                    ...,
+                                                    subquery = FALSE,
+                                                    lvl = 0) {
+  check_dots_empty0(...)
+
   sql_select_clauses(con,
     select    = sql_clause_select(con, select, distinct, top = limit),
     from      = sql_clause_from(from),

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -491,6 +491,8 @@ mssql_version <- function(con) {
 
 #' @export
 `sql_returning_cols.Microsoft SQL Server` <- function(con, cols, table, ...) {
+  check_dots_empty0(...)
+
   stopifnot(table %in% c("DELETED", "INSERTED"))
   returning_cols <- sql_named_cols(con, cols, table = ident(table))
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -443,6 +443,8 @@ mssql_version <- function(con) {
 
 #' @export
 `sql_table_analyze.Microsoft SQL Server` <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   # https://docs.microsoft.com/en-us/sql/t-sql/statements/update-statistics-transact-sql
   build_sql("UPDATE STATISTICS ", as.sql(table, con = con), con = con)
 }

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -109,6 +109,8 @@ sql_translation.MySQLConnection <- sql_translation.MariaDBConnection
 
 #' @export
 sql_table_analyze.MariaDBConnection <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   build_sql("ANALYZE TABLE ", as.sql(table, con = con), con = con)
 }
 #' @export

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -117,7 +117,17 @@ sql_table_analyze.MySQL <- sql_table_analyze.MariaDBConnection
 sql_table_analyze.MySQLConnection <- sql_table_analyze.MariaDBConnection
 
 #' @export
-sql_query_join.MariaDBConnection <- function(con, x, y, vars, type = "inner", by = NULL, ...) {
+sql_query_join.MariaDBConnection <- function(con,
+                                             x,
+                                             y,
+                                             vars,
+                                             type = "inner",
+                                             by = NULL,
+                                             na_matches = FALSE,
+                                             ...,
+                                             lvl = 0) {
+  check_dots_empty0(...)
+
   if (identical(type, "full")) {
     cli_abort("MySQL does not support full joins")
   }

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -130,7 +130,9 @@ sql_query_join.MySQLConnection <- sql_query_join.MariaDBConnection
 
 
 #' @export
-sql_expr_matches.MariaDBConnection <- function(con, x, y) {
+sql_expr_matches.MariaDBConnection <- function(con, x, y, ...) {
+  check_dots_empty0(...)
+
   # https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_equal-to
   build_sql(x, " <=> ", y, con = con)
 }

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -167,6 +167,8 @@ sql_random.MySQL <- sql_random.MariaDBConnection
 sql_query_update_from.MariaDBConnection <- function(con, x_name, y, by,
                                                     update_values, ...,
                                                     returning_cols = NULL) {
+  check_dots_empty0(...)
+
   # https://stackoverflow.com/a/19346375/946850
   parts <- rows_prep(con, x_name, y, by, lvl = 0)
   update_cols <- sql_table_prefix(con, names(update_values), x_name)

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -160,6 +160,7 @@ sql_values_subquery.MariaDBConnection <- sql_values_subquery.DBIConnection
 
 #' @export
 sql_values_subquery.MySQL <-function(con, df, types, lvl = 0, ...) {
+  check_dots_empty0(...)
   # https://dev.mysql.com/doc/refman/8.0/en/values.html
   sql_values_subquery_default(con, df, types = types, lvl = lvl, row = TRUE)
 }

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -36,7 +36,8 @@ dbplyr_edition.MySQL <- dbplyr_edition.MariaDBConnection
 dbplyr_edition.MySQLConnection <- dbplyr_edition.MariaDBConnection
 
 #' @export
-db_connection_describe.MariaDBConnection <- function(con) {
+db_connection_describe.MariaDBConnection <- function(con, ...) {
+  check_dots_empty0(...)
   info <- dbGetInfo(con)
 
   paste0(

--- a/R/backend-odbc.R
+++ b/R/backend-odbc.R
@@ -66,7 +66,8 @@ base_odbc_win <- sql_translator(
 
 # nocov start
 #' @export
-db_connection_describe.OdbcConnection <- function(con) {
+db_connection_describe.OdbcConnection <- function(con, ...) {
+  check_dots_empty0(...)
   info <- DBI::dbGetInfo(con)
 
   host <- if (info$servername == "") "localhost" else info$servername

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -157,6 +157,8 @@ sql_table_analyze.Oracle <- function(con, table, ...) {
 
 #' @export
 sql_query_wrap.Oracle <- function(con, from, name = NULL, ..., lvl = 0) {
+  check_dots_empty0(...)
+
   # Table aliases in Oracle should not have an "AS": https://www.techonthenet.com/oracle/alias.php
   if (is.ident(from)) {
     build_sql("(", from, ") ", as_subquery_name(name, default = NULL), con = con)

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -151,6 +151,8 @@ sql_query_explain.Oracle <- function(con, sql, ...) {
 
 #' @export
 sql_table_analyze.Oracle <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   # https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_4005.htm
   build_sql("ANALYZE TABLE ", as.sql(table, con = con), " COMPUTE STATISTICS", con = con)
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -69,6 +69,8 @@ sql_query_upsert.Oracle <- function(con,
                                     ...,
                                     returning_cols = NULL,
                                     method = NULL) {
+  check_dots_empty0(...)
+
   method <- method %||% "merge"
   arg_match(method, c("merge", "cte_update"), error_arg = "method")
   if (method == "cte_update") {

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -179,7 +179,9 @@ setdiff.tbl_Oracle <- function(x, y, copy = FALSE, ...) {
 }
 
 #' @export
-sql_expr_matches.Oracle <- function(con, x, y) {
+sql_expr_matches.Oracle <- function(con, x, y, ...) {
+  check_dots_empty0(...)
+
   # https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions040.htm
   build_sql("decode(", x, ", ", y, ", 0, 1) = 0", con = con)
 }

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -162,6 +162,8 @@ sql_query_wrap.Oracle <- function(con, from, name = NULL, ..., lvl = 0) {
 
 #' @export
 sql_query_save.Oracle <- function(con, sql, name, temporary = TRUE, ...) {
+  check_dots_empty0(...)
+
   build_sql(
     "CREATE ", if (temporary) sql("GLOBAL TEMPORARY "), "TABLE \n",
     as.sql(name, con), " AS\n", sql,

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -182,6 +182,7 @@ sql_query_save.Oracle <- function(con, sql, name, temporary = TRUE, ...) {
 
 #' @export
 sql_values_subquery.Oracle <- function(con, df, types, lvl = 0, ...) {
+  check_dots_empty0(...)
   sql_values_subquery_union(con, df, types = types, lvl = lvl, from = "DUAL")
 }
 

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -34,15 +34,20 @@ dbplyr_edition.Oracle <- function(con) {
 }
 
 #' @export
-sql_query_select.Oracle <- function(con, select, from, where = NULL,
-                             group_by = NULL, having = NULL,
-                             window = NULL,
-                             order_by = NULL,
-                             limit = NULL,
-                             distinct = FALSE,
-                             ...,
-                             subquery = FALSE,
-                             lvl = 0) {
+sql_query_select.Oracle <- function(con,
+                                    select,
+                                    from,
+                                    where = NULL,
+                                    group_by = NULL,
+                                    having = NULL,
+                                    window = NULL,
+                                    order_by = NULL,
+                                    limit = NULL,
+                                    distinct = FALSE,
+                                    ...,
+                                    subquery = FALSE,
+                                    lvl = 0) {
+  check_dots_empty0(...)
 
   sql_select_clauses(con,
     select    = sql_clause_select(con, select, distinct),

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -135,6 +135,8 @@ sql_translation.Oracle <- function(con) {
 
 #' @export
 sql_query_explain.Oracle <- function(con, sql, ...) {
+  check_dots_empty0(...)
+
   build_sql(
     "EXPLAIN PLAN FOR ", sql, ";\n",
     "SELECT PLAN_TABLE_OUTPUT FROM TABLE(DBMS_XPLAN.DISPLAY()));",

--- a/R/backend-postgres-old.R
+++ b/R/backend-postgres-old.R
@@ -37,6 +37,7 @@ db_write_table.PostgreSQLConnection <- function(con,
 
 #' @export
 db_query_fields.PostgreSQLConnection <- function(con, sql, ...) {
+  check_dots_empty0(...)
   fields <- build_sql(
     "SELECT * FROM ", sql_subquery(con, sql), " WHERE 0=1",
     con = con

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -37,7 +37,8 @@ dbplyr_edition.PostgreSQL <- function(con) {
 dbplyr_edition.PqConnection <- dbplyr_edition.PostgreSQL
 
 #' @export
-db_connection_describe.PqConnection <- function(con) {
+db_connection_describe.PqConnection <- function(con, ...) {
+  check_dots_empty0(...)
   info <- dbGetInfo(con)
   host <- if (info$host == "") "localhost" else info$host
 

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -254,6 +254,8 @@ sql_expr_matches.PostgreSQL <- sql_expr_matches.PqConnection
 # http://www.postgresql.org/docs/9.3/static/sql-explain.html
 #' @export
 sql_query_explain.PqConnection <- function(con, sql, format = "text", ...) {
+  check_dots_empty0(...)
+
   format <- match.arg(format, c("text", "json", "yaml", "xml"))
 
   build_sql(

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -242,7 +242,9 @@ sql_translation.PqConnection <- function(con) {
 sql_translation.PostgreSQL <- sql_translation.PqConnection
 
 #' @export
-sql_expr_matches.PqConnection <- function(con, x, y) {
+sql_expr_matches.PqConnection <- function(con, x, y, ...) {
+  check_dots_empty0(...)
+
   # https://www.postgresql.org/docs/current/functions-comparison.html
   build_sql(x, " IS NOT DISTINCT FROM ", y, con = con)
 }

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -275,6 +275,8 @@ sql_query_insert.PqConnection <- function(con,
                                           ...,
                                           returning_cols = NULL,
                                           method = NULL) {
+  check_dots_empty0(...)
+
   method <- method %||% "on_conflict"
   arg_match(method, c("on_conflict", "where_not_exists"), error_arg = "method")
   if (method == "where_not_exists") {
@@ -310,6 +312,8 @@ sql_query_upsert.PqConnection <- function(con,
                                           ...,
                                           returning_cols = NULL,
                                           method = NULL) {
+  check_dots_empty0(...)
+
   method <- method %||% "on_conflict"
   arg_match(method, c("cte_update", "on_conflict"), error_arg = "method")
 

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -118,6 +118,7 @@ sql_paste_redshift <- function(sep) {
 # https://docs.aws.amazon.com/redshift/latest/dg/r_EXPLAIN.html
 #' @export
 sql_query_explain.Redshift <- function(con, sql, ...) {
+  check_dots_empty0(...)
 
   build_sql("EXPLAIN ", sql, con = con)
 }

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -128,6 +128,7 @@ sql_query_explain.RedshiftConnection <- sql_query_explain.Redshift
 
 #' @export
 sql_values_subquery.Redshift <- function(con, df, types, lvl = 0, ...) {
+  check_dots_empty0(...)
   sql_values_subquery_union(con, df, types = types, lvl = lvl)
 }
 

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -222,7 +222,9 @@ simulate_snowflake <- function() simulate_dbi("Snowflake")
 # functions that performed similar operations, and found none.
 # Link to full list: https://docs.snowflake.com/en/sql-reference/sql-all.html
 #' @export
-sql_table_analyze.Snowflake <- function(con, table, ...) {}
+sql_table_analyze.Snowflake <- function(con, table, ...) {
+  check_dots_empty0(...)
+}
 
 snowflake_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed = FALSE, useBytes = FALSE) {
   # https://docs.snowflake.com/en/sql-reference/functions/regexp.html

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -33,7 +33,8 @@ dbplyr_edition.SQLiteConnection <- function(con) {
 }
 
 #' @export
-db_connection_describe.SQLiteConnection <- function(con) {
+db_connection_describe.SQLiteConnection <- function(con, ...) {
+  check_dots_empty0(...)
   paste0("sqlite ", sqlite_version(), " [", con@dbname, "]")
 }
 

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -119,6 +119,8 @@ sql_escape_logical.SQLiteConnection <- function(con, x){
 
 #' @export
 sql_query_wrap.SQLiteConnection <- function(con, from, name = NULL, ..., lvl = 0) {
+  check_dots_empty0(...)
+
   if (is.ident(from)) {
     setNames(from, name)
   } else {

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -40,6 +40,8 @@ db_connection_describe.SQLiteConnection <- function(con, ...) {
 
 #' @export
 sql_query_explain.SQLiteConnection <- function(con, sql, ...) {
+  check_dots_empty0(...)
+
   build_sql("EXPLAIN QUERY PLAN ", sql, con = con)
 }
 

--- a/R/backend-sqlite.R
+++ b/R/backend-sqlite.R
@@ -130,7 +130,9 @@ sql_query_wrap.SQLiteConnection <- function(con, from, name = NULL, ..., lvl = 0
 }
 
 #' @export
-sql_expr_matches.SQLiteConnection <- function(con, x, y) {
+sql_expr_matches.SQLiteConnection <- function(con, x, y, ...) {
+  check_dots_empty0(...)
+
   # https://sqlite.org/lang_expr.html#isisnot
   build_sql(x, " IS ", y, con = con)
 }

--- a/R/backend-teradata.R
+++ b/R/backend-teradata.R
@@ -43,6 +43,8 @@ sql_query_select.Teradata <- function(con,
                                       ...,
                                       subquery = FALSE,
                                       lvl = 0) {
+  check_dots_empty0(...)
+
   # #685
   # https://docs.teradata.com/r/2_MC9vCtAJRlKle2Rpb0mA/frQm7Rn09FJZZLQAuaUvJA
   # You cannot specify these options in a SELECT statement that specifies the TOP n operator:

--- a/R/backend-teradata.R
+++ b/R/backend-teradata.R
@@ -202,6 +202,8 @@ sql_translation.Teradata <- function(con) {
 
 #' @export
 sql_table_analyze.Teradata <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   # https://www.tutorialspoint.com/teradata/teradata_statistics.htm
   build_sql("COLLECT STATISTICS ", as.sql(table, con = con) , con = con)
 }

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -122,6 +122,8 @@ db_collect <- function(con, sql, n = -1, warn_incomplete = TRUE, ...) {
 }
 #' @export
 db_collect.DBIConnection <- function(con, sql, n = -1, warn_incomplete = TRUE, ...) {
+  check_dots_empty0(...)
+
   res <- dbSendQuery(con, sql)
   tryCatch({
     out <- dbFetch(res, n = n)

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -190,11 +190,12 @@ with_transaction <- function(con, in_transaction, code) {
 
 #' @export
 #' @rdname db-io
-db_table_temporary <- function(con, table, temporary) {
+db_table_temporary <- function(con, table, temporary, ...) {
   UseMethod("db_table_temporary")
 }
 #' @export
-db_table_temporary.DBIConnection <- function(con, table, temporary) {
+db_table_temporary.DBIConnection <- function(con, table, temporary, ...) {
+  check_dots_empty0(...)
   list(
     table = table,
     temporary = temporary

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -39,11 +39,18 @@ db_copy_to <-  function(con, table, values,
   UseMethod("db_copy_to")
 }
 #' @export
-db_copy_to.DBIConnection <- function(con, table, values,
-                            overwrite = FALSE, types = NULL, temporary = TRUE,
-                            unique_indexes = NULL, indexes = NULL,
-                            analyze = TRUE, ...,
-                            in_transaction = TRUE) {
+db_copy_to.DBIConnection <- function(con,
+                                     table,
+                                     values,
+                                     overwrite = FALSE,
+                                     types = NULL,
+                                     temporary = TRUE,
+                                     unique_indexes = NULL,
+                                     indexes = NULL,
+                                     analyze = TRUE,
+                                     ...,
+                                     in_transaction = TRUE) {
+  check_dots_empty0(...)
 
   new <- db_table_temporary(con, table, temporary)
   table <- new$table

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -101,6 +101,8 @@ db_compute.DBIConnection <- function(con,
                                      indexes = list(),
                                      analyze = TRUE,
                                      ...) {
+  check_dots_empty0()
+
   new <- db_table_temporary(con, table, temporary)
   table <- new$table
   temporary <- new$temporary

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -584,6 +584,8 @@ sql_query_set_op <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
 }
 #' @export
 sql_query_set_op.DBIConnection <- function(con, x, y, method, ..., all = FALSE, lvl = 0) {
+  check_dots_empty0(...)
+
   method <- paste0(method, if (all) " ALL")
   method <- style_kw(method)
   lines <- list(

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -319,15 +319,21 @@ sql_query_select <- function(con, select, from, where = NULL,
 }
 
 #' @export
-sql_query_select.DBIConnection <- function(con, select, from, where = NULL,
-                               group_by = NULL, having = NULL,
-                               window = NULL,
-                               order_by = NULL,
-                               limit = NULL,
-                               distinct = FALSE,
-                               ...,
-                               subquery = FALSE,
-                               lvl = 0) {
+sql_query_select.DBIConnection <- function(con,
+                                           select,
+                                           from,
+                                           where = NULL,
+                                           group_by = NULL,
+                                           having = NULL,
+                                           window = NULL,
+                                           order_by = NULL,
+                                           limit = NULL,
+                                           distinct = FALSE,
+                                           ...,
+                                           subquery = FALSE,
+                                           lvl = 0) {
+  check_dots_empty0(...)
+
   sql_select_clauses(con,
     select    = sql_clause_select(con, select, distinct),
     from      = sql_clause_from(from),

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -368,11 +368,29 @@ sql_select.DBIConnection <- function(con,
 
 #' @rdname db-sql
 #' @export
-sql_query_join <- function(con, x, y, vars, type = "inner", by = NULL, na_matches = FALSE, ..., lvl = 0) {
+sql_query_join <- function(con,
+                           x,
+                           y,
+                           vars,
+                           type = "inner",
+                           by = NULL,
+                           na_matches = FALSE,
+                           ...,
+                           lvl = 0) {
   UseMethod("sql_query_join")
 }
 #' @export
-sql_query_join.DBIConnection <- function(con, x, y, vars, type = "inner", by = NULL, na_matches = FALSE, ..., lvl = 0) {
+sql_query_join.DBIConnection <- function(con,
+                                         x,
+                                         y,
+                                         vars,
+                                         type = "inner",
+                                         by = NULL,
+                                         na_matches = FALSE,
+                                         ...,
+                                         lvl = 0) {
+  check_dots_empty0(...)
+
   JOIN <- switch(
     type,
     left = sql("LEFT JOIN"),

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -489,6 +489,8 @@ sql_query_multi_join.DBIConnection <- function(con,
                                                vars,
                                                ...,
                                                lvl = 0) {
+  check_dots_empty0(...)
+
   table_names <- names(table_vars)
   if (vctrs::vec_duplicate_any(table_names)) {
     cli_abort("{.arg table_names} must be unique.")

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -229,6 +229,8 @@ sql_query_wrap <- function(con, from, name = NULL, ..., lvl = 0) {
 }
 #' @export
 sql_query_wrap.DBIConnection <- function(con, from, name = NULL, ..., lvl = 0) {
+  check_dots_empty0(...)
+
   if (is.ident(from)) {
     setNames(from, name)
   } else if (is_schema(from) || is_catalog(from)) {

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -271,6 +271,8 @@ sql_query_rows <- function(con, sql, ...) {
 }
 #' @export
 sql_query_rows.DBIConnection <- function(con, sql, ...) {
+  check_dots_empty0(...)
+
   from <- dbplyr_sql_subquery(con, sql, "master")
   build_sql("SELECT COUNT(*) FROM ", from, con = con)
 }

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -449,6 +449,7 @@ sql_query_multi_join <- function(con,
                                  joins,
                                  table_vars,
                                  vars,
+                                 by_list,
                                  ...,
                                  lvl = 0) {
   UseMethod("sql_query_multi_join")
@@ -489,6 +490,7 @@ sql_query_multi_join.DBIConnection <- function(con,
                                                joins,
                                                table_vars,
                                                vars,
+                                               by_list,
                                                ...,
                                                lvl = 0) {
   check_dots_empty0(...)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -141,6 +141,8 @@ sql_table_analyze <- function(con, table, ...) {
 }
 #' @export
 sql_table_analyze.DBIConnection <- function(con, table, ...) {
+  check_dots_empty0(...)
+
   build_sql("ANALYZE ", as.sql(table, con = con), con = con)
 }
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -93,12 +93,14 @@ NULL
 
 #' @export
 #' @rdname db-sql
-sql_expr_matches <- function(con, x, y) {
+sql_expr_matches <- function(con, x, y, ...) {
   UseMethod("sql_expr_matches")
 }
 # https://modern-sql.com/feature/is-distinct-from
 #' @export
-sql_expr_matches.DBIConnection <- function(con, x, y) {
+sql_expr_matches.DBIConnection <- function(con, x, y, ...) {
+  check_dots_empty0(...)
+
   build_sql(
     "CASE WHEN (", x, " = ", y, ") OR (", x, " IS NULL AND ", y, " IS NULL) ",
     "THEN 0 ",

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -666,6 +666,8 @@ sql_query_insert.DBIConnection <- function(con,
                                            conflict = c("error", "ignore"),
                                            returning_cols = NULL,
                                            method = NULL) {
+  check_dots_empty0(...)
+
   method <- method %||% "where_not_exists"
   arg_match(method, "where_not_exists", error_arg = "method")
   # https://stackoverflow.com/questions/25969/insert-into-values-select-from
@@ -693,6 +695,8 @@ sql_query_append <- function(con, x_name, y, ..., returning_cols = NULL) {
 
 #' @export
 sql_query_append.DBIConnection <- function(con, x_name, y, ..., returning_cols = NULL) {
+  check_dots_empty0(...)
+
   # https://stackoverflow.com/questions/25969/insert-into-values-select-from
   parts <- rows_prep(con, x_name, y, by = list(), lvl = 0)
   insert_cols <- escape(ident(colnames(y)), collapse = ", ", parens = TRUE, con = con)
@@ -719,6 +723,8 @@ sql_query_update_from <- function(con, x_name, y, by, update_values, ...,
 sql_query_update_from.DBIConnection <- function(con, x_name, y, by,
                                                 update_values, ...,
                                                 returning_cols = NULL) {
+  check_dots_empty0(...)
+
   # https://stackoverflow.com/questions/2334712/how-do-i-update-from-a-select-in-sql-server
   parts <- rows_prep(con, x_name, y, by, lvl = 0)
   update_cols <- sql_escape_ident(con, names(update_values))
@@ -760,6 +766,9 @@ sql_query_upsert.DBIConnection <- function(con,
                                            ...,
                                            returning_cols = NULL,
                                            method = NULL) {
+  check_dots_empty0(...)
+
+
   method <- method %||% "cte_update"
   arg_match(method, "cte_update", error_arg = "method")
 
@@ -805,6 +814,8 @@ sql_query_delete <- function(con, x_name, y, by, ..., returning_cols = NULL) {
 
 #' @export
 sql_query_delete.DBIConnection <- function(con, x_name, y, by, ..., returning_cols = NULL) {
+  check_dots_empty0(...)
+
   parts <- rows_prep(con, x_name, y, by, lvl = 0)
 
   clauses <- list2(

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -214,6 +214,8 @@ sql_query_save <- function(con, sql, name, temporary = TRUE, ...) {
 }
 #' @export
 sql_query_save.DBIConnection <- function(con, sql, name, temporary = TRUE, ...) {
+  check_dots_empty0(...)
+
   build_sql(
     "CREATE ", if (temporary) sql("TEMPORARY "), "TABLE \n",
     as.sql(name, con), " AS\n", sql,

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -185,6 +185,8 @@ sql_query_explain <- function(con, sql, ...) {
 }
 #' @export
 sql_query_explain.DBIConnection <- function(con, sql, ...) {
+  check_dots_empty0(...)
+
   build_sql("EXPLAIN ", sql, con = con)
 }
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -159,11 +159,12 @@ sql_table_index.DBIConnection <- function(con,
                                           unique = FALSE,
                                           ...,
                                           call = caller_env()) {
+  check_dots_empty0(...)
+
   if (!(is_string(table) || is_schema(table))) {
     stop_input_type(
       table,
       c("a string", "a schema"),
-      ...,
       call = call
     )
   }
@@ -888,6 +889,8 @@ sql_returning_cols <- function(con, cols, table, ...) {
 
 #' @export
 sql_returning_cols.DBIConnection <- function(con, cols, table, ...) {
+  check_dots_empty0(...)
+
   returning_cols <- sql_named_cols(con, cols, table = table)
 
   sql_clause("RETURNING", returning_cols)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -548,6 +548,8 @@ sql_query_semi_join <- function(con, x, y, anti, by, vars, ..., lvl = 0) {
 }
 #' @export
 sql_query_semi_join.DBIConnection <- function(con, x, y, anti, by, vars, ..., lvl = 0) {
+  check_dots_empty0(...)
+
   x <- dbplyr_sql_subquery(con, x, name = by$x_as)
   y <- dbplyr_sql_subquery(con, y, name = by$y_as)
 

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -197,7 +197,14 @@ sql_query_fields <- function(con, sql, ...) {
 }
 #' @export
 sql_query_fields.DBIConnection <- function(con, sql, ...) {
-  dbplyr_query_select(con, sql("*"), dbplyr_sql_subquery(con, sql), where = sql("0 = 1"))
+  check_dots_empty0(...)
+
+  dbplyr_query_select(
+    con,
+    sql("*"),
+    dbplyr_sql_subquery(con, sql),
+    where = sql("0 = 1")
+  )
 }
 
 #' @rdname db-sql

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -394,7 +394,15 @@ dbplyr_query_join <- function(con, ..., lvl = 0) {
 }
 #' @export
 #' @importFrom dplyr sql_join
-sql_join.DBIConnection <- function(con, x, y, vars, type = "inner", by = NULL, na_matches = FALSE, ..., lvl = 0) {
+sql_join.DBIConnection <- function(con,
+                                   x,
+                                   y,
+                                   vars,
+                                   type = "inner",
+                                   by = NULL,
+                                   na_matches = FALSE,
+                                   ...,
+                                   lvl = 0) {
   sql_query_join(
     con, x, y, vars,
     type = type,

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -913,6 +913,8 @@ dbplyr_analyze <- function(con, ...) {
 #' @export
 #' @importFrom dplyr db_analyze
 db_analyze.DBIConnection <- function(con, table, ...) {
+  check_dots_used()
+
   sql <- sql_table_analyze(con, table, ...)
   if (is.null(sql)) {
     return() # nocov

--- a/R/db.R
+++ b/R/db.R
@@ -31,12 +31,13 @@ db_desc.DBIConnection <- function(x) {
 }
 #' @export
 #' @rdname db-misc
-db_connection_describe <- function(con) {
+db_connection_describe <- function(con, ...) {
   UseMethod("db_connection_describe")
 }
 # nocov start
 #' @export
-db_connection_describe.DBIConnection <- function(con) {
+db_connection_describe.DBIConnection <- function(con, ...) {
+  check_dots_empty0(...)
   class(con)[[1]]
 }
 # nocov end

--- a/R/explain.R
+++ b/R/explain.R
@@ -1,6 +1,7 @@
 #' @importFrom dplyr show_query
 #' @export
 show_query.tbl_lazy <- function(x, ..., cte = FALSE) {
+  check_dots_empty0(...)
   withr::local_options(list(dbplyr_use_colour = TRUE))
   sql <- remote_query(x, cte = cte)
   cat_line("<SQL>")

--- a/R/lazy-join-query.R
+++ b/R/lazy-join-query.R
@@ -181,6 +181,8 @@ op_vars.lazy_semi_join_query <- function(op) {
 
 #' @export
 sql_build.lazy_multi_join_query <- function(op, con, ...) {
+  check_dots_empty0(...)
+
   table_names_out <- generate_join_table_names(op$table_names)
 
   table_vars <- purrr::map(
@@ -238,6 +240,8 @@ generate_join_table_names <- function(table_names) {
 
 #' @export
 sql_build.lazy_rf_join_query <- function(op, con, ...) {
+  check_dots_empty0(...)
+
   table_names_out <- generate_join_table_names(op$table_names)
 
   vars_classic <- as.list(op$vars)
@@ -261,6 +265,8 @@ sql_build.lazy_rf_join_query <- function(op, con, ...) {
 
 #' @export
 sql_build.lazy_semi_join_query <- function(op, con, ...) {
+  check_dots_empty0(...)
+
   vars_prev <- op_vars(op$x)
   if (identical(op$vars$var, op$vars$name) &&
       identical(op$vars$var, vars_prev)) {

--- a/R/lazy-ops.R
+++ b/R/lazy-ops.R
@@ -57,11 +57,13 @@ print.lazy_base_local_query <- function(x, ...) {
 
 #' @export
 sql_build.lazy_base_remote_query <- function(op, con, ...) {
+  check_dots_empty0(...)
   as.sql(op$x, con = con)
 }
 
 #' @export
 sql_build.lazy_base_local_query <- function(op, con, ...) {
+  check_dots_empty0(...)
   ident(op$name)
 }
 

--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -165,6 +165,8 @@ op_desc.lazy_query <- function(op) {
 
 #' @export
 sql_build.lazy_select_query <- function(op, con, ...) {
+  check_dots_empty0(...)
+
   if (!is.null(op$message_summarise)) {
     inform(op$message_summarise)
   }

--- a/R/lazy-set-op-query.R
+++ b/R/lazy-set-op-query.R
@@ -37,6 +37,8 @@ op_vars.lazy_set_op_query <- function(op) {
 
 #' @export
 sql_build.lazy_set_op_query <- function(op, con, ...) {
+  check_dots_empty0(...)
+
   # add_op_set_op() ensures that both have same variables
   set_op_query(
     sql_optimise(sql_build(op$x, con), con),

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -59,7 +59,11 @@ print.multi_join_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
+sql_render.join_query <- function(query,
+                                  con = NULL,
+                                  ...,
+                                  subquery = FALSE,
+                                  lvl = 0) {
   from_x <- sql_render(query$x, con, ..., subquery = TRUE, lvl = lvl + 1)
   from_y <- sql_render(query$y, con, ..., subquery = TRUE, lvl = lvl + 1)
 
@@ -73,7 +77,11 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl 
 }
 
 #' @export
-sql_render.multi_join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
+sql_render.multi_join_query <- function(query,
+                                        con = NULL,
+                                        ...,
+                                        subquery = FALSE,
+                                        lvl = 0) {
   x <- sql_render(query$x, con, ..., subquery = TRUE, lvl = lvl + 1)
   query$joins$table <- purrr::map(
     query$joins$table,

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -77,7 +77,7 @@ sql_render.multi_join_query <- function(query, con = NULL, ..., subquery = FALSE
   x <- sql_render(query$x, con, ..., subquery = TRUE, lvl = lvl + 1)
   query$joins$table <- purrr::map(
     query$joins$table,
-    ~ sql_render(.x, con, ..., subquery = TRUE, lvl = lvl + 1)
+    function(table) sql_render(table, con, ..., subquery = TRUE, lvl = lvl + 1)
   )
 
   sql_query_multi_join(

--- a/R/query-semi-join.R
+++ b/R/query-semi-join.R
@@ -29,7 +29,11 @@ print.semi_join_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.semi_join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
+sql_render.semi_join_query <- function(query,
+                                       con = NULL,
+                                       ...,
+                                       subquery = FALSE,
+                                       lvl = 0) {
   from_x <- sql_render(query$x, con, ..., subquery = TRUE, lvl = lvl + 1)
   from_y <- sql_render(query$y, con, ..., subquery = TRUE, lvl = lvl + 1)
 

--- a/R/query-set-op.R
+++ b/R/query-set-op.R
@@ -24,7 +24,11 @@ print.set_op_query <- function(x, ...) {
 }
 
 #' @export
-sql_render.set_op_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0) {
+sql_render.set_op_query <- function(query,
+                                    con = NULL,
+                                    ...,
+                                    subquery = FALSE,
+                                    lvl = 0) {
   sub_lvl <- lvl + !inherits(con, "SQLiteConnection")
   from_x <- sql_render(query$x, con, ..., subquery = FALSE, lvl = sub_lvl)
   from_y <- sql_render(query$y, con, ..., subquery = FALSE, lvl = sub_lvl)

--- a/R/query.R
+++ b/R/query.R
@@ -1,5 +1,6 @@
 #' @export
 sql_build.query <- function(op, con = NULL, ...) {
+  check_dots_empty0(...)
   op
 }
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -561,6 +561,8 @@ has_returned_rows <- function(x) {
 
 #' @export
 sql_returning_cols.duckdb_connection <- function(con, cols, ...) {
+  check_dots_empty0(...)
+
   cli_abort("DuckDB does not support the {.arg returning} argument.")
 }
 

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -53,12 +53,22 @@ sql_render <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = 
 }
 
 #' @export
-sql_render.tbl_lazy <- function(query, con = query$src$con, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render.tbl_lazy <- function(query,
+                                con = query$src$con,
+                                ...,
+                                subquery = FALSE,
+                                lvl = 0,
+                                cte = FALSE) {
   sql_render(query$lazy_query, con = con, ..., subquery = subquery, lvl = lvl, cte = cte)
 }
 
 #' @export
-sql_render.lazy_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render.lazy_query <- function(query,
+                                  con = NULL,
+                                  ...,
+                                  subquery = FALSE,
+                                  lvl = 0,
+                                  cte = FALSE) {
   qry <- sql_build(query, con = con, ...)
   qry <- sql_optimise(qry, con = con, ..., subquery = subquery)
 
@@ -184,12 +194,26 @@ flatten_query.sql <- function(qry, query_list) {
 }
 
 #' @export
-sql_render.sql <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render.sql <- function(query,
+                           con = NULL,
+                           ...,
+                           subquery = FALSE,
+                           lvl = 0,
+                           cte = FALSE) {
+  check_dots_empty0(...)
+
   query
 }
 
 #' @export
-sql_render.ident <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render.ident <- function(query,
+                             con = NULL,
+                             ...,
+                             subquery = FALSE,
+                             lvl = 0,
+                             cte = FALSE) {
+  check_dots_empty0(...)
+
   if (subquery) {
     query
   } else {
@@ -198,7 +222,12 @@ sql_render.ident <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, 
 }
 
 #' @export
-sql_render.dbplyr_schema <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render.dbplyr_schema <- function(query,
+                                     con = NULL,
+                                     ...,
+                                     subquery = FALSE,
+                                     lvl = 0,
+                                     cte = FALSE) {
   query <- as.sql(query, con)
   sql_render(query, con = con, ..., subquery = subquery, lvl = lvl, cte = cte)
 }

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -30,6 +30,7 @@ sql_build <- function(op, con = NULL, ...) {
 
 #' @export
 sql_build.tbl_lazy <- function(op, con = op$src$con, ...) {
+  check_dots_used()
   # only used for testing
   qry <- sql_build(op$lazy_query, con = con, ...)
   sql_optimise(qry, con = con, ...)
@@ -37,6 +38,7 @@ sql_build.tbl_lazy <- function(op, con = op$src$con, ...) {
 
 #' @export
 sql_build.ident <- function(op, con = NULL, ...) {
+  check_dots_empty0(...)
   op
 }
 

--- a/R/src-sql.R
+++ b/R/src-sql.R
@@ -27,6 +27,7 @@ same_src.src_sql <- function(x, y) {
 #' @importFrom dplyr src_tbls
 #' @export
 src_tbls.src_sql <- function(x, ...) {
+  check_dots_empty0(...)
   dbListTables(x$con)
 }
 

--- a/R/tbl-sql.R
+++ b/R/tbl-sql.R
@@ -13,6 +13,8 @@
 #'   Mainly useful for better performance when creating
 #'   multiple `tbl` objects.
 tbl_sql <- function(subclass, src, from, ..., vars = NULL) {
+  check_dots_empty0(...)
+
   # If not literal sql, must be a table identifier
   from_sql <- as.sql(from, con = src$con)
   if (!(is.ident(from) || is.sql(from) || is_schema(from))) {

--- a/R/verb-compute.R
+++ b/R/verb-compute.R
@@ -14,6 +14,7 @@
 #' db <- memdb_frame(a = c(3, 4, 1, 2), b = c(5, 1, 2, NA))
 #' db %>% filter(a <= 2) %>% collect()
 collapse.tbl_sql <- function(x, ...) {
+  check_dots_empty0(...)
   sql <- db_sql_render(x$src$con, x)
 
   tbl_src_dbi(x$src, sql, colnames(x)) %>%

--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -198,6 +198,7 @@ sql_values_subquery <- function(con, df, types, lvl = 0, ...) {
 
 #' @export
 sql_values_subquery.DBIConnection <- function(con, df, types, lvl = 0, ...) {
+  check_dots_empty0(...)
   sql_values_subquery_default(con, df, types = types, lvl = lvl, row = FALSE)
 }
 
@@ -244,6 +245,7 @@ sql_values_subquery_default <- function(con, df, types, lvl, row) {
 }
 
 sql_values_subquery_column_alias <- function(con, df, types, lvl, ...) {
+  check_dots_empty0(...)
   df <- values_prepare(con, df)
   if (nrow(df) == 0L) {
     return(sql_values_zero_rows(con, df, types, lvl))

--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -166,6 +166,7 @@ lazy_values_query <- function(df, types) {
 
 #' @export
 sql_build.lazy_values_query <- function(op, con, ...) {
+  check_dots_empty0(...)
   op
 }
 

--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -170,7 +170,14 @@ sql_build.lazy_values_query <- function(op, con, ...) {
 }
 
 #' @export
-sql_render.lazy_values_query <- function(query, con = query$src$con, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render.lazy_values_query <- function(query,
+                                         con = query$src$con,
+                                         ...,
+                                         subquery = FALSE,
+                                         lvl = 0,
+                                         cte = FALSE) {
+  check_dots_empty0(...)
+
   sql_values_subquery(con, query$x, types = query$col_types, lvl = lvl)
 }
 

--- a/R/verb-head.R
+++ b/R/verb-head.R
@@ -26,6 +26,8 @@
 #' db2 <- lazy_frame(x = 1:100, con = simulate_mssql())
 #' db2 %>% head() %>% show_query()
 head.tbl_lazy <- function(x, n = 6L, ...) {
+  check_dots_empty0(...)
+
   if (!is.numeric(n) || length(n) != 1L || n < 0) {
     cli_abort("{.arg n} must be a non-negative integer")
   }

--- a/R/verb-pull.R
+++ b/R/verb-pull.R
@@ -16,6 +16,8 @@
 #'   mutate(z = x + y * 2) %>%
 #'   pull()
 pull.tbl_sql <- function(.data, var = -1, name = NULL, ...) {
+  check_dots_empty0(...)
+
   vars <- tbl_vars(.data)
   var <- tidyselect::vars_pull(vars, !!enquo(var), error_arg = "var")
   name_quo <- enquo(name)

--- a/R/verb-set-ops.R
+++ b/R/verb-set-ops.R
@@ -10,6 +10,8 @@
 # registered onLoad
 #' @importFrom dplyr intersect
 intersect.tbl_lazy <- function(x, y, copy = FALSE, ..., all = FALSE) {
+  check_dots_empty0(...)
+
   lazy_query <- add_set_op(x, y, "INTERSECT", copy = copy, ..., all = all)
 
   x$lazy_query <- lazy_query
@@ -19,6 +21,8 @@ intersect.tbl_lazy <- function(x, y, copy = FALSE, ..., all = FALSE) {
 #' @importFrom dplyr union
 #' @rdname intersect.tbl_lazy
 union.tbl_lazy <- function(x, y, copy = FALSE, ..., all = FALSE) {
+  check_dots_empty0(...)
+
   lazy_query <- add_set_op(x, y, "UNION", copy = copy, ..., all = all)
 
   x$lazy_query <- lazy_query
@@ -28,6 +32,8 @@ union.tbl_lazy <- function(x, y, copy = FALSE, ..., all = FALSE) {
 #' @importFrom dplyr union_all
 #' @rdname intersect.tbl_lazy
 union_all.tbl_lazy <- function(x, y, copy = FALSE, ...) {
+  check_dots_empty0(...)
+
   lazy_query <- add_set_op(x, y, "UNION ALL", copy = copy, ..., all = FALSE)
 
   x$lazy_query <- lazy_query
@@ -37,6 +43,8 @@ union_all.tbl_lazy <- function(x, y, copy = FALSE, ...) {
 #' @importFrom dplyr setdiff
 #' @rdname intersect.tbl_lazy
 setdiff.tbl_lazy <- function(x, y, copy = FALSE, ..., all = FALSE) {
+  check_dots_empty0(...)
+
   lazy_query <- add_set_op(x, y, "EXCEPT", copy = copy, ..., all = all)
 
   x$lazy_query <- lazy_query
@@ -44,6 +52,8 @@ setdiff.tbl_lazy <- function(x, y, copy = FALSE, ..., all = FALSE) {
 }
 
 add_set_op <- function(x, y, type, copy = FALSE, ..., all = FALSE, call = caller_env()) {
+  check_dots_empty0(...)
+
   y <- auto_copy(x, y, copy)
 
   if (inherits(x$src$con, "SQLiteConnection")) {

--- a/R/verb-slice.R
+++ b/R/verb-slice.R
@@ -76,6 +76,7 @@ slice_min.tbl_lazy <- function(.data,
                                by = NULL,
                                with_ties = TRUE,
                                na_rm = TRUE) {
+  check_dots_empty0(...)
   size <- check_slice_size(n, prop)
   check_unsupported_arg(na_rm, allowed = TRUE)
   slice_by(
@@ -98,6 +99,7 @@ slice_max.tbl_lazy <- function(.data,
                                prop,
                                with_ties = TRUE,
                                na_rm = TRUE) {
+  check_dots_empty0(...)
   size <- check_slice_size(n, prop)
   check_unsupported_arg(na_rm, allowed = TRUE)
   slice_by(
@@ -119,6 +121,7 @@ slice_sample.tbl_lazy <- function(.data,
                                   by = NULL,
                                   weight_by = NULL,
                                   replace = FALSE) {
+  check_dots_empty0(...)
   size <- check_slice_size(n, prop)
   weight_by <- enquo(weight_by)
   if (size$type == "prop") {

--- a/man/db-io.Rd
+++ b/man/db-io.Rd
@@ -34,7 +34,7 @@ db_compute(
 
 db_collect(con, sql, n = -1, warn_incomplete = TRUE, ...)
 
-db_table_temporary(con, table, temporary)
+db_table_temporary(con, table, temporary, ...)
 }
 \description{
 These generics are responsible for getting data into and out of the

--- a/man/db-misc.Rd
+++ b/man/db-misc.Rd
@@ -7,7 +7,7 @@
 \alias{dbplyr_edition}
 \title{Miscellaneous database generics}
 \usage{
-db_connection_describe(con)
+db_connection_describe(con, ...)
 
 sql_join_suffix(con, ...)
 

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -23,7 +23,7 @@
 \alias{sql_returning_cols}
 \title{SQL generation generics}
 \usage{
-sql_expr_matches(con, x, y)
+sql_expr_matches(con, x, y, ...)
 
 sql_translation(con)
 

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -77,7 +77,7 @@ sql_query_join(
   lvl = 0
 )
 
-sql_query_multi_join(con, x, joins, table_vars, vars, ..., lvl = 0)
+sql_query_multi_join(con, x, joins, table_vars, vars, by_list, ..., lvl = 0)
 
 sql_query_semi_join(con, x, y, anti, by, vars, ..., lvl = 0)
 


### PR DESCRIPTION
Closes #919.

This PR adds `...` to these generics:

* `db_connection_describe()`
* `db_table_temporary()`
* `sql_expr_matches()`

and checks for empty dots in most methods with dots.