### PR TITLE
Generate `SELECT` sql for joins in `sql_build()`

### DIFF
--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -135,7 +135,7 @@ sql_table_analyze.MySQLConnection <- sql_table_analyze.MariaDBConnection
 sql_query_join.MariaDBConnection <- function(con,
                                              x,
                                              y,
-                                             vars,
+                                             select,
                                              type = "inner",
                                              by = NULL,
                                              ...) {

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -205,7 +205,7 @@ sql_escape_datetime.MariaDBConnection <- function(con, x) {
   # https://dev.mysql.com/doc/refman/8.0/en/datetime.html
   # https://mariadb.com/kb/en/datetime/
   x <- strftime(x, "%Y-%m-%d %H:%M:%OS", tz = "UTC")
-  dbplyr:::sql_escape_string(con, x)
+  sql_escape_string(con, x)
 }
 #' @export
 sql_escape_datetime.MySQLConnection <- sql_escape_datetime.MariaDBConnection

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -410,12 +410,11 @@ sql_select.DBIConnection <- function(con,
 sql_query_join <- function(con,
                            x,
                            y,
-                           vars,
+                           select,
                            type = "inner",
                            by = NULL,
                            na_matches = FALSE,
                            ...,
-                           select = NULL,
                            lvl = 0) {
   check_dots_used()
   UseMethod("sql_query_join")
@@ -424,12 +423,11 @@ sql_query_join <- function(con,
 sql_query_join.DBIConnection <- function(con,
                                          x,
                                          y,
-                                         vars,
+                                         select,
                                          type = "inner",
                                          by = NULL,
                                          na_matches = FALSE,
                                          ...,
-                                         select = NULL,
                                          lvl = 0) {
   JOIN <- switch(
     type,
@@ -444,9 +442,6 @@ sql_query_join.DBIConnection <- function(con,
   x <- dbplyr_sql_subquery(con, x, name = by$x_as, lvl = lvl)
   y <- dbplyr_sql_subquery(con, y, name = by$y_as, lvl = lvl)
 
-  if (is.null(select)) {
-    select <- sql_rf_join_vars(con, type = type, vars, x_as = by$x_as, y_as = by$y_as)
-  }
   on <- sql_join_tbls(con, by, na_matches = na_matches)
 
   # Wrap with SELECT since callers assume a valid query is returned
@@ -474,12 +469,11 @@ sql_join.DBIConnection <- function(con,
                                    select = NULL,
                                    lvl = 0) {
   sql_query_join(
-    con, x, y, vars,
+    con, x, y, select,
     type = type,
     by = by,
     na_matches = na_matches,
     ...,
-    select = select,
     lvl = lvl
   )
 }

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -415,6 +415,7 @@ sql_query_join <- function(con,
                            by = NULL,
                            na_matches = FALSE,
                            ...,
+                           select = NULL,
                            lvl = 0) {
   check_dots_used()
   UseMethod("sql_query_join")
@@ -428,6 +429,7 @@ sql_query_join.DBIConnection <- function(con,
                                          by = NULL,
                                          na_matches = FALSE,
                                          ...,
+                                         select = NULL,
                                          lvl = 0) {
   JOIN <- switch(
     type,
@@ -442,7 +444,9 @@ sql_query_join.DBIConnection <- function(con,
   x <- dbplyr_sql_subquery(con, x, name = by$x_as, lvl = lvl)
   y <- dbplyr_sql_subquery(con, y, name = by$y_as, lvl = lvl)
 
-  select <- sql_rf_join_vars(con, type = type, vars, x_as = by$x_as, y_as = by$y_as)
+  if (is.null(select)) {
+    select <- sql_rf_join_vars(con, type = type, vars, x_as = by$x_as, y_as = by$y_as)
+  }
   on <- sql_join_tbls(con, by, na_matches = na_matches)
 
   # Wrap with SELECT since callers assume a valid query is returned
@@ -467,6 +471,7 @@ sql_join.DBIConnection <- function(con,
                                    by = NULL,
                                    na_matches = FALSE,
                                    ...,
+                                   select = NULL,
                                    lvl = 0) {
   sql_query_join(
     con, x, y, vars,
@@ -474,6 +479,7 @@ sql_join.DBIConnection <- function(con,
     by = by,
     na_matches = na_matches,
     ...,
+    select = select,
     lvl = lvl
   )
 }
@@ -483,9 +489,9 @@ sql_join.DBIConnection <- function(con,
 sql_query_multi_join <- function(con,
                                  x,
                                  joins,
-                                 table_vars,
+                                 table_names,
                                  by_list,
-                                 vars,
+                                 select,
                                  ...,
                                  lvl = 0) {
   check_dots_used()
@@ -502,8 +508,8 @@ sql_query_multi_join <- function(con,
 #'     from different tables
 #'   * `on` `<character>`
 #'   * `na_matches` `<character>`: Either `"na"` or `"never"`.
-#' @param vars See [sql_multi_join_vars()].
-#' @param table_vars `named <list_of<character>>`: All variables in each table.
+#' @param select A named SQL vector.
+#' @param table_names `<character>` The names of the tables.
 #' @noRd
 #' @examples
 #' # Left join with *
@@ -525,17 +531,15 @@ sql_query_multi_join <- function(con,
 sql_query_multi_join.DBIConnection <- function(con,
                                                x,
                                                joins,
-                                               table_vars,
+                                               table_names,
                                                by_list,
-                                               vars,
+                                               select,
                                                ...,
                                                lvl = 0) {
-  table_names <- names(table_vars)
   if (vctrs::vec_duplicate_any(table_names)) {
     cli_abort("{.arg table_names} must be unique.")
   }
 
-  select_sql <- sql_multi_join_vars(con, vars, table_vars)
   from <- dbplyr_sql_subquery(con, x, name = table_names[[1]], lvl = lvl)
 
   join_table_queries <- purrr::map2(
@@ -560,7 +564,7 @@ sql_query_multi_join.DBIConnection <- function(con,
   join_on_clauses <- vctrs::vec_interleave(join_clauses, on_clauses)
 
   clauses <- list2(
-    sql_clause_select(con, select_sql),
+    sql_clause_select(con, select),
     sql_clause_from(from),
     !!!join_on_clauses
   )

--- a/R/lazy-join-query.R
+++ b/R/lazy-join-query.R
@@ -256,7 +256,6 @@ sql_build.lazy_rf_join_query <- function(op, con, ...) {
   join_query(
     sql_optimise(sql_build(op$x, con), con),
     sql_optimise(sql_build(op$y, con), con),
-    vars = vars_classic,
     select = select,
     type = op$type,
     by = by,

--- a/R/lazy-join-query.R
+++ b/R/lazy-join-query.R
@@ -179,11 +179,11 @@ op_vars.lazy_semi_join_query <- function(op) {
 #' @export
 sql_build.lazy_multi_join_query <- function(op, con, ...) {
   table_names_out <- generate_join_table_names(op$table_names)
-
   table_vars <- purrr::map(
     set_names(c(list(op$x), op$joins$table), table_names_out),
     op_vars
   )
+  select_sql <- sql_multi_join_vars(con, op$vars, table_vars)
 
   op$joins$table <- purrr::map(op$joins$table, ~ sql_optimise(sql_build(.x, con), con))
   op$joins$by <- purrr::map2(
@@ -198,8 +198,8 @@ sql_build.lazy_multi_join_query <- function(op, con, ...) {
   multi_join_query(
     x = sql_optimise(sql_build(op$x, con), con),
     joins = op$joins,
-    table_vars = table_vars,
-    vars = op$vars
+    table_names = table_names_out,
+    select = select_sql
   )
 }
 
@@ -245,10 +245,19 @@ sql_build.lazy_rf_join_query <- function(op, con, ...) {
   by$x_as <- ident(table_names_out[[1]])
   by$y_as <- ident(table_names_out[[2]])
 
+  select <- sql_rf_join_vars(
+    con,
+    type = op$type,
+    vars = vars_classic,
+    x_as = by$x_as,
+    y_as = by$y_as
+  )
+
   join_query(
     sql_optimise(sql_build(op$x, con), con),
     sql_optimise(sql_build(op$y, con), con),
     vars = vars_classic,
+    select = select,
     type = op$type,
     by = by,
     suffix = NULL, # it seems like the suffix is not used for rendering

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -3,6 +3,8 @@
 join_query <- function(x,
                        y,
                        vars,
+                       ...,
+                       select,
                        type = "inner",
                        by = NULL,
                        suffix = c(".x", ".y"),
@@ -12,6 +14,7 @@ join_query <- function(x,
       x = x,
       y = y,
       vars = vars,
+      select = select,
       type = type,
       by = by,
       na_matches = na_matches
@@ -20,13 +23,13 @@ join_query <- function(x,
   )
 }
 
-multi_join_query <- function(x, joins, table_vars, vars) {
+multi_join_query <- function(x, joins, table_names, select) {
   structure(
     list(
       x = x,
       joins = joins,
-      table_vars = table_vars,
-      vars = vars
+      table_names = table_names,
+      select = select
     ),
     class = c("multi_join_query", "query")
   )
@@ -74,6 +77,7 @@ sql_render.join_query <- function(query, con = NULL, ..., subquery = FALSE, lvl 
     type = query$type,
     by = query$by,
     na_matches = query$na_matches,
+    select = query$select,
     lvl = lvl
   )
 }
@@ -94,9 +98,9 @@ sql_render.multi_join_query <- function(query,
     con = con,
     x = x,
     joins = query$joins,
-    table_vars = query$table_vars,
+    table_names = query$table_names,
     by_list = query$by_list,
-    vars = query$vars,
+    select = query$select,
     lvl = lvl
   )
 }

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -2,9 +2,8 @@
 #' @rdname sql_build
 join_query <- function(x,
                        y,
-                       vars,
-                       ...,
                        select,
+                       ...,
                        type = "inner",
                        by = NULL,
                        suffix = c(".x", ".y"),
@@ -13,7 +12,6 @@ join_query <- function(x,
     list(
       x = x,
       y = y,
-      vars = vars,
       select = select,
       type = type,
       by = by,

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -85,7 +85,7 @@ sql_query_join(
   lvl = 0
 )
 
-sql_query_multi_join(con, x, joins, table_vars, by_list, vars, ..., lvl = 0)
+sql_query_multi_join(con, x, joins, table_names, by_list, select, ..., lvl = 0)
 
 sql_query_semi_join(con, x, y, anti, by, vars, ..., lvl = 0)
 

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -77,12 +77,11 @@ sql_query_join(
   con,
   x,
   y,
-  vars,
+  select,
   type = "inner",
   by = NULL,
   na_matches = FALSE,
   ...,
-  select = NULL,
   lvl = 0
 )
 

--- a/man/db-sql.Rd
+++ b/man/db-sql.Rd
@@ -82,6 +82,7 @@ sql_query_join(
   by = NULL,
   na_matches = FALSE,
   ...,
+  select = NULL,
   lvl = 0
 )
 

--- a/man/sql_build.Rd
+++ b/man/sql_build.Rd
@@ -84,9 +84,8 @@ lazy_set_op_query(x, y, type, all, call = caller_env())
 join_query(
   x,
   y,
-  vars,
-  ...,
   select,
+  ...,
   type = "inner",
   by = NULL,
   suffix = c(".x", ".y"),

--- a/man/sql_build.Rd
+++ b/man/sql_build.Rd
@@ -85,6 +85,8 @@ join_query(
   x,
   y,
   vars,
+  ...,
+  select,
   type = "inner",
   by = NULL,
   suffix = c(".x", ".y"),

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -1076,7 +1076,7 @@ test_that("right_join uses *", {
 
   # cannot use * without relocate or select
   expect_equal(
-    sql_rf_join_vars(con, out$vars, type = "right", x_as = out$by$x_as, y_as = out$by$y_as),
+    out$select,
     sql(a = "`df_RHS`.`a`", b = "`df_RHS`.`b`", c = "`c`", z = "`z`")
   )
 
@@ -1087,7 +1087,7 @@ test_that("right_join uses *", {
     sql_build()
 
   expect_equal(
-    sql_rf_join_vars(con, out$vars, type = "right", x_as = out$by$x_as, y_as = out$by$y_as),
+    out$select,
     sql("`df_RHS`.*", c = "`c`")
   )
 
@@ -1098,7 +1098,7 @@ test_that("right_join uses *", {
     sql_build()
 
   expect_equal(
-    sql_rf_join_vars(con, out$vars, type = "right", x_as = out$by$x_as, y_as = out$by$y_as),
+    out$select,
     sql(a = "`df_RHS`.`a`", z = "`z`")
   )
 
@@ -1110,7 +1110,7 @@ test_that("right_join uses *", {
     sql_build()
 
   expect_equal(
-    sql_rf_join_vars(con, out$vars, type = "right", x_as = out$by$x_as, y_as = out$by$y_as),
+    out$select,
     sql(a = "`df_RHS`.`a`", `b.x` = "`df_LHS`.`b`", `b.y` = "`df_RHS`.`b`")
   )
 })
@@ -1159,7 +1159,7 @@ test_that("full_join() does not use *", {
     sql_build()
 
   expect_equal(
-    sql_rf_join_vars(con, out$vars, type = "full", x_as = out$by$x_as, y_as = out$by$y_as),
+    out$select,
     sql(
       a = "COALESCE(`df_LHS`.`a`, `df_RHS`.`a`)",
       b = "COALESCE(`df_LHS`.`b`, `df_RHS`.`b`)"

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -277,57 +277,57 @@ test_that("join uses correct table alias", {
   y <- lazy_frame(a = 1, y = 1, .name = "y")
 
   # self joins
-  table_vars <- sql_build(left_join(x, x, by = "a"))$table_vars
-  expect_named(table_vars, c("x_LHS", "x_RHS"))
+  table_names <- sql_build(left_join(x, x, by = "a"))$table_names
+  expect_equal(table_names, c("x_LHS", "x_RHS"))
 
-  table_vars <- sql_build(left_join(x, x, by = "a", x_as = "my_x"))$table_vars
-  expect_named(table_vars, c("my_x", "x"))
+  table_names <- sql_build(left_join(x, x, by = "a", x_as = "my_x"))$table_names
+  expect_equal(table_names, c("my_x", "x"))
 
-  table_vars <- sql_build(left_join(x, x, by = "a", y_as = "my_y"))$table_vars
-  expect_named(table_vars, c("x", "my_y"))
+  table_names <- sql_build(left_join(x, x, by = "a", y_as = "my_y"))$table_names
+  expect_equal(table_names, c("x", "my_y"))
 
-  table_vars <- sql_build(left_join(x, x, by = "a", x_as = "my_x", y_as = "my_y"))$table_vars
-  expect_named(table_vars, c("my_x", "my_y"))
+  table_names <- sql_build(left_join(x, x, by = "a", x_as = "my_x", y_as = "my_y"))$table_names
+  expect_equal(table_names, c("my_x", "my_y"))
 
   # x-y joins
-  table_vars <- sql_build(left_join(x, y, by = "a"))$table_vars
-  expect_named(table_vars, c("x", "y"))
+  table_names <- sql_build(left_join(x, y, by = "a"))$table_names
+  expect_equal(table_names, c("x", "y"))
 
-  table_vars <- sql_build(left_join(x, y, by = "a", x_as = "my_x"))$table_vars
-  expect_named(table_vars, c("my_x", "y"))
+  table_names <- sql_build(left_join(x, y, by = "a", x_as = "my_x"))$table_names
+  expect_equal(table_names, c("my_x", "y"))
 
-  table_vars <- sql_build(left_join(x, y, by = "a", y_as = "my_y"))$table_vars
-  expect_named(table_vars, c("x", "my_y"))
+  table_names <- sql_build(left_join(x, y, by = "a", y_as = "my_y"))$table_names
+  expect_equal(table_names, c("x", "my_y"))
 
-  table_vars <- sql_build(left_join(x, y, by = "a", x_as = "my_x", y_as = "my_y"))$table_vars
-  expect_named(table_vars, c("my_x", "my_y"))
+  table_names <- sql_build(left_join(x, y, by = "a", x_as = "my_x", y_as = "my_y"))$table_names
+  expect_equal(table_names, c("my_x", "my_y"))
 
   # x_as same name as `y`
-  table_vars <- sql_build(left_join(x, y, by = "a", x_as = "y"))$table_vars
-  expect_named(table_vars, c("y", "y...2"))
+  table_names <- sql_build(left_join(x, y, by = "a", x_as = "y"))$table_names
+  expect_equal(table_names, c("y", "y...2"))
 
-  table_vars <- sql_build(left_join(x %>% filter(x == 1), x, by = "x", y_as = "LHS"))$table_vars
-  expect_named(table_vars, c("LHS...1", "LHS"))
+  table_names <- sql_build(left_join(x %>% filter(x == 1), x, by = "x", y_as = "LHS"))$table_names
+  expect_equal(table_names, c("LHS...1", "LHS"))
 
   # sql_on -> use alias or LHS/RHS
-  table_vars <- sql_build(left_join(x, y, sql_on = sql("LHS.a = RHS.a")))$table_vars
-  expect_named(table_vars, c("LHS", "RHS"))
+  table_names <- sql_build(left_join(x, y, sql_on = sql("LHS.a = RHS.a")))$table_names
+  expect_equal(table_names, c("LHS", "RHS"))
 
-  table_vars <- sql_build(left_join(x, y, x_as = "my_x", sql_on = sql("my_x.a = RHS.a")))$table_vars
-  expect_named(table_vars, c("my_x", "RHS"))
+  table_names <- sql_build(left_join(x, y, x_as = "my_x", sql_on = sql("my_x.a = RHS.a")))$table_names
+  expect_equal(table_names, c("my_x", "RHS"))
 
   # triple join
   z <- lazy_frame(a = 1, z = 1, .name = "z")
   out <- left_join(x, y, by = "a") %>%
     left_join(z, by = "a") %>%
     sql_build()
-  expect_named(out$table_vars, c("x", "y", "z"))
+  expect_equal(out$table_names, c("x", "y", "z"))
 
   # triple join where names need to be repaired
   out <- left_join(x, x, by = "a") %>%
     left_join(z, by = "a") %>%
     sql_build()
-  expect_named(out$table_vars, c("x...1", "x...2", "z"))
+  expect_equal(out$table_names, c("x...1", "x...2", "z"))
 })
 
 test_that("select() before join is inlined", {
@@ -1037,10 +1037,7 @@ test_that("left_join/inner_join uses *", {
     left_join(lf2, by = c("a", "b")) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    sql("`df_LHS`.*", z = "`z`")
-  )
+  expect_equal(out$select, sql("`df_LHS`.*", z = "`z`"))
 
   # also works after relocate
   out <- lf1 %>%
@@ -1048,10 +1045,7 @@ test_that("left_join/inner_join uses *", {
     relocate(z) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    sql(z = "`z`", "`df_LHS`.*")
-  )
+  expect_equal(out$select, sql(z = "`z`", "`df_LHS`.*"))
 
   # does not use * if variable are missing
   out <- lf1 %>%
@@ -1059,10 +1053,7 @@ test_that("left_join/inner_join uses *", {
     select(a, c) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    sql(a = "`df_LHS`.`a`", c = "`c`")
-  )
+  expect_equal(out$select, sql(a = "`df_LHS`.`a`", c = "`c`"))
 
   # does not use * if variable names changed
   lf1 <- lazy_frame(a = 1, b = 2)
@@ -1071,10 +1062,7 @@ test_that("left_join/inner_join uses *", {
     left_join(lf2, by = c("a")) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    sql(a = "`df_LHS`.`a`", `b.x` = "`df_LHS`.`b`", `b.y` = "`df_RHS`.`b`")
-  )
+  expect_equal(out$select, sql(a = "`df_LHS`.`a`", `b.x` = "`df_LHS`.`b`", `b.y` = "`df_RHS`.`b`"))
 })
 
 test_that("right_join uses *", {
@@ -1136,10 +1124,7 @@ test_that("cross_join uses *", {
     cross_join(lf2) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    set_names(sql("`df_LHS`.*", "`df_RHS`.*"), c("", ""))
-  )
+  expect_equal(out$select, set_names(sql("`df_LHS`.*", "`df_RHS`.*"), c("", "")))
 
   # also works after relocate
   out <- lf1 %>%
@@ -1147,30 +1132,21 @@ test_that("cross_join uses *", {
     select(x, y, a, b) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    set_names(sql("`df_RHS`.*", "`df_LHS`.*"), c("", ""))
-  )
+  expect_equal(out$select, set_names(sql("`df_RHS`.*", "`df_LHS`.*"), c("", "")))
 
   out <- lf1 %>%
     cross_join(lf2) %>%
     select(x, a, b, y) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    sql(x = "`x`", "`df_LHS`.*", y = "`y`")
-  )
+  expect_equal(out$select, sql(x = "`x`", "`df_LHS`.*", y = "`y`"))
 
   out <- lf1 %>%
     cross_join(lf2) %>%
     select(a, x, y, b) %>%
     sql_build()
 
-  expect_equal(
-    sql_multi_join_vars(con, out$vars, out$table_vars),
-    sql(a = "`a`", "`df_RHS`.*", b = "`b`")
-  )
+  expect_equal(out$select, sql(a = "`a`", "`df_RHS`.*", b = "`b`"))
 })
 
 test_that("full_join() does not use *", {


### PR DESCRIPTION
Some time ago we added the feature to use `*` for column selection where possible. For select queries this was done in `sql_build()`, for join queries in `sql_render()`. This is inconsistent and I think it makes more sense to do this in `sql_build()`. This also has the advantage that it makes `sql_render()` a bit simpler for joins.
In the end this makes it easier to implement #1146 (this allows the user to control whether to use `*` or write out all columns).