### PR TITLE
Support relationship in joins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dbplyr (development version)
 
-* `*_join()` now allows providing a `relationship` argument (@bairdj, #1305).
+* `*_join()` now allows using specifying the relationship argument. It must be `NULL` or `"many-to-many"` (@bairdj, #1305).
 
 * The columns generated when using a window function in `filter()` are now named
   `col01` etc. instead of `q01()` (@mgirlich, #1258).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `*_join()` now allows providing a `relationship` argument (@bairdj, #1305).
+
 * The columns generated when using a window function in `filter()` are now named
   `col01` etc. instead of `q01()` (@mgirlich, #1258).
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -208,11 +208,16 @@ check_con <- function(con, ..., arg = caller_arg(con), call = caller_env()) {
 
 check_unsupported_arg <- function(x,
                                   allowed = NULL,
+                                  allow_null = FALSE,
                                   ...,
                                   backend = NULL,
                                   arg = caller_arg(x),
                                   call = caller_env()) {
   if (is_missing(x)) {
+    return()
+  }
+
+  if (allow_null && is_null(x)) {
     return()
   }
 
@@ -233,10 +238,13 @@ check_unsupported_arg <- function(x,
   }
 
   if (!is_null(allowed)) {
-    msg <- c(
-      msg,
-      i = "It must be {.val {allowed}} instead."
-    )
+    if (allow_null) {
+      allow_msg <- "It must be {.val {allowed}} or {.code NULL} instead."
+    } else {
+      allow_msg <- "It must be {.val {allowed}} instead."
+    }
+
+    msg <- c(msg, i = allow_msg)
   }
   cli_abort(msg, call = call)
 }

--- a/R/verb-joins.R
+++ b/R/verb-joins.R
@@ -36,6 +36,7 @@
 #'   and `%in%`.
 #' @param multiple,unmatched Unsupported in database backends. As a workaround
 #'   for multiple use a unique key and for unmatched a foreign key constraint.
+#' @param relationship Unsupported in database backends.
 #' @param x_as,y_as Alias to use for `x` resp. `y`. Defaults to `"LHS"` resp.
 #'   `"RHS"`
 #' @inherit arrange.tbl_lazy return
@@ -79,6 +80,7 @@ inner_join.tbl_lazy <- function(x,
                                 na_matches = c("never", "na"),
                                 multiple = NULL,
                                 unmatched = "drop",
+                                relationship = NULL,
                                 sql_on = NULL,
                                 auto_index = FALSE,
                                 x_as = NULL,
@@ -95,6 +97,7 @@ inner_join.tbl_lazy <- function(x,
     na_matches = na_matches,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     sql_on = sql_on,
     auto_index = auto_index,
     x_as = x_as,
@@ -117,6 +120,7 @@ left_join.tbl_lazy <- function(x,
                                na_matches = c("never", "na"),
                                multiple = NULL,
                                unmatched = "drop",
+                               relationship = NULL,
                                sql_on = NULL,
                                auto_index = FALSE,
                                x_as = NULL,
@@ -133,6 +137,7 @@ left_join.tbl_lazy <- function(x,
     na_matches = na_matches,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     sql_on = sql_on,
     auto_index = auto_index,
     x_as = x_as,
@@ -155,6 +160,7 @@ right_join.tbl_lazy <- function(x,
                                 na_matches = c("never", "na"),
                                 multiple = NULL,
                                 unmatched = "drop",
+                                relationship = NULL,
                                 sql_on = NULL,
                                 auto_index = FALSE,
                                 x_as = NULL,
@@ -171,6 +177,7 @@ right_join.tbl_lazy <- function(x,
     na_matches = na_matches,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     sql_on = sql_on,
     auto_index = auto_index,
     x_as = x_as,
@@ -192,6 +199,7 @@ full_join.tbl_lazy <- function(x,
                                keep = NULL,
                                na_matches = c("never", "na"),
                                multiple = NULL,
+                               relationship = NULL,
                                sql_on = NULL,
                                auto_index = FALSE,
                                x_as = NULL,
@@ -207,6 +215,7 @@ full_join.tbl_lazy <- function(x,
     keep = keep,
     na_matches = na_matches,
     multiple = multiple,
+    relationship = relationship,
     sql_on = sql_on,
     auto_index = auto_index,
     x_as = x_as,
@@ -314,6 +323,7 @@ add_join <- function(x,
                      na_matches = "never",
                      multiple = NULL,
                      unmatched = "drop",
+                     relationship = NULL,
                      sql_on = NULL,
                      auto_index = FALSE,
                      x_as = NULL,
@@ -336,6 +346,7 @@ add_join <- function(x,
 
   check_join_multiple(multiple, by, call = call)
   check_join_unmatched(unmatched, by, call = call)
+  check_join_relationship(relationship, call = call)
 
   y <- auto_copy(
     x, y,
@@ -819,4 +830,12 @@ check_join_unmatched <- function(unmatched, by, call = caller_env()) {
     "Argument {.arg unmatched} isn't supported on database backends.",
     i = "For equi joins you can instead add a foreign key from {.arg x} to {.arg y} for the join columns."
   ), call = call)
+}
+
+check_join_relationship <- function(relationship, call = caller_env()) {
+  if (is.null(relationship) || identical(relationship, "many-to-many")) {
+    return()
+  }
+
+  cli_abort("Argument {.arg relationship} isn't supported on database backends.", call = call)
 }

--- a/R/verb-joins.R
+++ b/R/verb-joins.R
@@ -346,7 +346,12 @@ add_join <- function(x,
 
   check_join_multiple(multiple, by, call = call)
   check_join_unmatched(unmatched, by, call = call)
-  check_join_relationship(relationship, call = call)
+  check_unsupported_arg(
+    relationship,
+    allowed = "many-to-many",
+    allow_null = TRUE,
+    call = call
+  )
 
   y <- auto_copy(
     x, y,
@@ -830,12 +835,4 @@ check_join_unmatched <- function(unmatched, by, call = caller_env()) {
     "Argument {.arg unmatched} isn't supported on database backends.",
     i = "For equi joins you can instead add a foreign key from {.arg x} to {.arg y} for the join columns."
   ), call = call)
-}
-
-check_join_relationship <- function(relationship, call = caller_env()) {
-  if (is.null(relationship) || identical(relationship, "many-to-many")) {
-    return()
-  }
-
-  cli_abort("Argument {.arg relationship} isn't supported on database backends.", call = call)
 }

--- a/man/join.tbl_sql.Rd
+++ b/man/join.tbl_sql.Rd
@@ -22,6 +22,7 @@
   na_matches = c("never", "na"),
   multiple = NULL,
   unmatched = "drop",
+  relationship = NULL,
   sql_on = NULL,
   auto_index = FALSE,
   x_as = NULL,
@@ -39,6 +40,7 @@
   na_matches = c("never", "na"),
   multiple = NULL,
   unmatched = "drop",
+  relationship = NULL,
   sql_on = NULL,
   auto_index = FALSE,
   x_as = NULL,
@@ -56,6 +58,7 @@
   na_matches = c("never", "na"),
   multiple = NULL,
   unmatched = "drop",
+  relationship = NULL,
   sql_on = NULL,
   auto_index = FALSE,
   x_as = NULL,
@@ -72,6 +75,7 @@
   keep = NULL,
   na_matches = c("never", "na"),
   multiple = NULL,
+  relationship = NULL,
   sql_on = NULL,
   auto_index = FALSE,
   x_as = NULL,
@@ -181,6 +185,8 @@ and \code{\%in\%}.}
 
 \item{multiple, unmatched}{Unsupported in database backends. As a workaround
 for multiple use a unique key and for unmatched a foreign key constraint.}
+
+\item{relationship}{Unsupported in database backends.}
 
 \item{sql_on}{A custom join predicate as an SQL expression.
 Usually joins use column equality, but you can perform more complex

--- a/tests/testthat/_snaps/verb-joins.md
+++ b/tests/testthat/_snaps/verb-joins.md
@@ -332,6 +332,14 @@
       ! Argument `unmatched` isn't supported on database backends.
       i For equi joins you can instead add a foreign key from `x` to `y` for the join columns.
 
+# using relationship gives an informative error
+
+    Code
+      left_join(lf, lf, by = "x", relationship = "one-to-one")
+    Condition
+      Error in `left_join()`:
+      ! Argument `relationship` isn't supported on database backends.
+
 # can optionally match NA values
 
     Code

--- a/tests/testthat/_snaps/verb-joins.md
+++ b/tests/testthat/_snaps/verb-joins.md
@@ -338,7 +338,8 @@
       left_join(lf, lf, by = "x", relationship = "one-to-one")
     Condition
       Error in `left_join()`:
-      ! Argument `relationship` isn't supported on database backends.
+      ! `relationship = "one-to-one"` isn't supported on database backends.
+      i It must be "many-to-many" or `NULL` instead.
 
 # can optionally match NA values
 

--- a/tests/testthat/test-verb-joins.R
+++ b/tests/testthat/test-verb-joins.R
@@ -942,6 +942,16 @@ test_that("using unmatched gives an informative error", {
   })
 })
 
+test_that("using relationship gives an informative error", {
+  lf <- lazy_frame(x = 1)
+  expect_no_error(left_join(lf, lf, by = "x", relationship = NULL))
+  expect_no_error(left_join(lf, lf, by = "x", relationship = "many-to-many"))
+
+  expect_snapshot(error = TRUE, {
+    left_join(lf, lf, by = "x", relationship = "one-to-one")
+  })
+})
+
 # sql_build ---------------------------------------------------------------
 
 test_that("join verbs generate expected ops", {


### PR DESCRIPTION
Fix for #1305 

This follows the same conventions as the `multiple` and `unmatched` parameters, in that it supports the database default behaviour (allow many-to-many).

If the user attempts to provide a value for `relationship` other than `NULL` or `many-to-many`, an error will be thrown.