### PR TITLE
sql_expr instead of translate_sql for snowflake

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # dbplyr (development version)
 
+* Fixed snowflake translations that were being reported as unknown (@edward-burn, #1570). 
 * Deprecated `win_rank_tdata()` has been removed.
 * `compute()`, `collect()`, and `collapse()` now have their own documentation pages.
 * dbplyr now uses the base pipe (#1626).

--- a/R/backend-snowflake.R
+++ b/R/backend-snowflake.R
@@ -46,9 +46,9 @@ sql_translation.Snowflake <- function(con) {
         # Snowflake needs backslashes escaped, so we must increase the level of escaping
         pattern <- gsub("\\", "\\\\", pattern, fixed = TRUE)
         if (negate) {
-          translate_sql(REGEXP_INSTR(!!string, !!pattern) == 0L, con = con)
+          sql_expr(REGEXP_INSTR(!!string, !!pattern) %=% 0L)
         } else {
-          translate_sql(REGEXP_INSTR(!!string, !!pattern) != 0L, con = con)
+          sql_expr(REGEXP_INSTR(!!string, !!pattern) != 0L)
         }
       },
       str_starts = function(string, pattern, negate = FALSE) {
@@ -58,9 +58,9 @@ sql_translation.Snowflake <- function(con) {
         # Snowflake needs backslashes escaped, so we must increase the level of escaping
         pattern <- gsub("\\", "\\\\", pattern, fixed = TRUE)
         if (negate) {
-          translate_sql(REGEXP_INSTR(!!string, !!pattern) != 1L, con = con)
+          sql_expr(REGEXP_INSTR(!!string, !!pattern) != 1L)
         } else {
-          translate_sql(REGEXP_INSTR(!!string, !!pattern) == 1L, con = con)
+          sql_expr(REGEXP_INSTR(!!string, !!pattern) %=% 1L)
         }
       },
       str_ends = function(string, pattern, negate = FALSE) {
@@ -70,16 +70,14 @@ sql_translation.Snowflake <- function(con) {
         # Snowflake needs backslashes escaped, so we must increase the level of escaping
         pattern <- gsub("\\", "\\\\", pattern, fixed = TRUE)
         if (negate) {
-          translate_sql(
+          sql_expr(
             REGEXP_INSTR(!!string, !!pattern, 1L, 1L, 1L) !=
-              LENGTH(!!string) + 1L,
-            con = con
+              (LENGTH(!!string) + 1L)
           )
         } else {
-          translate_sql(
-            REGEXP_INSTR(!!string, !!pattern, 1L, 1L, 1L) ==
-              LENGTH(!!string) + 1L,
-            con = con
+          sql_expr(
+            REGEXP_INSTR(!!string, !!pattern, 1L, 1L, 1L) %=%
+              (LENGTH(!!string) + 1L)
           )
         }
       },
@@ -387,9 +385,8 @@ snowflake_grepl <- function(
   }
   # Snowflake needs backslashes escaped, so we must increase the level of escaping
   pattern <- gsub("\\", "\\\\", pattern, fixed = TRUE)
-  translate_sql(
-    REGEXP_INSTR(!!x, !!pattern, 1L, 1L, 0L, !!regexp_parameters) != 0L,
-    con = con
+  sql_expr(
+    REGEXP_INSTR(!!x, !!pattern, 1L, 1L, 0L, !!regexp_parameters) != 0L
   )
 }
 


### PR DESCRIPTION
@Hadley I only saw this pattern in the backend specific translations for snowflake, so I think this closes #1570 