### PR TITLE
don't call `all_calls()` and `all_names()` recursively

### DIFF
--- a/R/translate-sql.R
+++ b/R/translate-sql.R
@@ -255,8 +255,7 @@ all_calls <- function(x) {
   if (is_quosure(x)) return(all_calls(quo_get_expr(x)))
   if (!is.call(x)) return(NULL)
 
-  fname <- as.character(x[[1]])
-  unique(c(fname, unlist(lapply(x[-1], all_calls), use.names = FALSE)))
+  setdiff(all.names(x, unique = TRUE), all_names(x))
 }
 
 all_names <- function(x) {
@@ -264,7 +263,7 @@ all_names <- function(x) {
   if (is_quosure(x)) return(all_names(quo_get_expr(x)))
   if (!is.call(x)) return(NULL)
 
-  unique(unlist(lapply(x[-1], all_names), use.names = FALSE))
+  all.vars(x)
 }
 
 # character vector -> environment


### PR DESCRIPTION
Since `all_calls()` and `all_names()` are run recursively, they complain about longer expressions. This PR rewrites them with the base functions `all.names()` and `all.vars()` to avoid this problem

Before This PR

![Kapture 2025-02-10 at 10 46 11](https://github.com/user-attachments/assets/b1ec5892-7040-4771-a137-d505c93d3018)

With this PR

``` r
long <- rlang::parse_quo(paste(rep(letters, 50), collapse = " + "), env = globalenv())

dbplyr:::all_names(long)
#>  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s"
#> [20] "t" "u" "v" "w" "x" "y" "z"
dbplyr:::all_calls(long)
#> [1] "+"
```