### PR TITLE
Support `in_schema/catalog()` in `lazy_frame()`

### DIFF
--- a/R/lazy-ops.R
+++ b/R/lazy-ops.R
@@ -32,6 +32,10 @@ lazy_base_query <- function(x, vars, class = character(), ...) {
 }
 
 lazy_query_local <- function(df, name) {
+  if (is_bare_character(name)) {
+    name <- ident(name)
+  }
+
   lazy_base_query(df, names(df), class = "local", name = name)
 }
 
@@ -62,7 +66,7 @@ sql_build.lazy_base_remote_query <- function(op, con, ...) {
 
 #' @export
 sql_build.lazy_base_local_query <- function(op, con, ...) {
-  ident(op$name)
+  as.sql(op$name, con = con)
 }
 
 # op_grps -----------------------------------------------------------------

--- a/R/remote.R
+++ b/R/remote.R
@@ -48,30 +48,33 @@ query_name.tbl_lazy <- function(x) {
 
 #' @export
 query_name.lazy_base_remote_query <- function(x) {
-  name <- x$x
-  if (is.sql(name)) {
-    return(NULL)
-  }
-
-  if (is.ident(name)) {
-    return(name)
-  }
-
-  if (is_schema(name) || is_catalog(name)) {
-    return(name$table)
-  }
-
-  if (inherits(name, "Id")) {
-    out <- name@name[["table"]]
-    return(ident(out))
-  }
-
-  abort("Unexpected type", .internal = TRUE)
+  get_table_ident_name(x$x)
 }
 
 #' @export
 query_name.lazy_base_local_query <- function(x) {
-  ident(x$name)
+  get_table_ident_name(x$name)
+}
+
+get_table_ident_name <- function(x) {
+  if (is.sql(x)) {
+    return(NULL)
+  }
+
+  if (is.ident(x)) {
+    return(x)
+  }
+
+  if (is_schema(x) || is_catalog(x)) {
+    return(x$table)
+  }
+
+  if (inherits(x, "Id")) {
+    out <- x@name[["table"]]
+    return(ident(out))
+  }
+
+  abort("Unexpected type", .internal = TRUE)
 }
 
 #' @export


### PR DESCRIPTION
This makes it much easier to test whether the SQL query generations works with `in_schema()` and `in_catalog()`. Before we always needed a live database to test support of schemas.