### PR TITLE
Don't rely on `names()` for `tbl_lazy()`

### DIFF
--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -100,7 +100,12 @@ tidyselect_data_has_predicates.tbl_lazy <- function(x) {
   FALSE
 }
 
+the <- new_environment()
+the$warned_on_tbl_lazy_names <- FALSE
+
 #' @export
 names.tbl_lazy <- function(x) {
-  colnames(x)
+  # FIXME find a way to nudge users away from using `names()` without RStudio
+  # getting on your nerves
+  NextMethod("names")
 }

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -203,11 +203,11 @@ across_setup <- function(data,
     error_call = call(fn)
   )
 
-  vars <- syms(names(tbl))[locs]
+  vars <- syms(colnames(tbl))[locs]
   if (allow_rename) {
     names_vars <- names(locs)
   } else {
-    names_vars <- names(tbl)[locs]
+    names_vars <- colnames(tbl)[locs]
   }
 
   dots <- call$...

--- a/R/verb-distinct.R
+++ b/R/verb-distinct.R
@@ -33,12 +33,107 @@ distinct.tbl_lazy <- function(.data, ..., .keep_all = FALSE) {
     dots <- partial_eval_dots(.data, ..., .named = FALSE)
     dots <- quos(!!!dots)
   }
-  prep <- dplyr::distinct_prepare(.data, dots, group_vars = group_vars(.data))
+  prep <- distinct_prepare_compat(.data, dots, group_vars = group_vars(.data))
   out <- dplyr::select(prep$data, prep$keep)
 
   out$lazy_query <- add_distinct(out)
   out
 }
+
+# copied from dplyr with minor changes (names -> colnames)
+# https://github.com/tidyverse/dplyr/blob/main/R/distinct.R
+distinct_prepare_compat <- function(.data,
+                             vars,
+                             group_vars = character(),
+                             .keep_all = FALSE,
+                             caller_env = caller_env(2),
+                             error_call = caller_env()
+                             ) {
+  stopifnot(is_quosures(vars), is.character(group_vars))
+
+  # If no input, keep all variables
+  if (length(vars) == 0) {
+    return(list(
+      data = .data,
+      vars = seq_along(.data),
+      keep = seq_along(.data)
+    ))
+  }
+
+  # If any calls, use mutate to add new columns, then distinct on those
+  computed_columns <- add_computed_columns(.data, vars, error_call = error_call)
+  .data <- computed_columns$data
+  distinct_vars <- computed_columns$added_names
+
+  # Once we've done the mutate, we no longer need lazy objects, and
+  # can instead just use their names
+  missing_vars <- setdiff(distinct_vars, colnames(.data))
+  if (length(missing_vars) > 0) {
+    bullets <- c(
+      "Must use existing variables.",
+      set_names(glue("`{missing_vars}` not found in `.data`."), rep("x", length(missing_vars)))
+    )
+    abort(bullets, call = error_call)
+  }
+
+  # Only keep unique vars
+  distinct_vars <- unique(distinct_vars)
+  # Missing grouping variables are added to the front
+  new_vars <- c(setdiff(group_vars, distinct_vars), distinct_vars)
+
+  if (.keep_all) {
+    keep <- seq_along(.data)
+  } else {
+    keep <- new_vars
+  }
+
+  list(data = .data, vars = new_vars, keep = keep)
+}
+
+# copied from dplyr
+# https://github.com/tidyverse/dplyr/blob/main/R/group-by.R#L243
+add_computed_columns <- function(.data,
+                                 vars,
+                                 error_call = caller_env()) {
+  is_symbol <- purrr::map_lgl(vars, quo_is_variable_reference)
+  needs_mutate <- have_name(vars) | !is_symbol
+
+  if (any(needs_mutate)) {
+    out <- mutate(.data, !!!vars)
+    col_names <- names(exprs_auto_name(vars))
+  } else {
+    out <- .data
+    col_names <- names(exprs_auto_name(vars))
+  }
+
+  list(data = out, added_names = col_names)
+}
+
+# copied from dplyr
+# https://github.com/tidyverse/dplyr/blob/main/R/group-by.R#L276
+quo_is_variable_reference <- function(quo) {
+  if (quo_is_symbol(quo)) {
+    return(TRUE)
+  }
+
+  if (quo_is_call(quo, n = 2)) {
+    expr <- quo_get_expr(quo)
+
+    if (is_call(expr, c("$", "[["))) {
+      if (!identical(expr[[2]], sym(".data"))) {
+        return(FALSE)
+      }
+
+      param <- expr[[3]]
+      if (is_symbol(param) || is_string(param)) {
+        return(TRUE)
+      }
+    }
+  }
+
+  FALSE
+}
+
 
 add_distinct <- function(.data) {
   lazy_query <- .data$lazy_query

--- a/R/verb-mutate.R
+++ b/R/verb-mutate.R
@@ -49,7 +49,7 @@ mutate.tbl_lazy <- function(.data,
     out$lazy_query$group_vars <- character()
   }
 
-  names_original <- names(.data)
+  names_original <- colnames(.data)
 
   out <- mutate_relocate(
     out = out,
@@ -248,7 +248,7 @@ mutate_relocate <- function(out, before, after, names_original) {
 
   # Only change the order of completely new columns that
   # didn't exist in the original data
-  names <- names(out)
+  names <- colnames(out)
   names <- setdiff(names, names_original)
 
   relocate(
@@ -260,7 +260,7 @@ mutate_relocate <- function(out, before, after, names_original) {
 }
 
 mutate_keep <- function(out, keep, used, names_new, names_groups) {
-  names <- names(out)
+  names <- colnames(out)
 
   if (keep == "all") {
     names_out <- names

--- a/R/verb-pivot-longer.R
+++ b/R/verb-pivot-longer.R
@@ -233,7 +233,7 @@ deduplicate_spec <- function(spec, df) {
   }
 
   # Match spec to data, handling duplicated column names
-  col_id <- vctrs::vec_match(names(df), spec$.name)
+  col_id <- vctrs::vec_match(colnames(df), spec$.name)
   has_match <- !is.na(col_id)
 
   if (!vctrs::vec_duplicate_any(col_id[has_match])) {

--- a/R/verb-pivot-wider.R
+++ b/R/verb-pivot-wider.R
@@ -224,7 +224,7 @@ dbplyr_pivot_wider_spec <- function(data,
 
   values_fn <- check_list_of_functions(values_fn, values_from_cols, call = error_call)
 
-  unused_cols <- setdiff(names(data), c(id_cols, names_from_cols, values_from_cols))
+  unused_cols <- setdiff(colnames(data), c(id_cols, names_from_cols, values_from_cols))
   unused_fn <- check_list_of_functions(unused_fn, unused_cols, call = error_call)
   unused_cols <- names(unused_fn)
 

--- a/tests/testthat/_snaps/tbl-lazy.md
+++ b/tests/testthat/_snaps/tbl-lazy.md
@@ -25,3 +25,12 @@
       SELECT *
       FROM `df`
 
+# names() inform that they aren't meant to be used
+
+    Code
+      names(lazy_frame(x = 1))
+    Message
+      Did you mean `colnames()`?
+    Output
+      [1] "lazy_query" "src"       
+

--- a/tests/testthat/test-tbl-lazy.R
+++ b/tests/testthat/test-tbl-lazy.R
@@ -40,3 +40,8 @@ test_that("base source of tbl_lazy is always 'df'", {
   out <- lazy_frame(x = 1, y = 5) %>% sql_build()
   expect_equal(out, base_query(ident("df")))
 })
+
+test_that("names() inform that they aren't meant to be used", {
+  skip("Don't know how to not inform during assignment")
+  expect_snapshot(names(lazy_frame(x = 1)))
+})

--- a/tests/testthat/test-verb-count.R
+++ b/tests/testthat/test-verb-count.R
@@ -43,21 +43,21 @@ test_that("count() does not create groups", {
 test_that("informs if n column already present, unless overridden", {
   df1 <- lazy_frame(n = c(1, 1, 2, 2, 2))
   expect_message(out <- count(df1, n), "already present")
-  expect_named(out, c("n", "nn"))
+  expect_equal(colnames(out), c("n", "nn"))
 
   # not a good idea, but supported
   expect_message(out <- count(df1, n, name = "n"), NA)
-  expect_named(out, "n")
+  expect_equal(colnames(out), "n")
 
   expect_message(out <- count(df1, n, name = "nn"), NA)
-  expect_named(out, c("n", "nn"))
+  expect_equal(colnames(out), c("n", "nn"))
 
   df2 <- lazy_frame(n = c(1, 1, 2, 2, 2), nn = 1:5)
   expect_message(out <- count(df2, n), "already present")
-  expect_named(out, c("n", "nn"))
+  expect_equal(colnames(out), c("n", "nn"))
 
   expect_message(out <- count(df2, n, nn), "already present")
-  expect_named(out, c("n", "nn", "nnn"))
+  expect_equal(colnames(out), c("n", "nn", "nnn"))
 })
 
 test_that(".drop is not supported", {

--- a/tests/testthat/test-verb-pivot-wider.R
+++ b/tests/testthat/test-verb-pivot-wider.R
@@ -295,7 +295,7 @@ test_that("`unused_fn` can summarize unused columns (#990)", {
     res <- tidyr::pivot_wider(df, id_cols = id, unused_fn = list(unused1 = max)) %>%
       collect()
   )
-  expect_named(res, c("id", "a", "b", "unused1"))
+  expect_equal(colnames(res), c("id", "a", "b", "unused1"))
   expect_identical(res$unused1, c(2, 4))
 
   # Globally
@@ -303,7 +303,7 @@ test_that("`unused_fn` can summarize unused columns (#990)", {
     res <- tidyr::pivot_wider(df, id_cols = id, unused_fn = min) %>%
       collect()
   )
-  expect_named(res, c("id", "a", "b", "unused1", "unused2"))
+  expect_equal(colnames(res), c("id", "a", "b", "unused1", "unused2"))
   expect_identical(res$unused1, c(1, 3))
   expect_identical(res$unused2, c(11, 13))
 })


### PR DESCRIPTION
Helps towards #1056.
Simply using `inform()` in `names.tbl_lazy()` is quite annoying. An assignment, e.g.

```
lf <- lazy_frame(x = 1)
```

inside RStudio triggers the `names()` function and therefore the user is informed. So, this should only inform under certain conditions.