### PR TITLE
Add != to <> translation for Access (#1219)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,9 +24,11 @@
 * The `rows_*()` functions now also work inside a transaction for Postgres
   (@mgirlich, #1183).
 
+* Added translation for `!=` to `<>` for Microsoft Access (@erikvona, #1219).
+
 # dbplyr 2.3.1
 
-## Breaking changes
+## Breaking changes 
 
 * `window_order()` now only accepts bare symbols or symbols wrapped in `desc()`.
   This breaking change is necessary to allow `select()` to drop and rename

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,7 @@
 
 # dbplyr 2.3.1
 
-## Breaking changes 
+## Breaking changes
 
 * `window_order()` now only accepts bare symbols or symbols wrapped in `desc()`.
   This breaking change is necessary to allow `select()` to drop and rename

--- a/R/backend-access.R
+++ b/R/backend-access.R
@@ -122,7 +122,9 @@ sql_translation.ACCESS <- function(con) {
       ifelse        = function(test, yes, no){
        sql_expr(iif(!!test, !!yes, !!no))
       },
-
+      # Access uses <> for inequality
+      `!=` = sql_infix("<>"),
+      
       # Coalesce doesn't exist in Access.
       # NZ() only works while in Access, not with the Access driver
       # IIF(ISNULL()) is the best way to construct this


### PR DESCRIPTION
As noted in the issue and title, add != to <> translation for Access since that's what Access uses