### PR TITLE
Allowing `compute` to persist tables with Spark SQL backend

### DIFF
--- a/R/backend-spark-sql.R
+++ b/R/backend-spark-sql.R
@@ -126,12 +126,8 @@ simulate_spark_sql <- function() simulate_dbi("Spark SQL")
                                    analyze = TRUE,
                                    in_transaction = FALSE) {
 
-  if (temporary) {
-    sql <- sql_values_subquery(con, values, types = types, lvl = 1)
-    db_compute(con, table, sql, overwrite = overwrite)
-  } else {
-    NextMethod()
-  }
+  sql <- sql_values_subquery(con, values, types = types, lvl = 1)
+  db_compute(con, table, sql, overwrite = overwrite, temporary = temporary)
 }
 
 #' @export
@@ -146,14 +142,11 @@ simulate_spark_sql <- function() simulate_dbi("Spark SQL")
                                    analyze = TRUE,
                                    in_transaction = FALSE) {
 
-  if (!temporary) {
-    cli::cli_abort("Spark SQL only support temporary tables")
-  }
-
   sql <- glue_sql2(
     con,
     "CREATE ", if (overwrite) "OR REPLACE ",
-    "TEMPORARY VIEW {.tbl {table}} AS \n",
+    if (temporary) "TEMPORARY VIEW" else "TABLE",
+    " {.tbl {table}} AS \n",
     "{.from {sql}}"
   )
   DBI::dbExecute(con, sql)


### PR DESCRIPTION
Fix for https://github.com/tidyverse/dbplyr/issues/1502

Previously this example would fail, it now succeeds:
```r
# I have results I don't want to collect but I do want to persist
results <- tbl(con, I("samples.nyctaxi.trips")) %>%
  group_by(pickup_zip) %>%
  summarise(avg_trip_dist = mean(trip_distance)) %>%
  compute(
    name = I("zacdav.default.avg_trip_dist"),
    temporary = FALSE,
    overwrite = TRUE
  )
```