### PR TITLE
Sql server count big

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `across(everything())` doesn't select grouping columns created via `.by` in
   `summarise()` (@mgirlich, #1493).
+*  Use `COUNT_BIG` instead of `COUNT` for SQL server so that `tally()` and
+  `count()` work regardless of size of the data (@edward-burn, #1498).
 
 # dbplyr 2.5.0
 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -416,7 +416,7 @@ simulate_mssql <- function(version = "15.0") {
   sql_variant(
     mssql_scalar,
     sql_translator(.parent = base_odbc_agg,
-      n          = function() sql("BIG_COUNT(*)"),
+      n          = function() sql("COUNT_BIG(*)"),
       sd            = sql_aggregate("STDEV", "sd"),
       var           = sql_aggregate("VAR", "var"),
       str_flatten = function(x, collapse = "") sql_expr(string_agg(!!x, !!collapse)),

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -416,7 +416,7 @@ simulate_mssql <- function(version = "15.0") {
   sql_variant(
     mssql_scalar,
     sql_translator(.parent = base_odbc_agg,
-      n          = function() sql("COUNT_BIG(*)"),
+      n           = function() sql("COUNT_BIG(*)"),
       sd            = sql_aggregate("STDEV", "sd"),
       var           = sql_aggregate("VAR", "var"),
       str_flatten = function(x, collapse = "") sql_expr(string_agg(!!x, !!collapse)),

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -416,6 +416,7 @@ simulate_mssql <- function(version = "15.0") {
   sql_variant(
     mssql_scalar,
     sql_translator(.parent = base_odbc_agg,
+      n          = function() sql("BIG_COUNT(*)"),
       sd            = sql_aggregate("STDEV", "sd"),
       var           = sql_aggregate("VAR", "var"),
       str_flatten = function(x, collapse = "") sql_expr(string_agg(!!x, !!collapse)),

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -453,6 +453,24 @@
       FROM `df`
       ORDER BY `y`
 
+# count_big
+
+    Code
+      dplyr::count(mf)
+    Output
+      <SQL>
+      SELECT COUNT_BIG(*) AS `n`
+      FROM `df`
+
+---
+
+    Code
+      dplyr::tally(mf)
+    Output
+      <SQL>
+      SELECT COUNT_BIG(*) AS `n`
+      FROM `df`
+
 # can copy_to() and compute() with temporary tables (#438)
 
     Code


### PR DESCRIPTION
Use COUNT_BIG instead of COUNT for sql server so as to avoid overflow error for very large tables