### PR TITLE
add comments to date translation to clarify non-SQL origins (months(), days() on Postgres + Snowflake)

### DIFF
--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -215,7 +215,6 @@ sql_translation.PqConnection <- function(con) {
       hours = function(x) {
         postgres_period(x, "hours")
       },
-
       days = function(x) {
         # lubridate::days() (base::days() does not exist)
         postgres_period(x, "days")

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -215,13 +215,16 @@ sql_translation.PqConnection <- function(con) {
       hours = function(x) {
         postgres_period(x, "hours")
       },
+
       days = function(x) {
+        # lubridate::days() (base::days() does not exist)
         postgres_period(x, "days")
       },
       weeks = function(x) {
         postgres_period(x, "weeks")
       },
       months = function(x) {
+        # base::months() (or applicable methods from lubridate, e.g., months.numeric)
         postgres_period(x, "months")
       },
       years = function(x) {

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -100,7 +100,7 @@ sql_translation.Snowflake <- function(con) {
       str_squish = function(string) {
         sql_expr(regexp_replace(trim(!!string), "\\\\s+", " "))
       },
-      # date functions (e.g., functions covered by lubridate or ?base::weekdays)
+      # date functions (e.g., from lubridate or ?base::weekdays)
       # https://docs.snowflake.com/en/sql-reference/functions-date-time.html
       day = function(x) {
         sql_expr(EXTRACT(DAY %FROM% !!x))

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -100,9 +100,7 @@ sql_translation.Snowflake <- function(con) {
       str_squish = function(string) {
         sql_expr(regexp_replace(trim(!!string), "\\\\s+", " "))
       },
-
-
-      # lubridate functions
+      # date functions (e.g., functions covered by lubridate or ?base::weekdays)
       # https://docs.snowflake.com/en/sql-reference/functions-date-time.html
       day = function(x) {
         sql_expr(EXTRACT(DAY %FROM% !!x))
@@ -188,12 +186,14 @@ sql_translation.Snowflake <- function(con) {
         glue_sql2(sql_current_con(), "INTERVAL '{.val x} hour'")
       },
       days = function(x) {
+        # lubridate::days() (base::days() does not exist)
         glue_sql2(sql_current_con(), "INTERVAL '{.val x} day'")
       },
       weeks = function(x) {
         glue_sql2(sql_current_con(), "INTERVAL '{.val x} week'")
       },
       months = function(x) {
+        # base::months() (or applicable methods from lubridate, e.g., months.numeric)
         glue_sql2(sql_current_con(), "INTERVAL '{.val x} month'")
       },
       years = function(x) {


### PR DESCRIPTION
I found myself confused while trying to trace back date translations in `dbplyr` to their non-SQL origins, specifically `base` vs. `lubridate` functions:
* `months()` to `lubridate`, when the translations actually correspond to `base::months()`
* `days()` to `base` R (actually corresponds to `lubridate::days()`

I've proposed minor comments to hopefully prevent this confusion for future folks referencing these backend-specific translations for `days()` and `months()` (only available for Postgres and Snowflake - the latter was mirrored from the former).

cc: @fh-afrachioni 