### PR TITLE
Uses dummy order in `distinct(.keep_all = TRUE)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `distinct(.keep_all = TRUE)` now works for SQL Server (@mgirlich, #1053).
+
 * Using `compute(temporary = FALSE)` without providing a name is now
   deprecated (@mgirlich, #1154).
 

--- a/R/verb-distinct.R
+++ b/R/verb-distinct.R
@@ -19,10 +19,21 @@ distinct.tbl_lazy <- function(.data, ..., .keep_all = FALSE) {
   empty_dots <- dots_n(...) == 0
   can_use_distinct <- !.keep_all || (empty_dots && is_empty(grps))
   if (!can_use_distinct) {
+    needs_dummy_order <- is.null(op_sort(.data))
+
+    if (needs_dummy_order) {
+      dummy_order_vars <- colnames(.data)[[1]]
+      .data <- .data %>% window_order(!!sym(dummy_order_vars))
+    }
+
     .data <- .data %>%
       group_by(..., .add = TRUE) %>%
       filter(row_number() == 1L) %>%
       group_by(!!!grps)
+
+    if (needs_dummy_order) {
+      .data <- .data %>% window_order()
+    }
 
     return(.data)
   }

--- a/tests/testthat/_snaps/verb-distinct.md
+++ b/tests/testthat/_snaps/verb-distinct.md
@@ -24,3 +24,16 @@
       ) `q01`
       WHERE (`q02` = 1)
 
+# distinct uses dummy window order when .keep_all is TRUE and no order is used
+
+    Code
+      lf %>% distinct(x, .keep_all = TRUE)
+    Output
+      <SQL>
+      SELECT `x`, `y`
+      FROM (
+        SELECT *, ROW_NUMBER() OVER (PARTITION BY `x` ORDER BY `x`) AS `q02`
+        FROM `df`
+      ) `q01`
+      WHERE (`q02` = 1)
+

--- a/tests/testthat/test-verb-distinct.R
+++ b/tests/testthat/test-verb-distinct.R
@@ -197,6 +197,11 @@ test_that("distinct respects window_order when .keep_all is TRUE", {
   )
 })
 
+test_that("distinct uses dummy window order when .keep_all is TRUE and no order is used", {
+  lf <- lazy_frame(x = 1, y = 2)
+  expect_snapshot(lf %>% distinct(x, .keep_all = TRUE))
+})
+
 # sql_build ---------------------------------------------------------------
 
 test_that("distinct sets flagged", {


### PR DESCRIPTION
Fixes #1053.