### PR TITLE
Add argument checks in some basic SQL functions

### DIFF
--- a/R/db-io.R
+++ b/R/db-io.R
@@ -42,6 +42,14 @@ db_copy_to <-  function(con,
                         analyze = TRUE,
                         ...,
                         in_transaction = TRUE) {
+  check_table_ident(table)
+  check_bool(overwrite)
+  check_character(types, allow_null = TRUE)
+  check_named(types)
+  check_bool(temporary)
+  check_bool(analyze)
+  check_bool(in_transaction)
+
   UseMethod("db_copy_to")
 }
 #' @export

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -102,6 +102,10 @@ db_compute <- function(con,
                        indexes = list(),
                        analyze = TRUE,
                        ...) {
+  check_table_ident(table)
+  check_scalar_sql(sql)
+  check_bool(temporary)
+
   UseMethod("db_compute")
 }
 #' @export

--- a/R/db-io.R
+++ b/R/db-io.R
@@ -158,6 +158,11 @@ db_write_table.DBIConnection <- function(con,
                                          values,
                                          temporary = TRUE,
                                          ...) {
+  check_table_ident(table)
+  check_character(types, allow_null = TRUE)
+  check_named(types)
+  check_bool(temporary)
+
   tryCatch(
     dbWriteTable(
       con,

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -196,6 +196,8 @@ sql_query_explain.DBIConnection <- function(con, sql, ...) {
 #' @rdname db-sql
 #' @export
 sql_query_fields <- function(con, sql, ...) {
+  check_table_ident(sql, sql = TRUE)
+
   UseMethod("sql_query_fields")
 }
 #' @export

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -150,7 +150,18 @@ sql_table_analyze.DBIConnection <- function(con, table, ...) {
 
 #' @rdname db-sql
 #' @export
-sql_table_index <- function(con, table, columns, name = NULL, unique = FALSE, ...) {
+sql_table_index <- function(con,
+                            table,
+                            columns,
+                            name = NULL,
+                            unique = FALSE,
+                            ...,
+                            call = caller_env()) {
+  check_table_ident(table, call = call)
+  check_character(columns, call = call)
+  check_name(name, allow_null = TRUE, call = call)
+  check_bool(unique, call = call)
+
   UseMethod("sql_table_index")
 }
 #' @export
@@ -161,16 +172,6 @@ sql_table_index.DBIConnection <- function(con,
                                           unique = FALSE,
                                           ...,
                                           call = caller_env()) {
-  if (!(is_string(table) || is_schema(table))) {
-    stop_input_type(
-      table,
-      c("a string", "a schema"),
-      ...,
-      call = call
-    )
-  }
-  check_character(columns)
-
   name <- name %||% paste0(c(unclass(table), columns), collapse = "_")
   fields <- escape(ident(columns), parens = TRUE, con = con)
   build_sql(

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -208,6 +208,10 @@ sql_query_fields.DBIConnection <- function(con, sql, ...) {
 #' @rdname db-sql
 #' @export
 sql_query_save <- function(con, sql, name, temporary = TRUE, ...) {
+  check_table_ident(sql, sql = TRUE)
+  check_table_ident(name)
+  check_bool(temporary)
+
   UseMethod("sql_query_save")
 }
 #' @export

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -225,6 +225,8 @@ sql_query_save.DBIConnection <- function(con, sql, name, temporary = TRUE, ...) 
 #' @export
 #' @rdname db-sql
 sql_query_wrap <- function(con, from, name = NULL, ..., lvl = 0) {
+  check_name(name, allow_null = TRUE)
+
   UseMethod("sql_query_wrap")
 }
 #' @export

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -186,6 +186,7 @@ sql_table_index.DBIConnection <- function(con,
 #' @rdname db-sql
 #' @export
 sql_query_explain <- function(con, sql, ...) {
+  check_scalar_sql(sql)
   UseMethod("sql_query_explain")
 }
 #' @export

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -271,6 +271,8 @@ sql_indent_subquery <- function(from, con, lvl = 0) {
 #' @rdname db-sql
 #' @export
 sql_query_rows <- function(con, sql, ...) {
+  check_table_ident(sql, sql = TRUE)
+
   UseMethod("sql_query_rows")
 }
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -225,7 +225,11 @@ check_named <- function(x, ..., arg = caller_arg(x), call = caller_env()) {
   }
 }
 
-check_table_ident <- function(x, ..., arg = caller_arg(x), call = caller_env()) {
+check_table_ident <- function(x,
+                              ...,
+                              sql = FALSE,
+                              arg = caller_arg(x),
+                              call = caller_env()) {
   if (is_bare_string(x)) {
     return()
   }
@@ -249,10 +253,16 @@ check_table_ident <- function(x, ..., arg = caller_arg(x), call = caller_env()) 
       ), call = call
       )
     }
+  } else if (sql && is.sql(x)) {
+    n <- length(x)
   } else {
+    what <- c("ident", "schema", "catalog", "Id")
+    if (sql) {
+      what <- c(what, "sql")
+    }
     stop_input_type(
       x,
-      what = c("ident", "schema", "catalog", "Id"),
+      what = what,
       call = call,
       arg = arg
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -224,3 +224,41 @@ check_named <- function(x, ..., arg = caller_arg(x), call = caller_env()) {
     cli_abort("The names of {.arg {arg}} must be unique.", call = call)
   }
 }
+
+check_table_ident <- function(x, ..., arg = caller_arg(x), call = caller_env()) {
+  if (is_bare_string(x)) {
+    return()
+  }
+
+  # also covers `ident_q`
+  if (is.ident(x)) {
+    n <- length(x)
+  } else if (is_schema(x)) {
+    n <- vctrs::vec_size_common(x$schema, x$table)
+  } else if (is_catalog(x)) {
+    n <- vctrs::vec_size_common(x$catalog, x$schema, x$table)
+  } else if (inherits(x, "Id")) {
+    n <- 1L
+    id <- x@name
+    known_names <- c("catalog", "schema", "table")
+    unknown_names <- setdiff(names(id), known_names)
+    if (!is_empty(unknown_names)) {
+      cli_abort(c(
+        "{.arg {arg}} is an {.cls Id} object with unknown names {.val {unknown_names}}.",
+        i = "An {.cls Id} object may only have the names {.val {known_names}}."
+      ), call = call
+      )
+    }
+  } else {
+    stop_input_type(
+      x,
+      what = c("ident", "schema", "catalog", "Id"),
+      call = call,
+      arg = arg
+    )
+  }
+
+  if (n != 1L) {
+    cli_abort("{.arg {arg}} must have size 1, not size {n}.", call = call)
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -272,3 +272,24 @@ check_table_ident <- function(x,
     cli_abort("{.arg {arg}} must have size 1, not size {n}.", call = call)
   }
 }
+
+check_scalar_sql <- function(x,
+                             ...,
+                             string = TRUE,
+                             arg = caller_arg(x),
+                             call = caller_env()) {
+  if (is.sql(x) && length(x) == 1L) {
+    return()
+  }
+
+  if (string && is_string(x)) {
+    return()
+  }
+
+  stop_input_type(
+    x,
+    what = c("a single SQL query", if (string) "a single string"),
+    call = call,
+    arg = arg
+  )
+}

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -31,7 +31,15 @@ sql_random(con)
 
 sql_table_analyze(con, table, ...)
 
-sql_table_index(con, table, columns, name = NULL, unique = FALSE, ...)
+sql_table_index(
+  con,
+  table,
+  columns,
+  name = NULL,
+  unique = FALSE,
+  ...,
+  call = caller_env()
+)
 
 sql_query_explain(con, sql, ...)
 


### PR DESCRIPTION
They are pretty basic functions that so far didn't check their arguments at all

* `sql_table_index()`
* `sql_query_fields()`
* `sql_query_save()`
* `sql_query_wrap()`
* `sql_query_rows()`
* `sql_query_explain()`

* `db_copy_to()`
* `db_compute()`
* `db_write_table()`