### PR TITLE
Remove arg `src` from `tbl_lazy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* Removed argument `src` of `tbl_lazy()` after it has been deprecated for years
+  (@mgirlich, #1208).
+
 * `sql_join_suffix()` gains the argument `suffix` so that methods can check
   whether the suffix is valid for the backend (@mgirlich).
 

--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -12,11 +12,8 @@
 #'
 #' df_sqlite <- tbl_lazy(df, con = simulate_sqlite())
 #' df_sqlite %>% summarise(x = sd(x, na.rm = TRUE)) %>% show_query()
-tbl_lazy <- function(df, con = NULL, src = NULL, name = "df") {
-  if (!is.null(src)) {
-    lifecycle::deprecate_warn("1.4.0", "tbl_lazy(src)", "tbl_lazy(con)")
-    con <- src
-  }
+tbl_lazy <- function(df, con = NULL, ..., name = "df") {
+  check_dots_empty0(...)
   con <- con %||% sql_current_con() %||% simulate_dbi()
   subclass <- class(con)[[1]]
 
@@ -30,9 +27,9 @@ methods::setOldClass(c("tbl_lazy", "tbl"))
 
 #' @export
 #' @rdname tbl_lazy
-lazy_frame <- function(..., con = NULL, src = NULL, .name = "df") {
+lazy_frame <- function(..., con = NULL, .name = "df") {
   con <- con %||% sql_current_con() %||% simulate_dbi()
-  tbl_lazy(tibble(...), con = con, src = src, name = .name)
+  tbl_lazy(tibble(...), con = con, name = .name)
 }
 
 #' @export

--- a/man/tbl_lazy.Rd
+++ b/man/tbl_lazy.Rd
@@ -5,9 +5,9 @@
 \alias{lazy_frame}
 \title{Create a local lazy tibble}
 \usage{
-tbl_lazy(df, con = NULL, src = NULL, name = "df")
+tbl_lazy(df, con = NULL, ..., name = "df")
 
-lazy_frame(..., con = NULL, src = NULL, .name = "df")
+lazy_frame(..., con = NULL, .name = "df")
 }
 \description{
 These functions are useful for testing SQL generation without having to

--- a/tests/testthat/_snaps/tbl-lazy.md
+++ b/tests/testthat/_snaps/tbl-lazy.md
@@ -1,3 +1,13 @@
+# argument src is deprecated
+
+    Code
+      tbl_lazy(mtcars, src = simulate_sqlite())
+    Condition
+      Error in `tbl_lazy()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * src = simulate_sqlite()
+
 # cannot convert tbl_lazy to data.frame
 
     Code

--- a/tests/testthat/_snaps/tbl-lazy.md
+++ b/tests/testthat/_snaps/tbl-lazy.md
@@ -1,20 +1,8 @@
-# argument src is deprecated
-
-    Code
-      dummy <- tbl_lazy(mtcars, src = simulate_sqlite())
-    Condition
-      Warning:
-      The `src` argument of `tbl_lazy()` is deprecated as of dbplyr 1.4.0.
-      i Please use the `con` argument instead.
-
 # cannot convert tbl_lazy to data.frame
 
     Code
-      as.data.frame(tbl_lazy(mtcars, src = simulate_sqlite()))
+      as.data.frame(tbl_lazy(mtcars, con = simulate_sqlite()))
     Condition
-      Warning:
-      The `src` argument of `tbl_lazy()` is deprecated as of dbplyr 1.4.0.
-      i Please use the `con` argument instead.
       Error in `as.data.frame()`:
       ! Can not coerce <tbl_lazy> to <data.frame>
 

--- a/tests/testthat/test-tbl-lazy.R
+++ b/tests/testthat/test-tbl-lazy.R
@@ -3,6 +3,10 @@ test_that("adds src class", {
   expect_s3_class(tb, "tbl_SQLiteConnection")
 })
 
+test_that("argument src is deprecated", {
+  expect_snapshot(error = TRUE, tbl_lazy(mtcars, src = simulate_sqlite()))
+})
+
 test_that("cannot convert tbl_lazy to data.frame", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-tbl-lazy.R
+++ b/tests/testthat/test-tbl-lazy.R
@@ -3,14 +3,10 @@ test_that("adds src class", {
   expect_s3_class(tb, "tbl_SQLiteConnection")
 })
 
-test_that("argument src is deprecated", {
-  expect_snapshot(dummy <- tbl_lazy(mtcars, src = simulate_sqlite()))
-})
-
 test_that("cannot convert tbl_lazy to data.frame", {
   expect_snapshot(
     error = TRUE,
-    as.data.frame(tbl_lazy(mtcars, src = simulate_sqlite()))
+    as.data.frame(tbl_lazy(mtcars, con = simulate_sqlite()))
   )
 })
 


### PR DESCRIPTION
Closes #1208.
@hadley Or would you prefer first going to `deprecate_stop()`? I would have guessed `src` wasn't used much anymore that's why I removed it directly.