### PR TITLE
Add argument `use_star`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* `show_query()` and `remote_query()` get the argument `use_star` that controls
+  whether to use `SELECT *` to select every column (@mgirlich, #1146).
+
 * `any()` and `all()` now work for MS SQL (@ejneer, #1273).
 
 * Fixed negation of bit (boolean) fields in MS SQL (@ejneer, #1239)

--- a/R/db.R
+++ b/R/db.R
@@ -55,12 +55,12 @@ sql_join_suffix.DBIConnection <- function(con, suffix, ...) {
 
 #' @rdname db-misc
 #' @export
-db_sql_render <- function(con, sql, ..., cte = FALSE) {
+db_sql_render <- function(con, sql, ..., cte = FALSE, use_star = TRUE) {
   UseMethod("db_sql_render")
 }
 #' @export
-db_sql_render.DBIConnection <- function(con, sql, ..., cte = FALSE) {
-  sql_render(sql, con = con, ..., cte = cte)
+db_sql_render.DBIConnection <- function(con, sql, ..., cte = FALSE, use_star = TRUE) {
+  sql_render(sql, con = con, ..., cte = cte, use_star = use_star)
 }
 
 #' @rdname db-misc

--- a/R/explain.R
+++ b/R/explain.R
@@ -1,8 +1,8 @@
 #' @importFrom dplyr show_query
 #' @export
-show_query.tbl_lazy <- function(x, ..., cte = FALSE) {
+show_query.tbl_lazy <- function(x, ..., cte = FALSE, use_star = TRUE) {
   withr::local_options(list(dbplyr_use_colour = TRUE))
-  sql <- remote_query(x, cte = cte)
+  sql <- remote_query(x, cte = cte, use_star = use_star)
   cat_line("<SQL>")
   cat_line(sql)
   invisible(x)

--- a/R/lazy-join-query.R
+++ b/R/lazy-join-query.R
@@ -177,15 +177,18 @@ op_vars.lazy_semi_join_query <- function(op) {
 }
 
 #' @export
-sql_build.lazy_multi_join_query <- function(op, con, ...) {
+sql_build.lazy_multi_join_query <- function(op, con, ..., use_star = TRUE) {
   table_names_out <- generate_join_table_names(op$table_names)
   table_vars <- purrr::map(
     set_names(c(list(op$x), op$joins$table), table_names_out),
     op_vars
   )
-  select_sql <- sql_multi_join_vars(con, op$vars, table_vars)
+  select_sql <- sql_multi_join_vars(con, op$vars, table_vars, use_star = use_star)
 
-  op$joins$table <- purrr::map(op$joins$table, ~ sql_optimise(sql_build(.x, con), con))
+  op$joins$table <- purrr::map(
+    op$joins$table,
+    ~ sql_optimise(sql_build(.x, con, use_star = use_star), con)
+  )
   op$joins$by <- purrr::map2(
     op$joins$by, seq_along(op$joins$by),
     function(by, i) {
@@ -196,7 +199,7 @@ sql_build.lazy_multi_join_query <- function(op, con, ...) {
   )
 
   multi_join_query(
-    x = sql_optimise(sql_build(op$x, con), con),
+    x = sql_optimise(sql_build(op$x, con, use_star = use_star), con),
     joins = op$joins,
     table_names = table_names_out,
     select = select_sql
@@ -234,7 +237,7 @@ generate_join_table_names <- function(table_names) {
 }
 
 #' @export
-sql_build.lazy_rf_join_query <- function(op, con, ...) {
+sql_build.lazy_rf_join_query <- function(op, con, ..., use_star = TRUE) {
   table_names_out <- generate_join_table_names(op$table_names)
 
   vars_classic <- as.list(op$vars)
@@ -250,12 +253,13 @@ sql_build.lazy_rf_join_query <- function(op, con, ...) {
     type = op$type,
     vars = vars_classic,
     x_as = by$x_as,
-    y_as = by$y_as
+    y_as = by$y_as,
+    use_star = use_star
   )
 
   join_query(
-    sql_optimise(sql_build(op$x, con), con),
-    sql_optimise(sql_build(op$y, con), con),
+    sql_optimise(sql_build(op$x, con, use_star = use_star), con),
+    sql_optimise(sql_build(op$y, con, use_star = use_star), con),
     select = select,
     type = op$type,
     by = by,
@@ -265,9 +269,10 @@ sql_build.lazy_rf_join_query <- function(op, con, ...) {
 }
 
 #' @export
-sql_build.lazy_semi_join_query <- function(op, con, ...) {
+sql_build.lazy_semi_join_query <- function(op, con, ..., use_star = TRUE) {
   vars_prev <- op_vars(op$x)
-  if (identical(op$vars$var, op$vars$name) &&
+  if (use_star &&
+      identical(op$vars$var, op$vars$name) &&
       identical(op$vars$var, vars_prev)) {
     vars <- sql("*")
   } else {
@@ -275,8 +280,8 @@ sql_build.lazy_semi_join_query <- function(op, con, ...) {
   }
 
   semi_join_query(
-    sql_optimise(sql_build(op$x, con), con),
-    sql_optimise(sql_build(op$y, con), con),
+    sql_optimise(sql_build(op$x, con, use_star = use_star), con),
+    sql_optimise(sql_build(op$y, con, use_star = use_star), con),
     vars = vars,
     anti = op$anti,
     by = op$by,

--- a/R/lazy-set-op-query.R
+++ b/R/lazy-set-op-query.R
@@ -36,11 +36,11 @@ op_vars.lazy_set_op_query <- function(op) {
 }
 
 #' @export
-sql_build.lazy_set_op_query <- function(op, con, ...) {
+sql_build.lazy_set_op_query <- function(op, con, ..., use_star = TRUE) {
   # add_op_set_op() ensures that both have same variables
   set_op_query(
-    sql_optimise(sql_build(op$x, con), con),
-    sql_optimise(sql_build(op$y, con), con),
+    sql_optimise(sql_build(op$x, con, use_star = use_star), con),
+    sql_optimise(sql_build(op$y, con, use_star = use_star), con),
     type = op$type,
     all = op$all
   )
@@ -78,15 +78,18 @@ op_vars.lazy_union_query <- function(op) {
 }
 
 #' @export
-sql_build.lazy_union_query <- function(op, con, ...) {
+sql_build.lazy_union_query <- function(op, con, ..., use_star = TRUE) {
   # add_union() ensures that both have same variables
   unions <- list(
-    table = purrr::map(op$unions$table, ~ sql_optimise(sql_build(.x, con), con)),
+    table = purrr::map(
+      op$unions$table,
+      ~ sql_optimise(sql_build(.x, con, use_star = use_star), con)
+    ),
     all = op$unions$all
   )
 
   union_query(
-    sql_optimise(sql_build(op$x, con), con),
+    sql_optimise(sql_build(op$x, con, use_star = use_star), con),
     unions
   )
 }

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -141,7 +141,7 @@ sql_render.multi_join_query <- function(query,
 #' )
 #'
 #' # Full and right join are handled via `sql_rf_join_vars`
-sql_multi_join_vars <- function(con, vars, table_vars) {
+sql_multi_join_vars <- function(con, vars, table_vars, use_star) {
   all_vars <- tolower(unlist(table_vars))
   duplicated_vars <- all_vars[vctrs::vec_duplicate_detect(all_vars)]
   duplicated_vars <- unique(duplicated_vars)
@@ -156,7 +156,7 @@ sql_multi_join_vars <- function(con, vars, table_vars) {
     used_vars_current <- vars$var[vars_idx]
     out_vars_current <- vars$name[vars_idx]
 
-    if (join_can_use_star(all_vars_current, used_vars_current, out_vars_current, vars_idx)) {
+    if (use_star && join_can_use_star(all_vars_current, used_vars_current, out_vars_current, vars_idx)) {
       id <- vars_idx[[1]]
       tbl_alias <- escape(ident(table_names[i]), con = con)
       out[[id]] <- sql(paste0(tbl_alias, ".*"))
@@ -206,7 +206,7 @@ sql_multi_join_var <- function(con, var, table_id, table_names, duplicated_vars)
   }
 }
 
-sql_rf_join_vars <- function(con, type, vars, x_as = "LHS", y_as = "RHS") {
+sql_rf_join_vars <- function(con, type, vars, x_as = "LHS", y_as = "RHS", use_star) {
   type <- arg_match0(type, c("right", "full"))
   table_names <- c(unclass(x_as), unclass(y_as))
 
@@ -260,7 +260,8 @@ sql_rf_join_vars <- function(con, type, vars, x_as = "LHS", y_as = "RHS") {
   sql_multi_join_vars(
     con = con,
     vars = multi_join_vars,
-    table_vars = table_vars
+    table_vars = table_vars,
+    use_star = use_star
   )
 }
 

--- a/R/remote.R
+++ b/R/remote.R
@@ -8,6 +8,8 @@
 #' @param x Remote table, currently must be a [tbl_sql].
 #' @param cte `r lifecycle::badge("experimental")`
 #'   Use common table expressions in the generated SQL?
+#' @param use_star `r lifecycle::badge("experimental")`
+#'   Use `*` to select every column?
 #' @param ... Additional arguments passed on to methods.
 #' @return The value, or `NULL` if not remote table, or not applicable.
 #'    For example, computed queries do not have a "name"
@@ -96,8 +98,8 @@ remote_con <- function(x) {
 
 #' @export
 #' @rdname remote_name
-remote_query <- function(x, cte = FALSE) {
-  db_sql_render(remote_con(x), x, cte = cte)
+remote_query <- function(x, cte = FALSE, use_star = TRUE) {
+  db_sql_render(remote_con(x), x, cte = cte, use_star = use_star)
 }
 
 #' @export

--- a/R/sql-build.R
+++ b/R/sql-build.R
@@ -23,21 +23,21 @@
 #'   rules that should be very similar to ANSI 92, and allows for testing
 #'   without an active database connection.
 #' @param ... Other arguments passed on to the methods. Not currently used.
-sql_build <- function(op, con = NULL, ...) {
+sql_build <- function(op, con = NULL, ..., use_star = TRUE) {
   unique_subquery_name_reset()
   check_dots_used()
   UseMethod("sql_build")
 }
 
 #' @export
-sql_build.tbl_lazy <- function(op, con = op$src$con, ...) {
+sql_build.tbl_lazy <- function(op, con = op$src$con, ..., use_star = TRUE) {
   # only used for testing
-  qry <- sql_build(op$lazy_query, con = con, ...)
+  qry <- sql_build(op$lazy_query, con = con, ..., use_star = use_star)
   sql_optimise(qry, con = con, ...)
 }
 
 #' @export
-sql_build.ident <- function(op, con = NULL, ...) {
+sql_build.ident <- function(op, con = NULL, ..., use_star = TRUE) {
   op
 }
 
@@ -49,19 +49,45 @@ sql_build.ident <- function(op, con = NULL, ...) {
 #' @param subquery Is this SQL going to be used in a subquery?
 #'   This is important because you can place a bare table name in a subquery
 #'   and  ORDER BY does not work in subqueries.
-sql_render <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
+sql_render <- function(query,
+                       con = NULL,
+                       ...,
+                       use_star = TRUE,
+                       subquery = FALSE,
+                       lvl = 0,
+                       cte = FALSE) {
   check_dots_used()
   UseMethod("sql_render")
 }
 
 #' @export
-sql_render.tbl_lazy <- function(query, con = query$src$con, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
-  sql_render(query$lazy_query, con = con, ..., subquery = subquery, lvl = lvl, cte = cte)
+sql_render.tbl_lazy <- function(query,
+                                con = query$src$con,
+                                ...,
+                                use_star = TRUE,
+                                subquery = FALSE,
+                                lvl = 0,
+                                cte = FALSE) {
+  sql_render(
+    query$lazy_query,
+    con = con,
+    ...,
+    use_star = use_star,
+    subquery = subquery,
+    lvl = lvl,
+    cte = cte
+  )
 }
 
 #' @export
-sql_render.lazy_query <- function(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE) {
-  qry <- sql_build(query, con = con, ...)
+sql_render.lazy_query <- function(query,
+                                  con = NULL,
+                                  ...,
+                                  use_star = TRUE,
+                                  subquery = FALSE,
+                                  lvl = 0,
+                                  cte = FALSE) {
+  qry <- sql_build(query, con = con, ..., use_star = use_star)
   qry <- sql_optimise(qry, con = con, ..., subquery = subquery)
 
   if (cte) {

--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -165,7 +165,7 @@ lazy_values_query <- function(df, types) {
 }
 
 #' @export
-sql_build.lazy_values_query <- function(op, con, ...) {
+sql_build.lazy_values_query <- function(op, con, ..., use_star = TRUE) {
   op
 }
 

--- a/man/db-misc.Rd
+++ b/man/db-misc.Rd
@@ -11,7 +11,7 @@ db_connection_describe(con, ...)
 
 sql_join_suffix(con, suffix, ...)
 
-db_sql_render(con, sql, ..., cte = FALSE)
+db_sql_render(con, sql, ..., cte = FALSE, use_star = TRUE)
 
 dbplyr_edition(con)
 }

--- a/man/remote_name.Rd
+++ b/man/remote_name.Rd
@@ -14,7 +14,7 @@ remote_src(x)
 
 remote_con(x)
 
-remote_query(x, cte = FALSE)
+remote_query(x, cte = FALSE, use_star = TRUE)
 
 remote_query_plan(x, ...)
 }
@@ -23,6 +23,9 @@ remote_query_plan(x, ...)
 
 \item{cte}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Use common table expressions in the generated SQL?}
+
+\item{use_star}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Use \code{*} to select every column?}
 
 \item{...}{Additional arguments passed on to methods.}
 }

--- a/man/sql_build.Rd
+++ b/man/sql_build.Rd
@@ -114,9 +114,17 @@ set_op_query(x, y, type, all = FALSE)
 
 union_query(x, unions)
 
-sql_build(op, con = NULL, ...)
+sql_build(op, con = NULL, ..., use_star = TRUE)
 
-sql_render(query, con = NULL, ..., subquery = FALSE, lvl = 0, cte = FALSE)
+sql_render(
+  query,
+  con = NULL,
+  ...,
+  use_star = TRUE,
+  subquery = FALSE,
+  lvl = 0,
+  cte = FALSE
+)
 
 sql_optimise(x, con = NULL, ..., subquery = FALSE)
 }

--- a/tests/testthat/test-query-join.R
+++ b/tests/testthat/test-query-join.R
@@ -57,7 +57,8 @@ test_that("sql_multi_join_vars generates expected SQL", {
         var = c("x", "a", "b"),
         table = c(1L, 1L, 2L)
       ),
-      table_vars = list(left = c("x", "a"), right = c("x", "b"))
+      table_vars = list(left = c("x", "a"), right = c("x", "b")),
+      use_star = TRUE
     ),
     sql("`left`.*", b = "`b`")
   )
@@ -75,7 +76,8 @@ test_that("sql_multi_join_vars generates expected SQL", {
         all_y = c("x", "a", "b")
       ),
       x_as = ident("left"),
-      y_as = ident("right")
+      y_as = ident("right"),
+      use_star = TRUE
     ),
     sql(
       x = "COALESCE(`left`.`x`, `right`.`x`)",
@@ -98,7 +100,8 @@ test_that("sql_multi_join_vars generates expected SQL", {
         all_y = c("a", "B")
       ),
       x_as = ident("left"),
-      y_as = ident("right")
+      y_as = ident("right"),
+      use_star = TRUE
     ),
     sql(
       a = "COALESCE(`left`.`a`, `right`.`a`)",

--- a/tests/testthat/test-translate-sql-window.R
+++ b/tests/testthat/test-translate-sql-window.R
@@ -238,7 +238,13 @@ test_that("names windows automatically", {
       across(c(col3, col4), ~ order_by(desc(ord), cumsum(.x)))
     )
 
-  sql_list <- get_select_sql(lf1$lazy_query$select, "mutate", op_vars(lf), simulate_sqlite())
+  sql_list <- get_select_sql(
+    lf1$lazy_query$select,
+    "mutate",
+    op_vars(lf),
+    simulate_sqlite(),
+    use_star = TRUE
+  )
   expect_equal(
     sql_list$window_sql,
     sql(
@@ -266,7 +272,13 @@ test_that("names windows automatically", {
       col4 = order_by(desc(ord), cumsum(col4))
     )
 
-  sql_list <- get_select_sql(lf2$lazy_query$select, "mutate", op_vars(lf), simulate_sqlite())
+  sql_list <- get_select_sql(
+    lf2$lazy_query$select,
+    "mutate",
+    op_vars(lf),
+    simulate_sqlite(),
+    use_star = TRUE
+  )
   expect_equal(
     sql_list$window_sql,
     sql(
@@ -302,7 +314,13 @@ test_that("only name windows if they appear multiple times", {
       across(c(col3), ~ order_by(desc(ord), cumsum(.x)))
     )
 
-  sql_list <- get_select_sql(lf$lazy_query$select, "mutate", op_vars(lf), simulate_sqlite())
+  sql_list <- get_select_sql(
+    lf$lazy_query$select,
+    "mutate",
+    op_vars(lf),
+    simulate_sqlite(),
+    use_star = TRUE
+  )
   expect_equal(sql_list$window_sql, sql("`win1` AS (PARTITION BY `part`)"))
   expect_equal(
     sql_list$select_sql,
@@ -327,7 +345,13 @@ test_that("name windows only if supported", {
       across(c(col1, col2), ~ sum(.x, na.rm = TRUE))
     )
 
-  sql_list <- get_select_sql(lf$lazy_query$select, "mutate", op_vars(lf), simulate_hana())
+  sql_list <- get_select_sql(
+    lf$lazy_query$select,
+    "mutate",
+    op_vars(lf),
+    simulate_hana(),
+    use_star = TRUE
+  )
   expect_equal(sql_list$window_sql, character())
   expect_equal(
     sql_list$select_sql,

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -1039,6 +1039,20 @@ test_that("left_join/inner_join uses *", {
 
   expect_equal(out$select, sql("`df_LHS`.*", z = "`z`"))
 
+  out <- lf1 %>%
+    left_join(lf2, by = c("a", "b")) %>%
+    sql_build(use_star = FALSE)
+
+  expect_equal(
+    out$select,
+    sql(
+      a = "`df_LHS`.`a`",
+      b = "`df_LHS`.`b`",
+      c = "`c`",
+      z = "`z`"
+    )
+  )
+
   # also works after relocate
   out <- lf1 %>%
     left_join(lf2, by = c("a", "b")) %>%
@@ -1091,6 +1105,22 @@ test_that("right_join uses *", {
     sql("`df_RHS`.*", c = "`c`")
   )
 
+  # does not use * if `use_star = FALSE`
+  out <- lf1 %>%
+    right_join(lf2, by = c("a", "b")) %>%
+    select(a, b, z, c) %>%
+    sql_build(use_star = FALSE)
+
+  expect_equal(
+    out$select,
+    sql(
+      a = "`df_RHS`.`a`",
+      b = "`df_RHS`.`b`",
+      z = "`z`",
+      c = "`c`"
+    )
+  )
+
   # does not use * if variable are missing
   out <- lf1 %>%
     right_join(lf2, by = c("a", "b")) %>%
@@ -1125,6 +1155,21 @@ test_that("cross_join uses *", {
     sql_build()
 
   expect_equal(out$select, set_names(sql("`df_LHS`.*", "`df_RHS`.*"), c("", "")))
+
+  # does not use * if `use_star = FALSE`
+  out <- lf1 %>%
+    cross_join(lf2) %>%
+    sql_build(use_star = FALSE)
+
+  expect_equal(
+    out$select,
+    sql(
+      a = "`a`",
+      b = "`b`",
+      x = "`x`",
+      y = "`y`"
+    )
+  )
 
   # also works after relocate
   out <- lf1 %>%

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -440,6 +440,12 @@ test_that("mutate() uses star", {
     lf %>% transmute(a = 1L, x, y, z = 2L) %>% remote_query(),
     sql("SELECT 1 AS `a`, *, 2 AS `z`\nFROM `df`")
   )
+
+  # does not use * if `use_star = FALSE`
+  expect_equal(
+    lf %>% mutate(z = 1L) %>% remote_query(use_star = FALSE),
+    sql("SELECT `x`, `y`, 1 AS `z`\nFROM `df`")
+  )
 })
 
 # sql_build ---------------------------------------------------------------


### PR DESCRIPTION
Part of #1146.

``` r
lf1 <- lazy_frame(x = 1, y = 2, z = 2, .name = "df1")
lf2 <- lazy_frame(x = 1, a = 2, b = 2, .name = "df2")

left_join_lf <- left_join(lf1, lf2, by = "x")
left_join_lf %>% show_query(use_star = TRUE)
#> <SQL>
#> SELECT `df1`.*, `a`, `b`
#> FROM `df1`
#> LEFT JOIN `df2`
#>   ON (`df1`.`x` = `df2`.`x`)
left_join_lf %>% show_query(use_star = FALSE)
#> <SQL>
#> SELECT `df1`.`x` AS `x`, `y`, `z`, `a`, `b`
#> FROM `df1`
#> LEFT JOIN `df2`
#>   ON (`df1`.`x` = `df2`.`x`)

right_join_lf <- right_join(lf1, lf2, by = "x") %>% select(x, a, b, y, z)
right_join_lf %>% show_query(use_star = TRUE)
#> <SQL>
#> SELECT `df2`.*, `y`, `z`
#> FROM `df1`
#> RIGHT JOIN `df2`
#>   ON (`df1`.`x` = `df2`.`x`)
right_join_lf %>% show_query(use_star = FALSE)
#> <SQL>
#> SELECT `df2`.`x` AS `x`, `a`, `b`, `y`, `z`
#> FROM `df1`
#> RIGHT JOIN `df2`
#>   ON (`df1`.`x` = `df2`.`x`)

cross_join_lf <- cross_join(lf1, lf2 %>% select(-x))
cross_join_lf %>% show_query(use_star = TRUE)
#> <SQL>
#> SELECT `df1`.*, `a`, `b`
#> FROM `df1`
#> CROSS JOIN `df2`
cross_join_lf %>% show_query(use_star = FALSE)
#> <SQL>
#> SELECT `df1`.`x` AS `x`, `y`, `z`, `a`, `b`
#> FROM `df1`
#> CROSS JOIN `df2`

semi_join_lf <- semi_join(lf1, lf2, by = "x")
semi_join_lf %>% show_query(use_star = TRUE)
#> <SQL>
#> SELECT *
#> FROM `df1`
#> WHERE EXISTS (
#>   SELECT 1 FROM `df2`
#>   WHERE (`df1`.`x` = `df2`.`x`)
#> )
semi_join_lf %>% show_query(use_star = FALSE)
#> <SQL>
#> SELECT `x`, `y`, `z`
#> FROM `df1`
#> WHERE EXISTS (
#>   SELECT 1 FROM `df2`
#>   WHERE (`df1`.`x` = `df2`.`x`)
#> )

mutate_lf <- lf1 %>% mutate(a = 1)
mutate_lf %>% show_query(use_star = TRUE)
#> <SQL>
#> SELECT *, 1.0 AS `a`
#> FROM `df1`
mutate_lf %>% show_query(use_star = FALSE)
#> <SQL>
#> SELECT `x`, `y`, `z`, 1.0 AS `a`
#> FROM `df1`
```

<sup>Created on 2023-05-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>