### PR TITLE
MS SQL Fix Translation of Unordered `row_number()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* The translation of an unordered `row_number()` now works for MS SQL (@ejneer, #1233)
+
 * The functions `simulate_vars()` and `simulate_vars_is_typed()` were removed
   as they weren't used anymore and tidyselect now offers `tidyselect_data_proxy()`
   and `tidyselect_data_has_predicates()` (@mgirllich, #1199).

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -434,9 +434,19 @@ simulate_mssql <- function(version = "15.0") {
       },
       all = mssql_bit_int_bit(win_aggregate("MIN")),
       any = mssql_bit_int_bit(win_aggregate("MAX")),
+      # mssql requires a subquery that returns a constant to work if no ordering
+      # is specified
+      # https://stackoverflow.com/questions/44105691/row-number-without-order-by
+      row_number = win_rank("ROW_NUMBER", function() {
+        curr_order <- win_current_order()
+        if (is_empty(curr_order)) {
+          return(sql("(SELECT 1)"))
+        }
+        curr_order
+      })
     )
-
-  )}
+  )
+}
 
 mssql_version <- function(con) {
   if (inherits(con, "TestConnection")) {

--- a/R/translate-sql-window.R
+++ b/R/translate-sql-window.R
@@ -125,7 +125,7 @@ rows <- function(from = -Inf, to = 0) {
 
 #' @rdname win_over
 #' @export
-win_rank <- function(f) {
+win_rank <- function(f, empty_order_over = win_current_order) {
   force(f)
   function(order = NULL) {
     group <- win_current_group()
@@ -146,7 +146,7 @@ win_rank <- function(f) {
       not_is_na_exprs <- purrr::map(order_symbols, ~ expr(!is.na(!!.x)))
       no_na_expr <- purrr::reduce(not_is_na_exprs, ~ call2("&", .x, .y))
     } else {
-      order_over <- win_current_order()
+      order_over <- empty_order_over()
     }
 
     rank_sql <- win_over(

--- a/man/win_over.Rd
+++ b/man/win_over.Rd
@@ -22,7 +22,7 @@ win_over(
   con = sql_current_con()
 )
 
-win_rank(f)
+win_rank(f, empty_order_over = win_current_order)
 
 win_aggregate(f)
 

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -370,3 +370,12 @@
       OUTPUT `INSERTED`.`a`, `INSERTED`.`b` AS `b2`
       ;
 
+# `row_number()` without order is translated correctly
+
+    Code
+      mf %>% mutate(rn = row_number())
+    Output
+      <SQL>
+      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS `rn`
+      FROM `df`
+

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -322,6 +322,11 @@ test_that("`sql_query_upsert()` is correct", {
   )
 })
 
+test_that("`row_number()` without order is translated correctly", {
+  mf <- lazy_frame(x = 1, con = simulate_mssql())
+  expect_snapshot(mf %>% mutate(rn = row_number()))
+})
+
 # Live database -----------------------------------------------------------
 
 test_that("can copy_to() and compute() with temporary tables (#272)", {


### PR DESCRIPTION
Fixes `row_number` issue of #1233 