### PR TITLE
`between()` translation for MS SQL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* The translation of `between()` now also works for MS SQL when used in `mutate()`
+  (@mgirlich, #1241).
+
 * The first argument of `ntile()` has been renamed from `order_by` to `x` to
   match the interface of `dplyr::ntile()` (@mgirlich, #1242).
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -266,6 +266,14 @@ simulate_mssql <- function(version = "15.0") {
         mssql_sql_if(enquo(test), enquo(yes), enquo(no))
       },
       case_when      = mssql_case_when,
+      between        = function(x, left, right) {
+        context <- sql_current_context()
+        if (context$clause == "WHERE") {
+          sql_expr(!!x %BETWEEN% !!left %AND% !!right)
+        } else {
+          sql_expr(IIF(!!x %BETWEEN% !!left %AND% !!right))
+        }
+      },
 
       as.logical    = sql_cast("BIT"),
 

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -114,6 +114,15 @@ test_that("last_value_sql() translated correctly", {
   )
 })
 
+test_that("between translation respects context", {
+  local_con(simulate_mssql())
+
+  local_context(list(clause = "WHERE"))
+  expect_equal(translate_sql(between(a, 1L, 2L)), sql("`a` BETWEEN 1 AND 2"))
+  local_context(list(clause = "SELECT"))
+  expect_equal(translate_sql(between(a, 1L, 2L)), sql("IIF(`a` BETWEEN 1 AND 2)"))
+})
+
 # verb translation --------------------------------------------------------
 
 test_that("convert between bit and boolean as needed", {


### PR DESCRIPTION
Fixes #1241.