### PR TITLE
Fix `across()` in combination with `summarise(.by)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dbplyr (development version)
 
+* `across(everything())` doesn't select grouping columns created via `.by` in
+  `summarise()` (@mgirlich, #1493).
+
 # dbplyr 2.5.0
 
 ## Improved tools for qualified table names

--- a/R/verb-summarise.R
+++ b/R/verb-summarise.R
@@ -35,7 +35,6 @@
 #'   show_query()
 summarise.tbl_lazy <- function(.data, ..., .by = NULL, .groups = NULL) {
   check_groups(.groups)
-  dots <- summarise_eval_dots(.data, ...)
 
   by <- compute_by(
     {{ .by }},
@@ -49,6 +48,8 @@ summarise.tbl_lazy <- function(.data, ..., .by = NULL, .groups = NULL) {
     .data$lazy_query$group_vars <- by$names
     .groups <- "drop"
   }
+
+  dots <- summarise_eval_dots(.data, ...)
   .data$lazy_query <- add_summarise(
     .data, dots,
     .groups = .groups,

--- a/tests/testthat/_snaps/tbl-sql.md
+++ b/tests/testthat/_snaps/tbl-sql.md
@@ -28,12 +28,8 @@
 # check_from is deprecated
 
     Code
-      tbl(con, "x", check_from = FALSE)
+      out <- tbl(con, "x", check_from = FALSE)
     Condition
       Warning:
       The `check_from` argument of `tbl_sql()` is deprecated as of dbplyr 2.5.0.
-    Output
-      # Source:   table<`x`> [0 x 1]
-      # Database: sqlite 3.45.0 [:memory:]
-      # i 1 variable: y <lgl>
 

--- a/tests/testthat/_snaps/verb-summarise.md
+++ b/tests/testthat/_snaps/verb-summarise.md
@@ -102,6 +102,16 @@
       FROM `df`
       GROUP BY `g`
 
+# across doesn't select columns from `.by` #1493
+
+    Code
+      out
+    Output
+      <SQL>
+      SELECT `g`, SUM(`..x`) AS `x`
+      FROM `df`
+      GROUP BY `g`
+
 # can't use `.by` with `.groups`
 
     Code

--- a/tests/testthat/test-tbl-sql.R
+++ b/tests/testthat/test-tbl-sql.R
@@ -65,7 +65,7 @@ test_that("check_from is deprecated", {
   con <- local_sqlite_connection()
   DBI::dbExecute(con, "CREATE TABLE x (y)")
 
-  expect_snapshot(tbl(con, "x", check_from = FALSE))
+  expect_snapshot(out <- tbl(con, "x", check_from = FALSE))
 })
 
 # n_groups ----------------------------------------------------------------

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -107,6 +107,19 @@ test_that("can group transiently using `.by`", {
   expect_equal(group_vars(out), character())
 })
 
+test_that("across doesn't select columns from `.by` #1493", {
+  lf <- lazy_frame(g = 1, x = 1)
+
+  out <- lf |>
+    summarise(
+      across(everything(), ~ sum(..x, na.rm = TRUE)),
+      .by = g
+    )
+
+  expect_snapshot(out)
+  expect_equal(sql_build(out)$select[1], "`g`")
+})
+
 test_that("can't use `.by` with `.groups`", {
   df <- lazy_frame(x = 1)
 

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -110,7 +110,7 @@ test_that("can group transiently using `.by`", {
 test_that("across doesn't select columns from `.by` #1493", {
   lf <- lazy_frame(g = 1, x = 1)
 
-  out <- lf |>
+  out <- lf %>%
     summarise(
       across(everything(), ~ sum(..x, na.rm = TRUE)),
       .by = g


### PR DESCRIPTION
Closes #1493.