### PR TITLE
ns-qualify methods in namespace top level

### DIFF
--- a/R/table-name.R
+++ b/R/table-name.R
@@ -21,7 +21,7 @@ table_path <- function(x) {
 }
 
 # So you can do SQL(table_path("foo"))
-setOldClass(c("dbplyr_table_path", "character"))
+methods::setOldClass(c("dbplyr_table_path", "character"))
 
 
 #' Table paths


### PR DESCRIPTION
Closes #1588

@IrshadUlHaq1 I really think this is a {pak} issue, many packages will encounter this issue since it's not something enforced anywhere else in R.

It's also something that's handled inconsistently even within {dbplyr}, which is evidence that tooling to prevent backsliding when fixing this issue is nonexistent:

https://github.com/tidyverse/dbplyr/blob/572693098d0098018b6bb2d1e88b650d2e1e1580/R/zzz.R#L6-L8