### PR TITLE
audit calls to `expect_error()` for `backend-*.R` files

### DIFF
--- a/R/translate-sql-helpers.R
+++ b/R/translate-sql-helpers.R
@@ -273,7 +273,10 @@ sql_not_supported <- function(f) {
   check_string(f)
 
   function(...) {
-    cli_abort("{.fun {f}} is not available in this SQL variant.")
+    cli_abort(
+      "{.fun {f}} is not available in this SQL variant.",
+      class = "dbplyr_error_unsupported_fn"
+    )
   }
 }
 

--- a/tests/testthat/_snaps/backend-.md
+++ b/tests/testthat/_snaps/backend-.md
@@ -1,3 +1,11 @@
+# basic arithmetic is correct
+
+    Code
+      test_translate_sql(100L %/% 3L)
+    Condition
+      Error in `100L %/% 3L`:
+      ! `%/%()` is not available in this SQL variant.
+
 # can translate subsetting
 
     Code

--- a/tests/testthat/_snaps/backend-access.md
+++ b/tests/testthat/_snaps/backend-access.md
@@ -1,3 +1,12 @@
+# custom scalar translated correctly
+
+    Code
+      test_translate_sql(paste(x, collapse = "-"))
+    Condition
+      Error in `check_collapse()`:
+      ! `collapse` not supported in DB translation of `paste()`.
+      i Please use `str_flatten()` instead.
+
 # queries translate correctly
 
     Code

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -32,6 +32,47 @@
       ! `abbr = TRUE` isn't supported in SQL Server translation.
       i It must be FALSE instead.
 
+---
+
+    Code
+      test_translate_sql(quarter(x, fiscal_start = 5))
+    Condition
+      Error in `quarter()`:
+      ! `fiscal_start = 5` isn't supported in SQL Server translation.
+      i It must be 1 instead.
+
+# custom clock functions translated correctly
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "year"))
+    Condition
+      Error in `date_count_between()`:
+      ! `precision` must be "day" on SQL backends.
+
+---
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5))
+    Condition
+      Error in `date_count_between()`:
+      ! `n` must be "1" on SQL backends.
+
+# difftime is translated correctly
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, units = "auto"))
+    Condition
+      Error in `difftime()`:
+      ! The only supported value for `units` on SQL backends is "days"
+
+---
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+    Condition
+      Error in `difftime()`:
+      ! The `tz` argument is not supported for SQL backends.
+
 # convert between bit and boolean as needed
 
     Code

--- a/tests/testthat/_snaps/backend-oracle.md
+++ b/tests/testthat/_snaps/backend-oracle.md
@@ -137,3 +137,19 @@
         SELECT 1, '{1,2,3}' FROM DUAL
       ) `values_table`
 
+# difftime is translated correctly
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, units = "auto"))
+    Condition
+      Error in `difftime()`:
+      ! The only supported value for `units` on SQL backends is "days"
+
+---
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+    Condition
+      Error in `difftime()`:
+      ! The `tz` argument is not supported for SQL backends.
+

--- a/tests/testthat/_snaps/backend-postgres.md
+++ b/tests/testthat/_snaps/backend-postgres.md
@@ -1,18 +1,68 @@
+# pasting translated correctly
+
+    Code
+      test_translate_sql(paste0(x, collapse = ""), window = FALSE)
+    Condition
+      Error in `check_collapse()`:
+      ! `collapse` not supported in DB translation of `paste()`.
+      i Please use `str_flatten()` instead.
+
+# custom lubridate functions translated correctly
+
+    Code
+      test_translate_sql(quarter(x, fiscal_start = 2))
+    Condition
+      Error in `quarter()`:
+      ! `fiscal_start = 2` isn't supported in PostgreSQL translation.
+      i It must be 1 instead.
+
+# custom clock functions translated correctly
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "year"))
+    Condition
+      Error in `date_count_between()`:
+      ! `precision` must be "day" on SQL backends.
+
+---
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5))
+    Condition
+      Error in `date_count_between()`:
+      ! `n` must be "1" on SQL backends.
+
+# difftime is translated correctly
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, units = "auto"))
+    Condition
+      Error in `difftime()`:
+      ! The only supported value for `units` on SQL backends is "days"
+
+---
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+    Condition
+      Error in `difftime()`:
+      ! The `tz` argument is not supported for SQL backends.
+
 # custom window functions translated correctly
 
     Code
-      (expect_error(test_translate_sql(quantile(x, 0.3, na.rm = TRUE), window = TRUE))
-      )
-    Output
-      <error/rlang_error>
+      test_translate_sql(quantile(x, 0.3, na.rm = TRUE), window = TRUE)
+    Condition
       Error in `quantile()`:
       ! Translation of `quantile()` in `mutate()` is not supported for PostgreSQL.
       i Use a combination of `summarise()` and `left_join()` instead:
         `df %>% left_join(summarise(<col> = quantile(x, 0.3, na.rm = TRUE)))`.
+
+---
+
     Code
-      (expect_error(test_translate_sql(median(x, na.rm = TRUE), window = TRUE)))
-    Output
-      <error/rlang_error>
+      test_translate_sql(median(x, na.rm = TRUE), window = TRUE)
+    Condition
       Error in `median()`:
       ! Translation of `median()` in `mutate()` is not supported for PostgreSQL.
       i Use a combination of `summarise()` and `left_join()` instead:

--- a/tests/testthat/_snaps/backend-redshift.md
+++ b/tests/testthat/_snaps/backend-redshift.md
@@ -35,3 +35,35 @@
         SELECT 1, '{1,2,3}'
       ) AS `values_table`
 
+# custom clock functions translated correctly
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "year"))
+    Condition
+      Error in `date_count_between()`:
+      ! `precision` must be "day" on SQL backends.
+
+---
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5))
+    Condition
+      Error in `date_count_between()`:
+      ! `n` must be "1" on SQL backends.
+
+# difftime is translated correctly
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, units = "auto"))
+    Condition
+      Error in `difftime()`:
+      ! The only supported value for `units` on SQL backends is "days"
+
+---
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+    Condition
+      Error in `difftime()`:
+      ! The `tz` argument is not supported for SQL backends.
+

--- a/tests/testthat/_snaps/backend-spark-sql.md
+++ b/tests/testthat/_snaps/backend-spark-sql.md
@@ -1,0 +1,32 @@
+# custom clock functions translated correctly
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "year"))
+    Condition
+      Error in `date_count_between()`:
+      ! `precision` must be "day" on SQL backends.
+
+---
+
+    Code
+      test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5))
+    Condition
+      Error in `date_count_between()`:
+      ! `n` must be "1" on SQL backends.
+
+# difftime is translated correctly
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, units = "auto"))
+    Condition
+      Error in `difftime()`:
+      ! The only supported value for `units` on SQL backends is "days"
+
+---
+
+    Code
+      test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+    Condition
+      Error in `difftime()`:
+      ! The `tz` argument is not supported for SQL backends.
+

--- a/tests/testthat/_snaps/backend-sqlite.md
+++ b/tests/testthat/_snaps/backend-sqlite.md
@@ -1,20 +1,3 @@
-# custom aggregates translated
-
-    Code
-      (expect_error(test_translate_sql(quantile(x, 0.5, na.rm = TRUE), window = FALSE))
-      )
-    Output
-      <error/rlang_error>
-      Error in `quantile()`:
-      ! `quantile()` is not available in this SQL variant.
-    Code
-      (expect_error(test_translate_sql(quantile(x, 0.5, na.rm = TRUE), window = TRUE))
-      )
-    Output
-      <error/rlang_error>
-      Error in `quantile()`:
-      ! `quantile()` is not available in this SQL variant.
-
 # custom SQL translation
 
     Code

--- a/tests/testthat/_snaps/translate-sql-helpers.md
+++ b/tests/testthat/_snaps/translate-sql-helpers.md
@@ -1,3 +1,11 @@
+# warns informatively with unsupported function
+
+    Code
+      sql_not_supported("cor")()
+    Condition
+      Error:
+      ! `cor()` is not available in this SQL variant.
+
 # duplicates throw an error
 
     Code

--- a/tests/testthat/test-backend-.R
+++ b/tests/testthat/test-backend-.R
@@ -15,7 +15,7 @@ test_that("basic arithmetic is correct", {
   expect_equal(test_translate_sql(5 ^ 2), sql("POWER(5.0, 2.0)"))
   expect_equal(test_translate_sql(100L %% 3L), sql("100 % 3"))
 
-  expect_error(test_translate_sql(100L %/% 3L), "not available")
+  expect_snapshot(error = TRUE, test_translate_sql(100L %/% 3L))
 })
 
 test_that("small numbers aren't converted to 0", {

--- a/tests/testthat/test-backend-access.R
+++ b/tests/testthat/test-backend-access.R
@@ -34,7 +34,7 @@ test_that("custom scalar translated correctly", {
   # paste()
   expect_equal(test_translate_sql(paste(x, y, sep = "+")), sql("`x` & '+' & `y`"))
   expect_equal(test_translate_sql(paste0(x, y)), sql("`x` & `y`"))
-  expect_error(test_translate_sql(paste(x, collapse = "-")),"`collapse` not supported")
+  expect_snapshot(error = TRUE, test_translate_sql(paste(x, collapse = "-")))
   # Logic
   expect_equal(test_translate_sql(ifelse(x, "true", "false")), sql("IIF(`x`, 'true', 'false')"))
 })
@@ -45,9 +45,18 @@ test_that("custom aggregators translated correctly", {
   expect_equal(test_translate_sql(sd(x, na.rm = TRUE), window = FALSE),  sql("STDEV(`x`)"))
   expect_equal(test_translate_sql(var(x, na.rm = TRUE), window = FALSE), sql("VAR(`x`)"))
 
-  expect_error(test_translate_sql(cor(x), window = FALSE), "not available")
-  expect_error(test_translate_sql(cov(x), window = FALSE), "not available")
-  expect_error(test_translate_sql(n_distinct(x), window = FALSE), "not available")
+  expect_error(
+    test_translate_sql(cor(x), window = FALSE),
+    class = "dbplyr_error_unsupported_fn"
+  )
+  expect_error(
+    test_translate_sql(cov(x), window = FALSE),
+    class = "dbplyr_error_unsupported_fn"
+  )
+  expect_error(
+    test_translate_sql(n_distinct(x), window = FALSE),
+    class = "dbplyr_error_unsupported_fn"
+  )
 })
 
 test_that("custom escaping works as expected", {

--- a/tests/testthat/test-backend-oracle.R
+++ b/tests/testthat/test-backend-oracle.R
@@ -87,7 +87,10 @@ test_that("custom clock functions translated correctly", {
   local_con(simulate_oracle())
   expect_equal(test_translate_sql(add_years(x, 1)), sql("(`x` + NUMTODSINTERVAL(1.0 * 365.25, 'day'))"))
   expect_equal(test_translate_sql(add_days(x, 1)), sql("(`x` + NUMTODSINTERVAL(1.0, 'day'))"))
-  expect_error(test_translate_sql(add_days(x, 1, "dots", "must", "be empty")))
+  expect_error(
+    test_translate_sql(add_days(x, 1, "dots", "must", "be empty")),
+    class = "rlib_error_dots_nonempty"
+  )
 })
 
 test_that("difftime is translated correctly", {
@@ -95,6 +98,12 @@ test_that("difftime is translated correctly", {
   expect_equal(test_translate_sql(difftime(start_date, end_date, units = "days")), sql("CEIL(CAST(`end_date` AS DATE) - CAST(`start_date` AS DATE))"))
   expect_equal(test_translate_sql(difftime(start_date, end_date)), sql("CEIL(CAST(`end_date` AS DATE) - CAST(`start_date` AS DATE))"))
 
-  expect_error(test_translate_sql(difftime(start_date, end_date, units = "auto")))
-  expect_error(test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days")))
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, units = "auto"))
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+  )
 })

--- a/tests/testthat/test-backend-postgres.R
+++ b/tests/testthat/test-backend-postgres.R
@@ -52,7 +52,10 @@ test_that("pasting translated correctly", {
   expect_equal(test_translate_sql(paste(x, y), window = FALSE),  sql("CONCAT_WS(' ', `x`, `y`)"))
   expect_equal(test_translate_sql(paste0(x, y), window = FALSE), sql("CONCAT_WS('', `x`, `y`)"))
 
-  expect_error(test_translate_sql(paste0(x, collapse = ""), window = FALSE), "`collapse` not supported")
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(paste0(x, collapse = ""), window = FALSE)
+  )
 })
 
 test_that("postgres mimics two argument log", {
@@ -73,7 +76,7 @@ test_that("custom lubridate functions translated correctly", {
   expect_equal(test_translate_sql(isoweek(x)), sql("EXTRACT(WEEK FROM `x`)"))
   expect_equal(test_translate_sql(quarter(x)), sql("EXTRACT(QUARTER FROM `x`)"))
   expect_equal(test_translate_sql(quarter(x, with_year = TRUE)), sql("(EXTRACT(YEAR FROM `x`) || '.' || EXTRACT(QUARTER FROM `x`))"))
-  expect_error(test_translate_sql(quarter(x, fiscal_start = 2)))
+  expect_snapshot(error = TRUE, test_translate_sql(quarter(x, fiscal_start = 2)))
   expect_equal(test_translate_sql(isoyear(x)), sql("EXTRACT(YEAR FROM `x`)"))
 
   expect_equal(test_translate_sql(seconds(x)), sql("CAST('`x` seconds' AS INTERVAL)"))
@@ -92,7 +95,10 @@ test_that("custom clock functions translated correctly", {
   local_con(simulate_postgres())
   expect_equal(test_translate_sql(add_years(x, 1)), sql("(`x` + 1.0*INTERVAL'1 year')"))
   expect_equal(test_translate_sql(add_days(x, 1)), sql("(`x` + 1.0*INTERVAL'1 day')"))
-  expect_error(test_translate_sql(add_days(x, 1, "dots", "must", "be empty")))
+  expect_error(
+    test_translate_sql(add_days(x, 1, "dots", "must", "be empty")),
+    class = "rlib_error_dots_nonempty"
+  )
   expect_equal(test_translate_sql(date_build(2020, 1, 1)), sql("MAKE_DATE(2020.0, 1.0, 1.0)"))
   expect_equal(test_translate_sql(date_build(year_column, 1L, 1L)), sql("MAKE_DATE(`year_column`, 1, 1)"))
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART('year', `date_column`)"))
@@ -100,8 +106,14 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATE_PART('day', `date_column`)"))
   expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
                sql("`date_column_2` - `date_column_1`"))
-  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
-  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(date_count_between(date_column_1, date_column_2, "year"))
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5))
+  )
 })
 
 test_that("difftime is translated correctly", {
@@ -109,17 +121,27 @@ test_that("difftime is translated correctly", {
   expect_equal(test_translate_sql(difftime(start_date, end_date, units = "days")), sql("(CAST(`start_date` AS DATE) - CAST(`end_date` AS DATE))"))
   expect_equal(test_translate_sql(difftime(start_date, end_date)), sql("(CAST(`start_date` AS DATE) - CAST(`end_date` AS DATE))"))
 
-  expect_error(test_translate_sql(difftime(start_date, end_date, units = "auto")))
-  expect_error(test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days")))
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, units = "auto"))
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+  )
 })
 
 test_that("custom window functions translated correctly", {
   local_con(simulate_postgres())
 
-  expect_snapshot({
-    (expect_error(test_translate_sql(quantile(x, 0.3, na.rm = TRUE), window = TRUE)))
-    (expect_error(test_translate_sql(median(x, na.rm = TRUE), window = TRUE)))
-  })
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(quantile(x, 0.3, na.rm = TRUE), window = TRUE)
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(median(x, na.rm = TRUE), window = TRUE)
+  )
 })
 
 test_that("custom SQL translation", {
@@ -202,7 +224,7 @@ test_that("can overwrite temp tables", {
   src <- src_test("postgres")
   copy_to(src, mtcars, "mtcars", overwrite = TRUE)
   withr::defer(DBI::dbRemoveTable(src, "mtcars"))
-  expect_error(copy_to(src, mtcars, "mtcars", overwrite = TRUE), NA)
+  expect_no_error(copy_to(src, mtcars, "mtcars", overwrite = TRUE))
 })
 
 test_that("copy_inline works", {
@@ -241,7 +263,7 @@ test_that("can insert with returning", {
     )
   }, transform = snap_transform_dbi)
 
-  expect_error(
+  expect_no_error(
     rows_insert(
       x, y,
       by = c("a", "b"),
@@ -249,8 +271,7 @@ test_that("can insert with returning", {
       conflict = "ignore",
       returning = everything(),
       method = "where_not_exists"
-    ),
-    NA
+    )
   )
 
   x <- local_db_table(con, df_x, "df_x2", overwrite = TRUE)
@@ -372,15 +393,14 @@ test_that("can upsert with returning", {
   }, transform = snap_transform_dbi)
 
   # DBI method does not need a unique index
-  expect_error(
+  expect_no_error(
     rows_upsert(
       x, y,
       by = c("a", "b"),
       in_place = TRUE,
       returning = everything(),
       method = "cte_update"
-    ),
-    NA
+    )
   )
 
   x <- local_db_table(con, df_x, "df_x2")

--- a/tests/testthat/test-backend-spark-sql.R
+++ b/tests/testthat/test-backend-spark-sql.R
@@ -2,7 +2,10 @@ test_that("custom clock functions translated correctly", {
   local_con(simulate_spark_sql())
   expect_equal(test_translate_sql(add_years(x, 1)), sql("ADD_MONTHS(`x`, 1.0 * 12.0)"))
   expect_equal(test_translate_sql(add_days(x, 1)), sql("DATE_ADD(`x`, 1.0)"))
-  expect_error(test_translate_sql(add_days(x, 1, "dots", "must", "be empty")))
+  expect_error(
+    test_translate_sql(add_days(x, 1, "dots", "must", "be empty")),
+    class = "rlib_error_dots_nonempty"
+  )
   expect_equal(test_translate_sql(date_build(2020, 1, 1)), sql("MAKE_DATE(2020.0, 1.0, 1.0)"))
   expect_equal(test_translate_sql(date_build(year_column, 1L, 1L)), sql("MAKE_DATE(`year_column`, 1, 1)"))
   expect_equal(test_translate_sql(get_year(date_column)), sql("DATE_PART('YEAR', `date_column`)"))
@@ -10,8 +13,14 @@ test_that("custom clock functions translated correctly", {
   expect_equal(test_translate_sql(get_day(date_column)), sql("DATE_PART('DAY', `date_column`)"))
   expect_equal(test_translate_sql(date_count_between(date_column_1, date_column_2, "day")),
                sql("DATEDIFF(`date_column_2`, `date_column_1`)"))
-  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "year")))
-  expect_error(test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5)))
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(date_count_between(date_column_1, date_column_2, "year"))
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(date_count_between(date_column_1, date_column_2, "day", n = 5))
+  )
 })
 
 test_that("difftime is translated correctly", {
@@ -19,6 +28,12 @@ test_that("difftime is translated correctly", {
   expect_equal(test_translate_sql(difftime(start_date, end_date, units = "days")), sql("DATEDIFF(`end_date`, `start_date`)"))
   expect_equal(test_translate_sql(difftime(start_date, end_date)), sql("DATEDIFF(`end_date`, `start_date`)"))
 
-  expect_error(test_translate_sql(difftime(start_date, end_date, units = "auto")))
-  expect_error(test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days")))
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, units = "auto"))
+  )
+  expect_snapshot(
+    error = TRUE,
+    test_translate_sql(difftime(start_date, end_date, tz = "UTC", units = "days"))
+  )
 })

--- a/tests/testthat/test-backend-sqlite.R
+++ b/tests/testthat/test-backend-sqlite.R
@@ -37,6 +37,14 @@ test_that("custom aggregates translated", {
 
   expect_equal(test_translate_sql(median(x, na.rm = TRUE), window = FALSE), sql('MEDIAN(`x`)'))
   expect_equal(test_translate_sql(sd(x, na.rm = TRUE), window = FALSE), sql('STDEV(`x`)'))
+  expect_error(
+    test_translate_sql(quantile(x, 0.5, na.rm = TRUE), window = FALSE),
+    class = "dbplyr_error_unsupported_fn"
+  )
+  expect_error(
+    test_translate_sql(quantile(x, 0.5, na.rm = TRUE), window = TRUE),
+    class = "dbplyr_error_unsupported_fn"
+  )
 })
 
 test_that("custom SQL translation", {

--- a/tests/testthat/test-backend-sqlite.R
+++ b/tests/testthat/test-backend-sqlite.R
@@ -37,11 +37,6 @@ test_that("custom aggregates translated", {
 
   expect_equal(test_translate_sql(median(x, na.rm = TRUE), window = FALSE), sql('MEDIAN(`x`)'))
   expect_equal(test_translate_sql(sd(x, na.rm = TRUE), window = FALSE), sql('STDEV(`x`)'))
-
-  expect_snapshot({
-    (expect_error(test_translate_sql(quantile(x, 0.5, na.rm = TRUE), window = FALSE)))
-    (expect_error(test_translate_sql(quantile(x, 0.5, na.rm = TRUE), window = TRUE)))
-  })
 })
 
 test_that("custom SQL translation", {

--- a/tests/testthat/test-translate-sql-helpers.R
+++ b/tests/testthat/test-translate-sql-helpers.R
@@ -10,6 +10,10 @@ test_that("aggregation functions warn once if na.rm = FALSE", {
   expect_warning(sql_mean("x"), NA)
 })
 
+test_that("warns informatively with unsupported function", {
+  expect_snapshot(error = TRUE, sql_not_supported("cor")())
+})
+
 test_that("missing window functions create a warning", {
   local_con(simulate_dbi())
   sim_scalar <- sql_translator()


### PR DESCRIPTION
Closes #1552. Following the lead of #1547, audits calls to `expect_error()`.

Transition `expect_error()`:

* ...to snapshot when testing the error message
* ...to classed error when testing an error from another package or an error thrown from a widely-used helper
* ...to `expect_no_error()` when `regex = NA`
