### PR TITLE
Handle dot-prefixed names in custom translation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * Spark SQL backend now supports persisting tables with
   `compute(x, name = I("x.y.z"), temporary = FALSE)` (@zacdav-db, #1502).
 
+* Custom translations of functions starting with `.` work (@MichaelChirico, #1529).
+
 # dbplyr 2.5.0
 
 ## Improved tools for qualified table names

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -252,7 +252,7 @@ find_fun <- function(fun) {
 fun_name <- function(fun) {
   # `dtplyr` uses the same idea but needs different environments
   pkg_env <- env_parent(global_env())
-  known <- c(ls(base_agg), ls(base_scalar))
+  known <- c(ls_all(base_agg), ls_all(base_scalar))
 
   for (x in known) {
     if (!env_has(pkg_env, x, inherit = TRUE))

--- a/R/translate-sql-helpers.R
+++ b/R/translate-sql-helpers.R
@@ -64,7 +64,7 @@ sql_variant <- function(scalar = sql_translator(),
   check_environment(window)
 
   # Need to check that every function in aggregate also occurs in window
-  missing <- setdiff(ls(aggregate), ls(window))
+  missing <- setdiff(ls_all(aggregate), ls_all(window))
   if (length(missing) > 0) {
     warn(paste0(
       "Translator is missing window variants of the following aggregate functions:\n",
@@ -72,10 +72,10 @@ sql_variant <- function(scalar = sql_translator(),
     ))
   }
 
-  aggregate_fns <- ls(envir = aggregate)
+  aggregate_fns <- ls_all(envir = aggregate)
 
   # An ensure that every window function is flagged in aggregate context
-  missing <- setdiff(ls(window), ls(aggregate))
+  missing <- setdiff(ls_all(window), ls_all(aggregate))
   missing_funs <- lapply(missing, sql_aggregate_win)
   env_bind(aggregate, !!!set_names(missing_funs, missing))
 
@@ -90,7 +90,7 @@ is.sql_variant <- function(x) inherits(x, "sql_variant")
 #' @export
 print.sql_variant <- function(x, ...) {
   wrap_ls <- function(x, ...) {
-    vars <- sort(ls(envir = x))
+    vars <- sort(ls_all(envir = x))
     wrapped <- strwrap(paste0(vars, collapse = ", "), ...)
     if (identical(wrapped, "")) return()
     paste0(wrapped, "\n", collapse = "")
@@ -113,7 +113,7 @@ print.sql_variant <- function(x, ...) {
 
 #' @export
 names.sql_variant <- function(x) {
-  c(ls(envir = x$scalar), ls(envir = x$aggregate), ls(envir = x$window))
+  c(ls_all(envir = x$scalar), ls_all(envir = x$aggregate), ls_all(envir = x$window))
 }
 
 #' @export

--- a/R/translate-sql-window.R
+++ b/R/translate-sql-window.R
@@ -371,7 +371,7 @@ uses_window_fun <- function(x, con, lq) {
   check_list(x)
 
   calls <- unlist(lapply(x, all_calls))
-  win_f <- ls(envir = dbplyr_sql_translation(con)$window)
+  win_f <- ls_all(envir = dbplyr_sql_translation(con)$window)
   any(calls %in% win_f)
 }
 
@@ -398,7 +398,7 @@ is_aggregating <- function(x, non_group_cols, agg_f) {
 }
 
 common_window_funs <- function() {
-  ls(dbplyr_sql_translation(NULL)$window) # nocov
+  ls_all(dbplyr_sql_translation(NULL)$window) # nocov
 }
 
 #' @noRd

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,6 +3,8 @@ deparse_all <- function(x) {
   purrr::map_chr(x, expr_text, width = 500L)
 }
 
+ls_all <- function(...) ls(..., all.names = TRUE)
+
 #' Provides comma-separated string out of the parameters
 #' @export
 #' @keywords internal

--- a/R/verb-filter.R
+++ b/R/verb-filter.R
@@ -73,7 +73,7 @@ add_filter <- function(.data, dots) {
     }
   } else {
     # Do partial evaluation, then extract out window functions
-    where <- translate_window_where_all(dots, ls(dbplyr_sql_translation(con)$window))
+    where <- translate_window_where_all(dots, ls_all(dbplyr_sql_translation(con)$window))
 
     # Add extracted window expressions as columns
     mutated <- mutate(.data, !!!where$comp)


### PR DESCRIPTION
Closes #1529 

 * For the specific issue #1529, the key IINM is the `ls()` calls in the `names.sql_variant()` method.
 * I peppered `ls_all()` everywhere I could see it, without too careful a reading of whether it may not be appropriate in that case. I fear I don't have context to discriminate which should continue being plain `ls()`.

I could go for an assist on writing a regression test, I couldn't quite put all the pieces together. How do I link a custom translation to a simulated connection?

Also LMK if you want more tests covering the switch to `ls_all()` for the other cases.