### PR TITLE
transition `expect_error()` for snowflake backend

### DIFF
--- a/R/utils-check.R
+++ b/R/utils-check.R
@@ -144,7 +144,7 @@ check_unsupported_arg <- function(x,
 
     msg <- c(msg, i = allow_msg)
   }
-  cli_abort(msg, call = call)
+  cli_abort(msg, call = call, class = "unsupported_arg_error")
 }
 
 stop_unsupported_function <- function(f, ..., with = NULL, call = caller_env()) {

--- a/R/utils-check.R
+++ b/R/utils-check.R
@@ -144,7 +144,7 @@ check_unsupported_arg <- function(x,
 
     msg <- c(msg, i = allow_msg)
   }
-  cli_abort(msg, call = call, class = "unsupported_arg_error")
+  cli_abort(msg, call = call, class = "dbplyr_error_unsupported_arg")
 }
 
 stop_unsupported_function <- function(f, ..., with = NULL, call = caller_env()) {

--- a/tests/testthat/_snaps/backend-snowflake.md
+++ b/tests/testthat/_snaps/backend-snowflake.md
@@ -1,3 +1,28 @@
+# pasting translated correctly
+
+    Code
+      test_translate_sql(paste0(x, collapse = ""))
+    Condition
+      Error in `check_collapse()`:
+      ! `collapse` not supported in DB translation of `paste()`.
+      i Please use `str_flatten()` instead.
+
+# difftime is translated correctly
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, units = "auto"))
+    Condition
+      Error in `difftime()`:
+      ! The only supported value for `units` on SQL backends is "days"
+
+---
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+    Condition
+      Error in `difftime()`:
+      ! The `tz` argument is not supported for SQL backends.
+
 # pmin() and pmax() respect na.rm
 
     Code

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -55,7 +55,7 @@
       (expect_error(rows_insert(lf, lf, by = "x", conflict = "error", in_place = FALSE))
       )
     Output
-      <error/unsupported_arg_error>
+      <error/dbplyr_error_unsupported_arg>
       Error in `rows_insert()`:
       ! `conflict = "error"` isn't supported on database backends.
       i It must be "ignore" instead.

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -55,7 +55,7 @@
       (expect_error(rows_insert(lf, lf, by = "x", conflict = "error", in_place = FALSE))
       )
     Output
-      <error/rlang_error>
+      <error/unsupported_arg_error>
       Error in `rows_insert()`:
       ! `conflict = "error"` isn't supported on database backends.
       i It must be "ignore" instead.

--- a/tests/testthat/_snaps/translate-sql-conditional.md
+++ b/tests/testthat/_snaps/translate-sql-conditional.md
@@ -48,13 +48,13 @@
       (expect_error(test_translate_sql(case_when(x == 1L ~ "yes", .ptype = character())))
       )
     Output
-      <error/rlang_error>
+      <error/unsupported_arg_error>
       Error in `case_when()`:
       ! Argument `.ptype` isn't supported on database backends.
     Code
       (expect_error(test_translate_sql(case_when(x == 1L ~ "yes", .size = 1))))
     Output
-      <error/rlang_error>
+      <error/unsupported_arg_error>
       Error in `case_when()`:
       ! Argument `.size` isn't supported on database backends.
 
@@ -122,7 +122,7 @@
     Code
       (expect_error(test_translate_sql(case_match(x, 1 ~ 1, .ptype = integer()))))
     Output
-      <error/rlang_error>
+      <error/unsupported_arg_error>
       Error in `case_match()`:
       ! Argument `.ptype` isn't supported on database backends.
 

--- a/tests/testthat/_snaps/translate-sql-conditional.md
+++ b/tests/testthat/_snaps/translate-sql-conditional.md
@@ -48,13 +48,13 @@
       (expect_error(test_translate_sql(case_when(x == 1L ~ "yes", .ptype = character())))
       )
     Output
-      <error/unsupported_arg_error>
+      <error/dbplyr_error_unsupported_arg>
       Error in `case_when()`:
       ! Argument `.ptype` isn't supported on database backends.
     Code
       (expect_error(test_translate_sql(case_when(x == 1L ~ "yes", .size = 1))))
     Output
-      <error/unsupported_arg_error>
+      <error/dbplyr_error_unsupported_arg>
       Error in `case_when()`:
       ! Argument `.size` isn't supported on database backends.
 
@@ -122,7 +122,7 @@
     Code
       (expect_error(test_translate_sql(case_match(x, 1 ~ 1, .ptype = integer()))))
     Output
-      <error/unsupported_arg_error>
+      <error/dbplyr_error_unsupported_arg>
       Error in `case_match()`:
       ! Argument `.ptype` isn't supported on database backends.
 

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -169,7 +169,7 @@
     Code
       (expect_error(tidyr::pivot_wider(df, id_expand = TRUE)))
     Output
-      <error/unsupported_arg_error>
+      <error/dbplyr_error_unsupported_arg>
       Error in `tidyr::pivot_wider()`:
       ! `id_expand = TRUE` isn't supported on database backends.
       i It must be FALSE instead.

--- a/tests/testthat/_snaps/verb-pivot-wider.md
+++ b/tests/testthat/_snaps/verb-pivot-wider.md
@@ -169,7 +169,7 @@
     Code
       (expect_error(tidyr::pivot_wider(df, id_expand = TRUE)))
     Output
-      <error/rlang_error>
+      <error/unsupported_arg_error>
       Error in `tidyr::pivot_wider()`:
       ! `id_expand = TRUE` isn't supported on database backends.
       i It must be FALSE instead.

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -14,7 +14,7 @@ test_that("pasting translated correctly", {
   expect_equal(test_translate_sql(str_c(x, y)), sql("CONCAT_WS('', `x`, `y`)"))
   expect_equal(test_translate_sql(str_c(x, y, sep = "|")), sql("CONCAT_WS('|', `x`, `y`)"))
 
-  expect_error(test_translate_sql(paste0(x, collapse = "")), "`collapse` not supported")
+  expect_snapshot(error = TRUE, test_translate_sql(paste0(x, collapse = "")))
 
   expect_equal(test_translate_sql(str_flatten(x), window = TRUE), sql("LISTAGG(`x`, '') OVER ()"))
   expect_equal(test_translate_sql(str_flatten(x, collapse = "|"), window = TRUE), sql("LISTAGG(`x`, '|') OVER ()"))
@@ -87,7 +87,10 @@ test_that("custom lubridate functions translated correctly", {
   ))
   expect_equal(test_translate_sql(quarter(x)), sql("EXTRACT('quarter', `x`)"))
   expect_equal(test_translate_sql(quarter(x, with_year = TRUE)), sql("(EXTRACT('year', `x`) || '.' || EXTRACT('quarter', `x`))"))
-  expect_error(test_translate_sql(quarter(x, fiscal_start = 2)))
+  expect_error(
+    test_translate_sql(quarter(x, fiscal_start = 2)),
+    class = "unsupported_arg_error"
+  )
   expect_equal(test_translate_sql(isoyear(x)), sql("EXTRACT('year', `x`)"))
 
   expect_equal(test_translate_sql(seconds(x)), sql("INTERVAL '`x` second'"))
@@ -106,7 +109,10 @@ test_that("custom clock functions translated correctly", {
   local_con(simulate_snowflake())
   expect_equal(test_translate_sql(add_years(x, 1)), sql("DATEADD(YEAR, 1.0, `x`)"))
   expect_equal(test_translate_sql(add_days(x, 1)), sql("DATEADD(DAY, 1.0, `x`)"))
-  expect_error(test_translate_sql(add_days(x, 1, "dots", "must", "be empty")))
+  expect_error(
+    test_translate_sql(add_days(x, 1, "dots", "must", "be empty")),
+    class = "rlib_error_dots_nonempty"
+  )
   expect_equal(test_translate_sql(date_build(2020, 1, 1)), sql("DATE_FROM_PARTS(2020.0, 1.0, 1.0)"))
   expect_equal(test_translate_sql(date_build(year_column, 1L, 1L)), sql("DATE_FROM_PARTS(`year_column`, 1, 1)"))
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART(YEAR, `date_column`)"))
@@ -119,8 +125,14 @@ test_that("difftime is translated correctly", {
   expect_equal(test_translate_sql(difftime(start_date, end_date, units = "days")), sql("DATEDIFF(DAY, `end_date`, `start_date`)"))
   expect_equal(test_translate_sql(difftime(start_date, end_date)), sql("DATEDIFF(DAY, `end_date`, `start_date`)"))
 
-  expect_error(test_translate_sql(difftime(start_date, end_date, units = "auto")))
-  expect_error(test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days")))
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, units = "auto"))
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+  )
 })
 
 test_that("min() and max()", {

--- a/tests/testthat/test-backend-snowflake.R
+++ b/tests/testthat/test-backend-snowflake.R
@@ -89,7 +89,7 @@ test_that("custom lubridate functions translated correctly", {
   expect_equal(test_translate_sql(quarter(x, with_year = TRUE)), sql("(EXTRACT('year', `x`) || '.' || EXTRACT('quarter', `x`))"))
   expect_error(
     test_translate_sql(quarter(x, fiscal_start = 2)),
-    class = "unsupported_arg_error"
+    class = "dbplyr_error_unsupported_arg"
   )
   expect_equal(test_translate_sql(isoyear(x)), sql("EXTRACT('year', `x`)"))
 


### PR DESCRIPTION
Related to the first checkbox in #1546 but does not close; a demo of what that PR would look like for all backends.


For snowflake, transition `expect_error()`:

* ...to snapshot when testing the error message
* ...to classed error when testing an error from another package or an error thrown from a widely-used helper
* ...to `expect_no_error()` (or no test) when `regex = NA`
* Analogous story for `expect_warning()` and `expect_message()`.