### PR TITLE
date_count_between translations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 * `across(everything())` doesn't select grouping columns created via `.by` in
   `summarise()` (@mgirlich, #1493).
+
 *  New translations of clock function `date_count_between()` for SQL server, Redshift, Snowflake, Postgres, and Spark (@edward-burn, #1495).
+
 * Spark SQL backend now supports persisting tables with
   `compute(x, name = I("x.y.z"), temporary = FALSE)` (@zacdav-db, #1502).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `across(everything())` doesn't select grouping columns created via `.by` in
   `summarise()` (@mgirlich, #1493).
+*  New translations of clock function `date_count_between()` for SQL server, Redshift, Snowflake, Postgres, and Spark (@edward-burn, #1495).
 
 # dbplyr 2.5.0
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -376,7 +376,7 @@ simulate_mssql <- function(version = "15.0") {
 
         check_dots_empty()
         if (precision != "day") {
-          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+          cli_abort("{.arg precision} must be {.val day} on SQL backends.")
         }
         if (n != 1) {
           cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -379,7 +379,7 @@ simulate_mssql <- function(version = "15.0") {
           cli_abort("{.arg precision} must be {.val day} on SQL backends.")
         }
         if (n != 1) {
-          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+          cli_abort("{.arg n} must be {.val 1} on SQL backends.")
         }
 
         sql_expr(DATEDIFF(DAY, !!start, !!end))

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -372,6 +372,18 @@ simulate_mssql <- function(version = "15.0") {
       get_day = function(x) {
         sql_expr(DATEPART(DAY, !!x))
       },
+      date_count_between = function(start, end, precision, ..., n = 1L){
+
+        check_dots_empty()
+        if (precision != "day") {
+          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+        }
+        if (n != 1) {
+          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+        }
+
+        sql_expr(DATEDIFF(DAY, !!start, !!end))
+      },
 
       difftime = function(time1, time2, tz, units = "days") {
 

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -248,6 +248,18 @@ sql_translation.PqConnection <- function(con) {
       date_build = function(year, month = 1L, day = 1L, ..., invalid = NULL) {
         sql_expr(make_date(!!year, !!month, !!day))
       },
+      date_count_between = function(start, end, precision, ..., n = 1L){
+
+        check_dots_empty()
+        if (precision != "day") {
+          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+        }
+        if (n != 1) {
+          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+        }
+
+        sql_expr(!!end - !!start)
+      },
       get_year = function(x) {
         sql_expr(date_part('year', !!x))
       },

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -252,10 +252,10 @@ sql_translation.PqConnection <- function(con) {
 
         check_dots_empty()
         if (precision != "day") {
-          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+          cli_abort("{.arg precision} must be {.val day} on SQL backends.")
         }
         if (n != 1) {
-          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+          cli_abort("{.arg n} must be {.val 1} on SQL backends.")
         }
 
         sql_expr(!!end - !!start)

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -83,6 +83,18 @@ sql_translation.RedshiftConnection <- function(con) {
       get_day = function(x) {
         sql_expr(DATE_PART('day', !!x))
       },
+      date_count_between = function(start, end, precision, ..., n = 1L){
+
+        check_dots_empty()
+        if (precision != "day") {
+          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+        }
+        if (n != 1) {
+          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+        }
+
+        sql_expr(DATEDIFF(DAY, !!start, !!end))
+      },
 
       difftime = function(time1, time2, tz, units = "days") {
 

--- a/R/backend-redshift.R
+++ b/R/backend-redshift.R
@@ -87,10 +87,10 @@ sql_translation.RedshiftConnection <- function(con) {
 
         check_dots_empty()
         if (precision != "day") {
-          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+          cli_abort("{.arg precision} must be {.val day} on SQL backends.")
         }
         if (n != 1) {
-          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+          cli_abort("{.arg n} must be {.val 1} on SQL backends.")
         }
 
         sql_expr(DATEDIFF(DAY, !!start, !!end))

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -232,6 +232,18 @@ sql_translation.Snowflake <- function(con) {
       get_day = function(x) {
         sql_expr(DATE_PART(DAY, !!x))
       },
+      date_count_between = function(start, end, precision, ..., n = 1L){
+
+        check_dots_empty()
+        if (precision != "day") {
+          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+        }
+        if (n != 1) {
+          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+        }
+
+        sql_expr(DATEDIFF(DAY, !!start, !!end))
+      },
 
       difftime = function(time1, time2, tz, units = "days") {
 

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -236,10 +236,10 @@ sql_translation.Snowflake <- function(con) {
 
         check_dots_empty()
         if (precision != "day") {
-          cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+          cli_abort("{.arg precision} must be {.val day} on SQL backends.")
         }
         if (n != 1) {
-          cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+          cli_abort("{.arg n} must be {.val 1} on SQL backends.")
         }
 
         sql_expr(DATEDIFF(DAY, !!start, !!end))

--- a/R/backend-spark-sql.R
+++ b/R/backend-spark-sql.R
@@ -58,6 +58,18 @@ simulate_spark_sql <- function() simulate_dbi("Spark SQL")
        get_day = function(x) {
          sql_expr(date_part('DAY', !!x))
        },
+       date_count_between = function(start, end, precision, ..., n = 1L){
+
+         check_dots_empty()
+         if (precision != "day") {
+           cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+         }
+         if (n != 1) {
+           cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+         }
+
+         sql_expr(datediff(!!end, !!start))
+       },
 
        difftime = function(time1, time2, tz, units = "days") {
 

--- a/R/backend-spark-sql.R
+++ b/R/backend-spark-sql.R
@@ -62,10 +62,10 @@ simulate_spark_sql <- function() simulate_dbi("Spark SQL")
 
          check_dots_empty()
          if (precision != "day") {
-           cli::cli_abort('The only supported value for {.arg precision} on SQL backends is "day"')
+           cli_abort("{.arg precision} must be {.val day} on SQL backends.")
          }
          if (n != 1) {
-           cli::cli_abort('The only supported value for {.arg n} on SQL backends is "1"')
+           cli_abort("{.arg n} must be {.val 1} on SQL backends.")
          }
 
          sql_expr(datediff(!!end, !!start))

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -139,6 +139,10 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATEPART(YEAR, `date_column`)"))
   expect_equal(test_translate_sql(get_month(date_column)), sql("DATEPART(MONTH, `date_column`)"))
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATEPART(DAY, `date_column`)"))
+  expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
+               sql("DATEDIFF(DAY, `date_column_1`, `date_column_2`)"))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
 })
 
 test_that("difftime is translated correctly", {

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -98,6 +98,10 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART('year', `date_column`)"))
   expect_equal(test_translate_sql(get_month(date_column)), sql("DATE_PART('month', `date_column`)"))
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATE_PART('day', `date_column`)"))
+  expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
+               sql("`date_column_2` - `date_column_1`"))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
 })
 
 test_that("difftime is translated correctly", {

--- a/tests/testthat/test-backend-redshift.R
+++ b/tests/testthat/test-backend-redshift.R
@@ -68,6 +68,10 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART('year', `date_column`)"))
   expect_equal(test_translate_sql(get_month(date_column)), sql("DATE_PART('month', `date_column`)"))
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATE_PART('day', `date_column`)"))
+  expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
+               sql("DATEDIFF(DAY, `date_column_1`, `date_column_2`)"))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
 })
 
 test_that("difftime is translated correctly", {

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -112,6 +112,10 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART(YEAR, `date_column`)"))
   expect_equal(test_translate_sql(get_month(date_column)), sql("DATE_PART(MONTH, `date_column`)"))
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATE_PART(DAY, `date_column`)"))
+  expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
+               sql("DATEDIFF(DAY, `date_column_1`, `date_column_2`)"))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
 })
 
 test_that("difftime is translated correctly", {

--- a/tests/testthat/test-backend-spark-sql.R
+++ b/tests/testthat/test-backend-spark-sql.R
@@ -8,6 +8,10 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART('YEAR', `date_column`)"))
   expect_equal(test_translate_sql(get_month(date_column)), sql("DATE_PART('MONTH', `date_column`)"))
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATE_PART('DAY', `date_column`)"))
+  expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
+               sql("DATEDIFF(`date_column_2`, `date_column_1`)"))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
+  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
 })
 
 test_that("difftime is translated correctly", {


### PR DESCRIPTION
For #1495, adds translations for clock::date_count_between() for a number of backends along with tests and update of news.