### PR TITLE
Infix `$` translation for nested values in Snowflake

### DIFF
--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -277,7 +277,13 @@ sql_translation.Snowflake <- function(con) {
         } else {
           glue_sql2(sql_current_con(), "GREATEST({.val dots*})")
         }
-      }
+      },
+      `$`   = function(x, name) {
+        if (is.sql(x)) {
+          glue_sql2(sql_current_con(), "{x}:{.col name}")
+        } else {
+          eval(bquote(`$`(x, .(substitute(name)))))
+        }
     ),
     sql_translator(
       .parent = base_agg,


### PR DESCRIPTION
Nested values in Snowflake are accessed via `:` rather than `.`.

https://docs.snowflake.com/en/user-guide/querying-semistructured#traversing-semi-structured-data