### PR TITLE
mutate() now supports the argument .keep = "transmute"

### DIFF
--- a/R/verb-mutate.R
+++ b/R/verb-mutate.R
@@ -24,7 +24,7 @@
 mutate.tbl_lazy <- function(.data,
                             ...,
                             .by = NULL,
-                            .keep = c("all", "used", "unused", "none"),
+                            .keep = c("all", "used", "unused", "none", "transmute"),
                             .before = NULL,
                             .after = NULL) {
   keep <- arg_match(.keep)
@@ -53,6 +53,7 @@ mutate.tbl_lazy <- function(.data,
 
   out <- mutate_relocate(
     out = out,
+    keep = keep,
     before = {{ .before }},
     after = {{ .after }},
     names_original = names_original
@@ -238,11 +239,11 @@ get_mutate_dot_cols <- function(quosures, all_vars) {
   )
 }
 
-mutate_relocate <- function(out, before, after, names_original) {
+mutate_relocate <- function(out, keep, before, after, names_original) {
   before <- enquo(before)
   after <- enquo(after)
 
-  if (quo_is_null(before) && quo_is_null(after)) {
+  if (keep == "transmute" || (quo_is_null(before) && quo_is_null(after))) {
     return(out)
   }
 
@@ -264,6 +265,9 @@ mutate_keep <- function(out, keep, used, names_new, names_groups) {
 
   if (keep == "all") {
     names_out <- names
+  } else if (keep == "transmute") {
+    names_groups <- setdiff(names_groups, names_new)
+    names_out <- c(names_groups, names_new)
   } else {
     names_keep <- switch(
       keep,

--- a/man/mutate.tbl_lazy.Rd
+++ b/man/mutate.tbl_lazy.Rd
@@ -8,7 +8,7 @@
   .data,
   ...,
   .by = NULL,
-  .keep = c("all", "used", "unused", "none"),
+  .keep = c("all", "used", "unused", "none", "transmute"),
   .before = NULL,
   .after = NULL
 )
@@ -38,6 +38,8 @@ columns. This is useful if you generate new columns, but no longer need
 the columns used to generate them.
 \item \code{"none"} doesn't retain any extra columns from \code{.data}. Only the grouping
 variables and columns created by \code{...} are kept.
+\item \code{"transmute"} equivalent to "none", but preserves the column order in the
+mutate.
 }}
 
 \item{.before, .after}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns


### PR DESCRIPTION
Hi @hadley and @DavisVaughan,

This merge request seeks to support the new .keep = "transmute" argument in the mutate, based on the dplyr pull request   https://github.com/tidyverse/dplyr/pull/7038

Below I leave an example comparing transmute with mutate(.keep = "transmute")

```
con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")

example <- tibble(
  group = c("a", "a", "b", "b"),
  old = c(1, 2, 3, 4)
)

example <- copy_to(con, example)

# transmute --------------------------------------------------------------------

example %>% transmute(
  group,
  new = old * 2,
  old
) %>% 
  show_query()

# <SQL>
SELECT `group`, `old` * 2.0 AS `new`, `old`
FROM `example`

# mutate(.keep = "transmute") --------------------------------------------------

example %>% mutate(
  .keep = "transmute",
  group,
  new = old * 2,
  old
) %>% 
  show_query()

# <SQL>
SELECT `group`, `old` * 2.0 AS `new`, `old`
FROM `example`

# group_by + transmute ---------------------------------------------------------

example %>% 
  group_by(group) %>% 
  transmute(
    new = sum(old,na.rm = TRUE),
    old
  ) %>% 
  ungroup() %>% 
  show_query()

# <SQL>
SELECT `group`, SUM(`old`) OVER (PARTITION BY `group`) AS `new`, `old`
FROM `example`

# group_by + mutate(.keep = "transmute") ---------------------------------------

example %>% 
  group_by(group) %>% 
  mutate(
    .keep = "transmute",
    new = sum(old,na.rm = TRUE),
    old
  ) %>% 
  ungroup() %>% 
  show_query()

# <SQL>
SELECT `group`, SUM(`old`) OVER (PARTITION BY `group`) AS `new`, `old`
FROM `example`

# mutate(.keep = "transmute", by = ...) ----------------------------------------

example %>%  
  mutate(
    .keep = "transmute",
    .by = "group",
    new = sum(old,na.rm = TRUE),
    old
  ) %>% 
  show_query()

# <SQL>
SELECT `group`, SUM(`old`) OVER (PARTITION BY `group`) AS `new`, `old`
FROM `example`
```

Regards,