### PR TITLE
Refine `select` inline criteria to keep `arrange`d computed columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
 * The databricks backend now supports creating non-temporary tables too (#1418).
 
 * `x$name` never attempts to evaluate `name` (#1368).
+* Refined the `select()` inlining criteria to keep computed columns used to
+  `arrange()` subqueries that are eliminated by a subsequent select (@ejneer,
+  #1437).
 
 * `rows_patch(in_place = FALSE)` now works when more than one column should be
   patched (@gorcha, #1443).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dbplyr (development version)
 
+* Refined the `select()` inlining criteria to keep computed columns used to
+  `arrange()` subqueries that are eliminated by a subsequent select (@ejneer,
+  #1437).
+
 * dbplyr now exports some tools to work with the internal `table_path` class
   which is useful for certain backends that need to work with this 
   data structure (#1300).
@@ -38,9 +42,6 @@
 * The databricks backend now supports creating non-temporary tables too (#1418).
 
 * `x$name` never attempts to evaluate `name` (#1368).
-* Refined the `select()` inlining criteria to keep computed columns used to
-  `arrange()` subqueries that are eliminated by a subsequent select (@ejneer,
-  #1437).
 
 * `rows_patch(in_place = FALSE)` now works when more than one column should be
   patched (@gorcha, #1443).

--- a/R/verb-select.R
+++ b/R/verb-select.R
@@ -134,11 +134,8 @@ add_select <- function(lazy_query, vars) {
 select_can_be_inlined <- function(lazy_query, vars) {
   vars_data <- op_vars(lazy_query)
 
-  computed_columns <- purrr::pmap(
-    lazy_query$select,
-    function(name, expr, ...) if (is_quosure(expr)) name
-  ) %>%
-    purrr::compact()
+  computed_flag <- purrr::map_lgl(lazy_query$select$expr, is_quosure)
+  computed_columns <- lazy_query$select$name[computed_flag]
 
   order_vars <- purrr::map_chr(lazy_query$order_by, as_label)
 

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -181,6 +181,22 @@
       Error in `select()`:
       ! This tidyselect interface doesn't support predicates.
 
+# computed columns are not inlined away
+
+    Code
+      lf %>% mutate(z = 1) %>% arrange(x, z) %>% select(x)
+    Condition
+      Warning:
+      ORDER BY is ignored in subqueries without LIMIT
+      i Do you need to move arrange() later in the pipeline or use window_order() instead?
+    Output
+      <SQL>
+      SELECT `x`
+      FROM (
+        SELECT `df`.*, 1.0 AS `z`
+        FROM `df`
+      ) AS `q01`
+
 # multiple selects are collapsed
 
     Code

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -181,22 +181,6 @@
       Error in `select()`:
       ! This tidyselect interface doesn't support predicates.
 
-# computed columns are not inlined away
-
-    Code
-      lf %>% mutate(z = 1) %>% arrange(x, z) %>% select(x)
-    Condition
-      Warning:
-      ORDER BY is ignored in subqueries without LIMIT
-      i Do you need to move arrange() later in the pipeline or use window_order() instead?
-    Output
-      <SQL>
-      SELECT `x`
-      FROM (
-        SELECT `df`.*, 1.0 AS `z`
-        FROM `df`
-      ) AS `q01`
-
 # multiple selects are collapsed
 
     Code

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -181,6 +181,22 @@
       Error in `select()`:
       ! This tidyselect interface doesn't support predicates.
 
+# arranged computed columns are not inlined away
+
+    Code
+      lf %>% mutate(z = 1) %>% arrange(x, z) %>% select(x)
+    Condition
+      Warning:
+      ORDER BY is ignored in subqueries without LIMIT
+      i Do you need to move arrange() later in the pipeline or use window_order() instead?
+    Output
+      <SQL>
+      SELECT `x`
+      FROM (
+        SELECT `df`.*, 1.0 AS `z`
+        FROM `df`
+      ) AS `q01`
+
 # multiple selects are collapsed
 
     Code

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -309,6 +309,33 @@ test_that("where() isn't suppored", {
   })
 })
 
+test_that("arranged computed columns are not inlined away", {
+  lf <- lazy_frame(x = 1)
+
+  # shouldn't inline
+  out <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x)
+  # should inline
+  out2 <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x, z)
+
+  inner_query <- out$lazy_query$x
+  expect_snapshot({
+      lf %>% mutate(z = 1) %>% arrange(x, z) %>% select(x)
+  })
+  expect_s3_class(inner_query, "lazy_select_query")
+  expect_equal(
+    inner_query$order_by,
+    list(quo(x), quo(z)),
+    ignore_formula_env = TRUE
+  )
+  expect_equal(op_vars(inner_query), c("x", "z"))
+  expect_equal(op_vars(out$lazy_query), "x")
+  expect_equal(
+      # order vars in a subquery are dropped
+      inner_query[setdiff(names(inner_query), "order_vars")],
+      out2$lazy_query[setdiff(names(out2$lazy_query), "order_vars")]
+  )
+})
+
 # sql_render --------------------------------------------------------------
 
 test_that("multiple selects are collapsed", {

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -35,6 +35,31 @@ test_that("select after distinct produces subquery", {
   expect_true(lq$x$distinct)
 })
 
+test_that("select after arrange produces subquery, if needed", {
+  lf <- lazy_frame(x = 1)
+
+  # shouldn't inline
+  out <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x)
+  # should inline
+  out2 <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x, z)
+
+  inner_query <- out$lazy_query$x
+  expect_s3_class(inner_query, "lazy_select_query")
+  expect_equal(inner_query$order_by, list(quo(x), quo(z)), ignore_formula_env = TRUE)
+  expect_equal(
+    op_vars(inner_query),
+    c("x", "z")
+  )
+  expect_equal(op_vars(out$lazy_query), "x")
+
+  # order vars in a subquery are dropped
+  expect_equal(
+    inner_query[setdiff(names(inner_query), "order_vars")],
+    out2$lazy_query[setdiff(names(out2$lazy_query), "order_vars")]
+  )
+})
+
+
 test_that("rename/relocate after distinct is inlined #1141", {
   lf <- lazy_frame(x = 1, y = 1:2)
   expect_snapshot({
@@ -282,30 +307,6 @@ test_that("where() isn't suppored", {
   expect_snapshot(error = TRUE, {
     lf %>% select(where(is.integer))
   })
-})
-
-test_that("arranged computed columns are not inlined away", {
-  lf <- lazy_frame(x = 1)
-
-  # shouldn't inline
-  out <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x)
-  # should inline
-  out2 <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x, z)
-
-  inner_query <- out$lazy_query$x
-  expect_s3_class(inner_query, "lazy_select_query")
-  expect_equal(
-    inner_query$order_by,
-    list(quo(x), quo(z)),
-    ignore_formula_env = TRUE
-  )
-  expect_equal(op_vars(inner_query), c("x", "z"))
-  expect_equal(op_vars(out$lazy_query), "x")
-  expect_equal(
-      # order vars in a subquery are dropped
-      inner_query[setdiff(names(inner_query), "order_vars")],
-      out2$lazy_query[setdiff(names(out2$lazy_query), "order_vars")]
-  )
 })
 
 # sql_render --------------------------------------------------------------

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -284,6 +284,14 @@ test_that("where() isn't suppored", {
   })
 })
 
+test_that("computed columns are not inlined away", {
+  lf <- lazy_frame(x = 1, y = 2)
+
+  expect_snapshot({
+    lf %>% mutate(z = 1) %>% arrange(x, z) %>% select(x)
+  })
+})
+
 # sql_render --------------------------------------------------------------
 
 test_that("multiple selects are collapsed", {

--- a/tests/testthat/test-verb-select.R
+++ b/tests/testthat/test-verb-select.R
@@ -284,12 +284,28 @@ test_that("where() isn't suppored", {
   })
 })
 
-test_that("computed columns are not inlined away", {
-  lf <- lazy_frame(x = 1, y = 2)
+test_that("arranged computed columns are not inlined away", {
+  lf <- lazy_frame(x = 1)
 
-  expect_snapshot({
-    lf %>% mutate(z = 1) %>% arrange(x, z) %>% select(x)
-  })
+  # shouldn't inline
+  out <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x)
+  # should inline
+  out2 <- lf %>% mutate(z = 2) %>% arrange(x, z) %>% select(x, z)
+
+  inner_query <- out$lazy_query$x
+  expect_s3_class(inner_query, "lazy_select_query")
+  expect_equal(
+    inner_query$order_by,
+    list(quo(x), quo(z)),
+    ignore_formula_env = TRUE
+  )
+  expect_equal(op_vars(inner_query), c("x", "z"))
+  expect_equal(op_vars(out$lazy_query), "x")
+  expect_equal(
+      # order vars in a subquery are dropped
+      inner_query[setdiff(names(inner_query), "order_vars")],
+      out2$lazy_query[setdiff(names(out2$lazy_query), "order_vars")]
+  )
 })
 
 # sql_render --------------------------------------------------------------


### PR DESCRIPTION
Fixes #1437

This will stop `arrange`d computed columns from being inlined away from subqueries. Of course the subquery `ORDER BY` warning will be thrown, but I think that is expected behavior.

Before:

``` r
library(dbplyr)
library(dplyr, warn.conflicts = FALSE)

db <- lazy_frame(x = 1, y = 2) 

db %>% 
  mutate(z = 1) %>% 
  arrange(x, z) %>%
  select(x)
#> <SQL>
#> SELECT `x`
#> FROM `df`
#> ORDER BY `x`, `z`
```

<sup>Created on 2024-02-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

After:

``` r
library(dbplyr)
library(dplyr, warn.conflicts = FALSE)

db <- lazy_frame(x = 1, y = 2) 

db %>% 
  mutate(z = 1) %>% 
  arrange(x, z) %>%
  select(x)
#> Warning: ORDER BY is ignored in subqueries without LIMIT
#> ℹ Do you need to move arrange() later in the pipeline or use window_order() instead?
#> <SQL>
#> SELECT `x`
#> FROM (
#>   SELECT `df`.*, 1.0 AS `z`
#>   FROM `df`
#> ) AS `q01`
```

<sup>Created on 2024-02-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>