### PR TITLE
Unary minus doesn't need parens for simple expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* `-1 + x` is now translated correctly (#1420).
+
 * SQL server: `filter()` does a better job of converting logical vectors 
   from bit to boolean (@ejneer, #1288). 
 

--- a/R/translate-sql-helpers.R
+++ b/R/translate-sql-helpers.R
@@ -175,10 +175,11 @@ sql_infix <- function(f, pad = TRUE) {
 escape_infix_expr <- function(xq, x, escape_unary_minus = FALSE) {
   infix_calls <- c("+", "-", "*", "/", "%%", "^")
   is_infix <- is_call(xq, infix_calls, n = 2)
-  is_unary_minus <- escape_unary_minus && is_call(xq, "-", n = 1)
+  is_unary_minus <- escape_unary_minus && 
+    is_call(xq, "-", n = 1) && !is_atomic(x, n = 1)
 
   if (is_infix || is_unary_minus) {
-    enpared <- glue_sql2(sql_current_con(), "({x})")
+    enpared <- glue_sql2(sql_current_con(), "({.val x})")
     return(enpared)
   }
 

--- a/tests/testthat/test-backend-.R
+++ b/tests/testthat/test-backend-.R
@@ -39,6 +39,7 @@ test_that("unary plus works for non-numeric expressions", {
 test_that("unary minus flips sign of number", {
   local_con(simulate_dbi())
   expect_equal(test_translate_sql(-10L), sql("-10"))
+  expect_equal(test_translate_sql(-10L + x), sql("-10 + `x`"))
   expect_equal(test_translate_sql(x == -10), sql('`x` = -10.0'))
   expect_equal(test_translate_sql(x %in% c(-1L, 0L)), sql('`x` IN (-1, 0)'))
 })

--- a/tests/testthat/test-translate-sql-helpers.R
+++ b/tests/testthat/test-translate-sql-helpers.R
@@ -63,7 +63,7 @@ test_that("can translate infix expression without parentheses", {
 test_that("unary minus works with expressions", {
   local_con(simulate_dbi())
   expect_equal(test_translate_sql(-!!expr(x+2)), sql("-(`x` + 2.0)"))
-  expect_equal(test_translate_sql(--x), sql("-(-`x`)"))
+  expect_equal(test_translate_sql(--x), sql("--`x`"))
 })
 
 test_that("pad = FALSE works", {


### PR DESCRIPTION
Fixes #1420