### PR TITLE
Support namespaced functions in `across()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* Using a function with a namespace in `across()` now works, e.g.
+  `across(x, dplyr::dense_rank)` (@mgirlich, #1231).
+
 * Can now use `select()` again after using `arrange(desc(x))` (@ejneer, #1240).
 
 * The first argument of `ntile()` has been renamed from `order_by` to `x` to

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -86,6 +86,8 @@ across_funs <- function(funs, env, data, dots, names_spec, fn, evaluated = FALSE
     names_spec <- names_spec %||% "{.col}"
   } else if (is_quosure(funs)) {
     return(across_funs(quo_squash(funs), env, data, dots, names_spec, fn, evaluated = evaluated))
+  } else if (is_call(funs, "::")) {
+    return(across_funs(funs[[3]], env, data, dots, names_spec, fn, evaluated = evaluated))
   } else if (is_symbol(funs) || is_function(funs) ||
              is_call(funs, "~") || is_call(funs, "function")) {
     is_local_list <- function(funs) {

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -37,6 +37,15 @@ test_that("across() translates functions", {
   )
 })
 
+test_that("across() translates functions in namespace #1231", {
+  lf <- lazy_frame(a = 1,  b = 2)
+
+  expect_equal(
+    capture_across(lf, across(a:b, dplyr::dense_rank)),
+    exprs(a = dense_rank(a), b = dense_rank(b))
+  )
+})
+
 test_that("across() captures anonymous functions", {
   lf <- lazy_frame(a = 1)
 


### PR DESCRIPTION
Fixes #1231.