### PR TITLE
Respect na.rm = TRUE in `pmin()` and `pmax()` for Snowflake

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,9 +51,12 @@
 * Teradata:
   * `as.Date(x)` is now translate to `CAST(x AS DATE)` again unless `x` is a
     string (@mgirlich, #1285).
+    
+* Snowflake: 
+  * `na.rm = TRUE` is now respected in `pmin()` and `pmax()` instead (@fh-mthomson, #1329)
 
 * `remote_name()` now returns a string with the name of the table. To get the
-  qualified identifier use the newly added `remote_table()` (@mgirlich, #1280).
+  qualified identifier use the newly added `remote_table()` (@mgirlich, #1329).
 
 * Queries now qualify `*` with the table alias for better compatibility (@mgirlich, #1003).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,7 @@
   * `na.rm = TRUE` is now respected in `pmin()` and `pmax()` instead of being silently ignored (@fh-mthomson, #1329)
 
 * `remote_name()` now returns a string with the name of the table. To get the
-  qualified identifier use the newly added `remote_table()` (@mgirlich, #1329).
+  qualified identifier use the newly added `remote_table()` (@mgirlich, #1280).
 
 * Queries now qualify `*` with the table alias for better compatibility (@mgirlich, #1003).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,7 @@
     string (@mgirlich, #1285).
     
 * Snowflake: 
-  * `na.rm = TRUE` is now respected in `pmin()` and `pmax()` instead (@fh-mthomson, #1329)
+  * `na.rm = TRUE` is now respected in `pmin()` and `pmax()` instead of being silently ignored (@fh-mthomson, #1329)
 
 * `remote_name()` now returns a string with the name of the table. To get the
   qualified identifier use the newly added `remote_table()` (@mgirlich, #1329).

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -293,11 +293,11 @@ snowflake_pmin_pmax_sql_expression <- function(dots, comparison){
   for (i in 2:length(dots)){
     dot_combined <- snowflake_pmin_pmax_builder(dots[i], dot_combined, comparison)
   }
-  glue_sql2(sql_current_con(), "{dot_combined}")
+  dot_combined
 }
 
 snowflake_pmin_pmax_builder <- function(dot_1, dot_2, comparison){
-  glue("COALESCE(IFF({dot_2} {comparison} {dot_1}, {dot_2}, {dot_1}), {dot_2}, {dot_1})")
+  glue_sql2(sql_current_con(), glue("COALESCE(IFF({dot_2} {comparison} {dot_1}, {dot_2}, {dot_1}), {dot_2}, {dot_1})"))
 }
 
 utils::globalVariables(c("%REGEXP%", "DAYNAME", "DECODE", "FLOAT", "MONTHNAME", "POSITION", "trim"))

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -191,6 +191,29 @@ sql_translation.Snowflake <- function(con) {
             "seconds", "minutes", "hours", "days", "weeks", "months", "quarters", "years")
         )
         sql_expr(DATE_TRUNC(!!unit, !!x))
+      },
+      # LEAST / GREATEST on Snowflake will not respect na.rm = TRUE (similar )
+      # https://docs.snowflake.com/en/sql-reference/functions/least
+      # https://docs.snowflake.com/en/sql-reference/functions/greatest
+      # "If any of the argument values is NULL, the result is NULL."
+      # Source: https://stackoverflow.com/a/74529349/22193215
+      # [move to PR context] References:
+      # * https://community.snowflake.com/s/question/0D50Z00009LHFw1SAH/greatest-and-null-values
+      # * https://stackoverflow.com/questions/74527418/how-to-use-greatest-in-snowflake-with-null-values?newreg=1d65af9409e5443b85843be173894863
+      # * https://github.com/tidyverse/dbplyr/issues/118
+      pmin = function(x, y, na.rm = FALSE) {
+        if (identical(na.rm, TRUE)) {
+          glue_sql2(sql_current_con(), "-(GREATEST([-{x}], [-{y}])[0]::INT)")
+        } else {
+          glue_sql2(sql_current_con(), "LEAST({x}, {y})")
+        }
+      },
+      pmax = function(x, y, na.rm = FALSE) {
+        if (identical(na.rm, TRUE)) {
+          glue_sql2(sql_current_con(), "GREATEST([{x}], [{y}])[0]::INT")
+        } else {
+          glue_sql2(sql_current_con(), "GREATEST({x}, {y})")
+        }
       }
     ),
     sql_translator(
@@ -248,6 +271,7 @@ snowflake_grepl <- function(pattern,
   # behavior
   sql_expr(((!!x)) %REGEXP% (".*" || !!paste0('(', pattern, ')') || ".*"))
 }
+
 snowflake_round <- function(x, digits = 0L) {
   digits <- as.integer(digits)
   sql_expr(round(((!!x)) %::% FLOAT, !!digits))

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -202,7 +202,7 @@ sql_translation.Snowflake <- function(con) {
       pmin = function(..., na.rm = FALSE) {
         dots <- snowflake_pmin_pmax_na_rm(..., na.rm = na.rm)
         if (identical(na.rm, TRUE)) {
-          sql_expr(IFF(!!dots$x <= !!dots$y, !!dots$x, !!dots$y))
+          sql_expr(COALESCE(IFF(!!dots$x <= !!dots$y, !!dots$x, !!dots$y), !!dots$x, !!dots$y))
         } else {
           glue_sql2(sql_current_con(), "LEAST({.val dots*})")
         }
@@ -210,7 +210,7 @@ sql_translation.Snowflake <- function(con) {
       pmax = function(..., na.rm = FALSE) {
         dots <- snowflake_pmin_pmax_na_rm(..., na.rm = na.rm)
         if (identical(na.rm, TRUE)) {
-          sql_expr(IFF(!!dots$x <= !!dots$y, !!dots$y, !!dots$x))
+          sql_expr(COALESCE(IFF(!!dots$x <= !!dots$y, !!dots$y, !!dots$x), !!dots$y, !!dots$x))
         } else {
           glue_sql2(sql_current_con(), "GREATEST({.val dots*})")
         }

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -192,15 +192,10 @@ sql_translation.Snowflake <- function(con) {
         )
         sql_expr(DATE_TRUNC(!!unit, !!x))
       },
-      # LEAST / GREATEST on Snowflake will not respect na.rm = TRUE (similar )
+      # LEAST / GREATEST on Snowflake will not respect na.rm = TRUE by default (similar to Oracle/Access)
       # https://docs.snowflake.com/en/sql-reference/functions/least
       # https://docs.snowflake.com/en/sql-reference/functions/greatest
-      # "If any of the argument values is NULL, the result is NULL."
-      # Source: https://stackoverflow.com/a/74529349/22193215
-      # [move to PR context] References:
-      # * https://community.snowflake.com/s/question/0D50Z00009LHFw1SAH/greatest-and-null-values
-      # * https://stackoverflow.com/questions/74527418/how-to-use-greatest-in-snowflake-with-null-values?newreg=1d65af9409e5443b85843be173894863
-      # * https://github.com/tidyverse/dbplyr/issues/118
+      # Solution source: https://stackoverflow.com/a/74529349/22193215
       pmin = function(..., na.rm = FALSE) {
         if (identical(na.rm, TRUE)) {
           dots <- snowflake_pmin_pmax_concat_dots(..., na.rm = na.rm, negate = TRUE)

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -199,7 +199,7 @@ sql_translation.Snowflake <- function(con) {
       pmin = function(..., na.rm = FALSE) {
         if (identical(na.rm, TRUE)) {
           dots <- snowflake_pmin_pmax_concat_dots(..., na.rm = na.rm, negate = TRUE)
-          glue_sql2(sql_current_con(), "-(GREATEST({dots})[0]::INT)")
+          glue_sql2(sql_current_con(), "-(GREATEST({dots})[0]::FLOAT)")
         } else {
           dots <- snowflake_pmin_pmax_concat_dots(..., na.rm = na.rm)
           glue_sql2(sql_current_con(), "LEAST({dots})")
@@ -208,7 +208,7 @@ sql_translation.Snowflake <- function(con) {
       pmax = function(..., na.rm = FALSE) {
         dots <- snowflake_pmin_pmax_concat_dots(..., na.rm = na.rm)
         if (identical(na.rm, TRUE)) {
-          glue_sql2(sql_current_con(), "GREATEST({dots})[0]::INT")
+          glue_sql2(sql_current_con(), "GREATEST({dots})[0]::FLOAT")
         } else {
           glue_sql2(sql_current_con(), "GREATEST({dots})")
         }

--- a/tests/testthat/_snaps/backend-snowflake.md
+++ b/tests/testthat/_snaps/backend-snowflake.md
@@ -8,3 +8,17 @@
       ! `ignore.case = TRUE` isn't supported in Snowflake translation.
       i It must be FALSE instead.
 
+# pmin() and pmax() respect na.rm
+
+    Code
+      test_translate_sql(pmin(x, y, z, na.rm = TRUE))
+    Output
+      <SQL> COALESCE(IFF(COALESCE(IFF(`x` <= `y`, `x`, `y`), `x`, `y`) <= `z`, COALESCE(IFF(`x` <= `y`, `x`, `y`), `x`, `y`), `z`), COALESCE(IFF(`x` <= `y`, `x`, `y`), `x`, `y`), `z`)
+
+---
+
+    Code
+      test_translate_sql(pmax(x, y, z, na.rm = TRUE))
+    Output
+      <SQL> COALESCE(IFF(COALESCE(IFF(`x` >= `y`, `x`, `y`), `x`, `y`) >= `z`, COALESCE(IFF(`x` >= `y`, `x`, `y`), `x`, `y`), `z`), COALESCE(IFF(`x` >= `y`, `x`, `y`), `x`, `y`), `z`)
+

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -97,3 +97,15 @@ test_that("custom lubridate functions translated correctly", {
   expect_equal(test_translate_sql(floor_date(x, 'month')), sql("DATE_TRUNC('month', `x`)"))
   expect_equal(test_translate_sql(floor_date(x, 'week')),  sql("DATE_TRUNC('week', `x`)"))
 })
+
+test_that("pmin and max become MIN and MAX", {
+  local_con(simulate_snowflake())
+
+  # na.rm = TRUE: override LEAST / GREATEST behavior for Snowflake
+  expect_equal(test_translate_sql(pmin(x, y, na.rm = TRUE)), sql('-(GREATEST([-`x`], [-`y`])[0]::INT)'))
+  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql('GREATEST([`x`], [`y`])[0]::INT'))
+
+  # na.rm = FALSE: leverage default Snowflake behavior for LEAST / GREATEST
+  expect_equal(test_translate_sql(pmin(x, y, na.rm = FALSE)), sql('LEAST(`x`, `y`)'))
+  expect_equal(test_translate_sql(pmax(x, y, na.rm = FALSE)), sql('GREATEST(`x`, `y`)'))
+})

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -128,9 +128,10 @@ test_that("pmin() and pmax() respect na.rm", {
 
   # na.rm = TRUE: override default behavior for Snowflake (only supports pairs)
   expect_equal(test_translate_sql(pmin(x, y, na.rm = TRUE)), sql("COALESCE(IFF(`x` <= `y`, `x`, `y`), `x`, `y`)"))
-  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql("COALESCE(IFF(`x` <= `y`, `y`, `x`), `y`, `x`)"))
+  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql("COALESCE(IFF(`x` >= `y`, `x`, `y`), `x`, `y`)"))
 
-  expect_error(test_translate_sql(pmax(x, y, z, na.rm = TRUE)))
+  expect_snapshot(test_translate_sql(pmin(x, y, z, na.rm = TRUE)))
+  expect_snapshot(test_translate_sql(pmax(x, y, z, na.rm = TRUE)))
 
   # na.rm = FALSE: leverage default behavior for Snowflake
   expect_equal(test_translate_sql(pmin(x, y, z, na.rm = FALSE)), sql("LEAST(`x`, `y`, `z`)"))

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -102,10 +102,10 @@ test_that("pmin and max become MIN and MAX", {
   local_con(simulate_snowflake())
 
   # na.rm = TRUE: override LEAST / GREATEST behavior for Snowflake
-  expect_equal(test_translate_sql(pmin(x, y, na.rm = TRUE)), sql('-(GREATEST([-`x`], [-`y`])[0]::INT)'))
-  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql('GREATEST([`x`], [`y`])[0]::INT'))
+  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = TRUE)), sql('-(GREATEST([-`x`], [-`y`], [-`z`])[0]::INT)'))
+  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = TRUE)), sql('GREATEST([`x`], [`y`], [`z`])[0]::INT'))
 
   # na.rm = FALSE: leverage default Snowflake behavior for LEAST / GREATEST
-  expect_equal(test_translate_sql(pmin(x, y, na.rm = FALSE)), sql('LEAST(`x`, `y`)'))
-  expect_equal(test_translate_sql(pmax(x, y, na.rm = FALSE)), sql('GREATEST(`x`, `y`)'))
+  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = FALSE)), sql('LEAST(`x`, `y`, `z`)'))
+  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = FALSE)), sql('GREATEST(`x`, `y`, `z`)'))
 })

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -127,8 +127,8 @@ test_that("pmin() and pmax() respect na.rm", {
   # https://docs.snowflake.com/en/sql-reference/functions/greatest
 
   # na.rm = TRUE: override default behavior for Snowflake
-  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = TRUE)), sql('-(GREATEST([-`x`], [-`y`], [-`z`])[0]::INT)'))
-  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = TRUE)), sql('GREATEST([`x`], [`y`], [`z`])[0]::INT'))
+  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = TRUE)), sql('-(GREATEST([-`x`], [-`y`], [-`z`])[0]::FLOAT)'))
+  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = TRUE)), sql('GREATEST([`x`], [`y`], [`z`])[0]::FLOAT'))
 
   # na.rm = FALSE: leverage default behavior for Snowflake
   expect_equal(test_translate_sql(pmin(x, y, z, na.rm = FALSE)), sql('LEAST(`x`, `y`, `z`)'))

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -121,15 +121,14 @@ test_that("min() and max()", {
 
 test_that("pmin() and pmax() respect na.rm", {
   local_con(simulate_snowflake())
-  test_translate_sql(pmin(x, y, na.rm = TRUE))
 
   # Snowflake default for LEAST/GREATEST: If any of the argument values is NULL, the result is NULL.
   # https://docs.snowflake.com/en/sql-reference/functions/least
   # https://docs.snowflake.com/en/sql-reference/functions/greatest
 
   # na.rm = TRUE: override default behavior for Snowflake (only supports pairs)
-  expect_equal(test_translate_sql(pmin(x, y, na.rm = TRUE)), sql("IFF(`x` <= `y`, `x`, `y`)"))
-  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql("IFF(`x` <= `y`, `y`, `x`)"))
+  expect_equal(test_translate_sql(pmin(x, y, na.rm = TRUE)), sql("COALESCE(IFF(`x` <= `y`, `x`, `y`), `x`, `y`)"))
+  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql("COALESCE(IFF(`x` <= `y`, `y`, `x`), `y`, `x`)"))
 
   expect_error(test_translate_sql(pmax(x, y, z, na.rm = TRUE)))
 

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -2,17 +2,17 @@ test_that("custom scalar translated correctly", {
   local_con(simulate_snowflake())
   expect_equal(test_translate_sql(log10(x)), sql("LOG(10.0, `x`)"))
   expect_equal(test_translate_sql(round(x, digits = 1.1)), sql("ROUND((`x`) :: FLOAT, 1)"))
-  expect_equal(test_translate_sql(grepl("exp", x)),        sql("(`x`) REGEXP ('.*' || '(exp)' || '.*')"))
+  expect_equal(test_translate_sql(grepl("exp", x)), sql("(`x`) REGEXP ('.*' || '(exp)' || '.*')"))
   expect_snapshot((expect_error(test_translate_sql(grepl("exp", x, ignore.case = TRUE)))))
 })
 
 test_that("pasting translated correctly", {
   local_con(simulate_snowflake())
 
-  expect_equal(test_translate_sql(paste(x, y)),  sql("ARRAY_TO_STRING(ARRAY_CONSTRUCT_COMPACT(`x`, `y`), ' ')"))
+  expect_equal(test_translate_sql(paste(x, y)), sql("ARRAY_TO_STRING(ARRAY_CONSTRUCT_COMPACT(`x`, `y`), ' ')"))
   expect_equal(test_translate_sql(paste0(x, y)), sql("ARRAY_TO_STRING(ARRAY_CONSTRUCT_COMPACT(`x`, `y`), '')"))
   expect_equal(test_translate_sql(str_c(x, y)), sql("CONCAT_WS('', `x`, `y`)"))
-  expect_equal(test_translate_sql(str_c(x, y, sep = '|')), sql("CONCAT_WS('|', `x`, `y`)"))
+  expect_equal(test_translate_sql(str_c(x, y, sep = "|")), sql("CONCAT_WS('|', `x`, `y`)"))
 
   expect_error(test_translate_sql(paste0(x, collapse = "")), "`collapse` not supported")
 
@@ -40,33 +40,33 @@ test_that("aggregates are translated correctly", {
   local_con(simulate_snowflake())
 
   expect_equal(test_translate_sql(cor(x, y), window = FALSE), sql("CORR(`x`, `y`)"))
-  expect_equal(test_translate_sql(cor(x, y), window = TRUE),  sql("CORR(`x`, `y`) OVER ()"))
+  expect_equal(test_translate_sql(cor(x, y), window = TRUE), sql("CORR(`x`, `y`) OVER ()"))
 
   expect_equal(test_translate_sql(cov(x, y), window = FALSE), sql("COVAR_SAMP(`x`, `y`)"))
-  expect_equal(test_translate_sql(cov(x, y), window = TRUE),  sql("COVAR_SAMP(`x`, `y`) OVER ()"))
+  expect_equal(test_translate_sql(cov(x, y), window = TRUE), sql("COVAR_SAMP(`x`, `y`) OVER ()"))
 
   expect_equal(test_translate_sql(all(x, na.rm = TRUE), window = FALSE), sql("BOOLAND_AGG(`x`)"))
-  expect_equal(test_translate_sql(all(x, na.rm = TRUE), window = TRUE),  sql("BOOLAND_AGG(`x`) OVER ()"))
+  expect_equal(test_translate_sql(all(x, na.rm = TRUE), window = TRUE), sql("BOOLAND_AGG(`x`) OVER ()"))
 
   expect_equal(test_translate_sql(any(x, na.rm = TRUE), window = FALSE), sql("BOOLOR_AGG(`x`)"))
-  expect_equal(test_translate_sql(any(x, na.rm = TRUE), window = TRUE),  sql("BOOLOR_AGG(`x`) OVER ()"))
+  expect_equal(test_translate_sql(any(x, na.rm = TRUE), window = TRUE), sql("BOOLOR_AGG(`x`) OVER ()"))
 
   expect_equal(test_translate_sql(sd(x, na.rm = TRUE), window = FALSE), sql("STDDEV(`x`)"))
-  expect_equal(test_translate_sql(sd(x, na.rm = TRUE), window = TRUE),  sql("STDDEV(`x`) OVER ()"))
+  expect_equal(test_translate_sql(sd(x, na.rm = TRUE), window = TRUE), sql("STDDEV(`x`) OVER ()"))
 })
 
 test_that("snowflake mimics two argument log", {
   local_con(simulate_snowflake())
 
-  expect_equal(test_translate_sql(log(x)), sql('LN(`x`)'))
-  expect_equal(test_translate_sql(log(x, 10)), sql('LOG(10.0, `x`)'))
-  expect_equal(test_translate_sql(log(x, 10L)), sql('LOG(10, `x`)'))
+  expect_equal(test_translate_sql(log(x)), sql("LN(`x`)"))
+  expect_equal(test_translate_sql(log(x, 10)), sql("LOG(10.0, `x`)"))
+  expect_equal(test_translate_sql(log(x, 10L)), sql("LOG(10, `x`)"))
 })
 
 test_that("custom lubridate functions translated correctly", {
   local_con(simulate_snowflake())
 
-  expect_equal(test_translate_sql(day(x)),  sql("EXTRACT(DAY FROM `x`)"))
+  expect_equal(test_translate_sql(day(x)), sql("EXTRACT(DAY FROM `x`)"))
   expect_equal(test_translate_sql(mday(x)), sql("EXTRACT(DAY FROM `x`)"))
   expect_equal(test_translate_sql(yday(x)), sql("EXTRACT('dayofyear', `x`)"))
   expect_equal(test_translate_sql(wday(x)), sql("EXTRACT('dayofweek', DATE(`x`) + 0) + 1.0"))
@@ -88,21 +88,21 @@ test_that("custom lubridate functions translated correctly", {
 
   expect_equal(test_translate_sql(seconds(x)), sql("INTERVAL '`x` second'"))
   expect_equal(test_translate_sql(minutes(x)), sql("INTERVAL '`x` minute'"))
-  expect_equal(test_translate_sql(hours(x)),   sql("INTERVAL '`x` hour'"))
-  expect_equal(test_translate_sql(days(x)),    sql("INTERVAL '`x` day'"))
-  expect_equal(test_translate_sql(weeks(x)),   sql("INTERVAL '`x` week'"))
-  expect_equal(test_translate_sql(months(x)),  sql("INTERVAL '`x` month'"))
-  expect_equal(test_translate_sql(years(x)),   sql("INTERVAL '`x` year'"))
+  expect_equal(test_translate_sql(hours(x)), sql("INTERVAL '`x` hour'"))
+  expect_equal(test_translate_sql(days(x)), sql("INTERVAL '`x` day'"))
+  expect_equal(test_translate_sql(weeks(x)), sql("INTERVAL '`x` week'"))
+  expect_equal(test_translate_sql(months(x)), sql("INTERVAL '`x` month'"))
+  expect_equal(test_translate_sql(years(x)), sql("INTERVAL '`x` year'"))
 
-  expect_equal(test_translate_sql(floor_date(x, 'month')), sql("DATE_TRUNC('month', `x`)"))
-  expect_equal(test_translate_sql(floor_date(x, 'week')),  sql("DATE_TRUNC('week', `x`)"))
+  expect_equal(test_translate_sql(floor_date(x, "month")), sql("DATE_TRUNC('month', `x`)"))
+  expect_equal(test_translate_sql(floor_date(x, "week")), sql("DATE_TRUNC('week', `x`)"))
 })
 
 test_that("min() and max()", {
   local_con(simulate_snowflake())
 
-  expect_equal(test_translate_sql(min(x, na.rm = TRUE)), sql('MIN(`x`) OVER ()'))
-  expect_equal(test_translate_sql(max(x, na.rm = TRUE)), sql('MAX(`x`) OVER ()'))
+  expect_equal(test_translate_sql(min(x, na.rm = TRUE)), sql("MIN(`x`) OVER ()"))
+  expect_equal(test_translate_sql(max(x, na.rm = TRUE)), sql("MAX(`x`) OVER ()"))
 
   # na.rm = FALSE is ignored
   # https://docs.snowflake.com/en/sql-reference/functions/min
@@ -121,16 +121,19 @@ test_that("min() and max()", {
 
 test_that("pmin() and pmax() respect na.rm", {
   local_con(simulate_snowflake())
+  test_translate_sql(pmin(x, y, na.rm = TRUE))
 
   # Snowflake default for LEAST/GREATEST: If any of the argument values is NULL, the result is NULL.
   # https://docs.snowflake.com/en/sql-reference/functions/least
   # https://docs.snowflake.com/en/sql-reference/functions/greatest
 
-  # na.rm = TRUE: override default behavior for Snowflake
-  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = TRUE)), sql('-(GREATEST([-`x`], [-`y`], [-`z`])[0]::FLOAT)'))
-  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = TRUE)), sql('GREATEST([`x`], [`y`], [`z`])[0]::FLOAT'))
+  # na.rm = TRUE: override default behavior for Snowflake (only supports pairs)
+  expect_equal(test_translate_sql(pmin(x, y, na.rm = TRUE)), sql("IFF(`x` <= `y`, `x`, `y`)"))
+  expect_equal(test_translate_sql(pmax(x, y, na.rm = TRUE)), sql("IFF(`x` <= `y`, `y`, `x`)"))
+
+  expect_error(test_translate_sql(pmax(x, y, z, na.rm = TRUE)))
 
   # na.rm = FALSE: leverage default behavior for Snowflake
-  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = FALSE)), sql('LEAST(`x`, `y`, `z`)'))
-  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = FALSE)), sql('GREATEST(`x`, `y`, `z`)'))
+  expect_equal(test_translate_sql(pmin(x, y, z, na.rm = FALSE)), sql("LEAST(`x`, `y`, `z`)"))
+  expect_equal(test_translate_sql(pmax(x, y, z, na.rm = FALSE)), sql("GREATEST(`x`, `y`, `z`)"))
 })


### PR DESCRIPTION
Closes #1329 

Incremental approaches taken (as of commits linked below):
1. Initial approach taken from https://stackoverflow.com/a/74529349/22193215, but that doesn't scale well to dates, only integers / floats, since NEGATE on a date isn't supported for the `pmin(..., na.rm = TRUE)` translation: c2532c055f629a1f142e7490bf5f759d129c98bd
2. Migrated to approach closer to https://github.com/tidyverse/dbplyr/blob/main/R/backend-access.R#L135-L142: only supports two columns: 773633110c05b4bc2e3974e6fd360c1b996c2c56
3. [current] generalizable approach for N>2 columns, using ugly, but recursive approach: 1ac318808e8d78e684b32c963a10b61579ef5710