### PR TITLE
`NEWS.md` notes for #1502/#1514 - SparkSQL backend `compute` changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * `across(everything())` doesn't select grouping columns created via `.by` in
   `summarise()` (@mgirlich, #1493).
+  
+* Spark SQL backend now supports persisting tables with
+  `compute(x, name = I("x.y.z"), temporary = FALSE)` (@zacdav-db, #1502).
 
 # dbplyr 2.5.0
 

--- a/R/backend-spark-sql.R
+++ b/R/backend-spark-sql.R
@@ -126,12 +126,8 @@ simulate_spark_sql <- function() simulate_dbi("Spark SQL")
                                    analyze = TRUE,
                                    in_transaction = FALSE) {
 
-  if (temporary) {
-    sql <- sql_values_subquery(con, values, types = types, lvl = 1)
-    db_compute(con, table, sql, overwrite = overwrite)
-  } else {
-    NextMethod()
-  }
+  sql <- sql_values_subquery(con, values, types = types, lvl = 1)
+  db_compute(con, table, sql, overwrite = overwrite, temporary = temporary)
 }
 
 #' @export
@@ -146,14 +142,11 @@ simulate_spark_sql <- function() simulate_dbi("Spark SQL")
                                    analyze = TRUE,
                                    in_transaction = FALSE) {
 
-  if (!temporary) {
-    cli::cli_abort("Spark SQL only support temporary tables")
-  }
-
   sql <- glue_sql2(
     con,
     "CREATE ", if (overwrite) "OR REPLACE ",
-    "TEMPORARY VIEW {.tbl {table}} AS \n",
+    if (temporary) "TEMPORARY VIEW" else "TABLE",
+    " {.tbl {table}} AS \n",
     "{.from {sql}}"
   )
   DBI::dbExecute(con, sql)


### PR DESCRIPTION
Adding notes that were omitted as part of https://github.com/tidyverse/dbplyr/pull/1514
