### PR TITLE
pmin and pmax on SQL server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dbplyr (development version)
 
+* Add support for `pmin()` and `pmax()` on SQL Server (@edward-burn, #1602). 
+
 * Fix for failing snapshot tests (@edward-burn, #1567). 
 
 * Tightened argument checks for SQL translations. These changes should 

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -291,10 +291,6 @@ simulate_mssql <- function(version = "15.0") {
       ceil          = sql_prefix("CEILING"),
       ceiling       = sql_prefix("CEILING"),
 
-      # https://dba.stackexchange.com/questions/187090
-      pmin          = sql_not_supported("pmin"),
-      pmax          = sql_not_supported("pmax"),
-
       is.null       = mssql_is_null,
       is.na         = mssql_is_null,
 


### PR DESCRIPTION
Remove not supported error. Closes #1602