### PR TITLE
Don't qualify `*` in single-table SELECTs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `glue_sql2()` is now exported for building SQL strings with glue syntax and
   type markers. `build_sql()` is deprecated in favor of `glue_sql2()` (#1249).
+* `SELECT` statements that use a single table now use `*` rather than `TABLE.*` (#1485, #1577).
 * dbplyr 1e interfaces are now deprecated (#1197). Backend developers have had >2 years to update.
 * MySQL gains slightly better translation for `as.integer()` and `as.integer64()` (#1647).
 * Fixed snowflake translations that were being reported as unknown (@edward-burn, #1570). 

--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -199,7 +199,6 @@ sql_build.lazy_select_query <- function(op, con, ..., sql_options = NULL) {
     select = op$select,
     select_operation = op$select_operation,
     in_vars = op_vars(op$x),
-    table_alias = alias,
     con = con,
     use_star = sql_options$use_star
   )
@@ -227,7 +226,6 @@ get_select_sql <- function(
   select,
   select_operation,
   in_vars,
-  table_alias,
   con,
   use_star
 ) {
@@ -250,13 +248,13 @@ get_select_sql <- function(
 
   if (use_star && is_select_identity(select, in_vars)) {
     out <- list(
-      select_sql = sql_star(con, table_alias),
+      select_sql = sql_star(con),
       window_sql = character()
     )
     return(out)
   }
 
-  select <- select_use_star(select, in_vars, table_alias, con, use_star)
+  select <- select_use_star(select, in_vars, con, use_star)
 
   # translate once just to register windows
   win_register_activate()
@@ -284,7 +282,7 @@ get_select_sql <- function(
   )
 }
 
-select_use_star <- function(select, vars_prev, table_alias, con, use_star) {
+select_use_star <- function(select, vars_prev, con, use_star) {
   if (!use_star) {
     return(select)
   }
@@ -308,7 +306,7 @@ select_use_star <- function(select, vars_prev, table_alias, con, use_star) {
     idx_end <- seq2(last + 1, n)
     vctrs::vec_rbind(
       vctrs::vec_slice(select, idx_start),
-      tibble(name = "", expr = list(sql_star(con, table_alias))),
+      tibble(name = "", expr = list(sql_star(con))),
       vctrs::vec_slice(select, idx_end)
     )
   } else {

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -370,7 +370,11 @@ sql_table_prefix <- function(con, var, table = NULL) {
 }
 
 sql_star <- function(con, table = NULL) {
-  sql_qualify_var(con, table, SQL("*"))
+  if (is.null(table)) {
+    sql("*")
+  } else {
+    sql_qualify_var(con, table, SQL("*"))
+  }
 }
 
 sql_qualify_var <- function(con, table, var) {

--- a/tests/testthat/_snaps/backend-.md
+++ b/tests/testthat/_snaps/backend-.md
@@ -25,7 +25,7 @@
       filter(lazy_frame(x = 1, y = 1), x == y$id)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` = `y`.`id`)
 
@@ -35,7 +35,7 @@
       filter(lazy_frame(x = 1), x == y$id)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` = 1.0)
 
@@ -63,7 +63,7 @@
       filter(mf, x == a)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` = X'616263')
 
@@ -73,7 +73,7 @@
       filter(mf, x %in% L)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` IN (X'616263', X'0102'))
 
@@ -83,7 +83,7 @@
       qry
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` IN (X'616263', X'0102'))
 

--- a/tests/testthat/_snaps/backend-access.md
+++ b/tests/testthat/_snaps/backend-access.md
@@ -13,6 +13,6 @@
       head(mf)
     Output
       <SQL>
-      SELECT TOP 6 `df`.*
+      SELECT TOP 6 *
       FROM `df`
 

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -82,7 +82,7 @@
       filter(mf, is.na(x))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`x` IS NULL))
 
@@ -92,7 +92,7 @@
       filter(mf, !is.na(x))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (NOT((`x` IS NULL)))
 
@@ -102,7 +102,7 @@
       filter(mf, x == 1L || x == 2L)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` = 1 OR `x` = 2)
 
@@ -112,7 +112,7 @@
       mutate(mf, z = ifelse(x == 1L, 1L, 2L))
     Output
       <SQL>
-      SELECT `df`.*, IIF(`x` = 1, 1, 2) AS `z`
+      SELECT *, IIF(`x` = 1, 1, 2) AS `z`
       FROM `df`
 
 ---
@@ -121,7 +121,7 @@
       mutate(mf, z = case_when(x == 1L ~ 1L))
     Output
       <SQL>
-      SELECT `df`.*, CASE WHEN (`x` = 1) THEN 1 END AS `z`
+      SELECT *, CASE WHEN (`x` = 1) THEN 1 END AS `z`
       FROM `df`
 
 ---
@@ -130,7 +130,7 @@
       mutate(mf, z = !is.na(x))
     Output
       <SQL>
-      SELECT `df`.*, ~CAST(IIF((`x` IS NULL), 1, 0) AS BIT) AS `z`
+      SELECT *, ~CAST(IIF((`x` IS NULL), 1, 0) AS BIT) AS `z`
       FROM `df`
 
 ---
@@ -198,7 +198,7 @@
       filter(mf, x == a)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` = 0x616263)
 
@@ -208,7 +208,7 @@
       filter(mf, x %in% L)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` IN (0x616263, 0x0102))
 
@@ -218,7 +218,7 @@
       qry
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` IN (0x616263, 0x0102))
 
@@ -228,7 +228,7 @@
       filter(mf, x == TRUE)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` = 1)
 
@@ -275,7 +275,7 @@
       <SQL>
       SELECT `x`
       FROM (
-        SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY RAND(CHECKSUM(NEWID()))) AS `col01`
+        SELECT *, ROW_NUMBER() OVER (ORDER BY RAND(CHECKSUM(NEWID()))) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -428,7 +428,7 @@
       filter(mf, x)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (cast(`x` AS `BIT`) = 1)
 
@@ -438,7 +438,7 @@
       filter(mf, TRUE)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (cast(1 AS `BIT`) = 1)
 
@@ -448,7 +448,7 @@
       filter(mf, (!x) | FALSE)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((NOT(cast(`x` AS `BIT`) = 1)) OR cast(0 AS `BIT`) = 1)
 
@@ -460,7 +460,7 @@
       <SQL>
       SELECT `LHS`.`x` AS `x`
       FROM (
-        SELECT `df`.*
+        SELECT *
         FROM `df`
         WHERE (cast(`x` AS `BIT`) = 1)
       ) AS `LHS`
@@ -473,7 +473,7 @@
       mutate(mf, rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS `rown`
       FROM `df`
 
 ---
@@ -482,9 +482,7 @@
       mutate(group_by(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT
-        `df`.*,
-        ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY (SELECT NULL)) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY (SELECT NULL)) AS `rown`
       FROM `df`
 
 ---
@@ -493,7 +491,7 @@
       mutate(arrange(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
       FROM `df`
       ORDER BY `y`
 

--- a/tests/testthat/_snaps/backend-mysql.md
+++ b/tests/testthat/_snaps/backend-mysql.md
@@ -39,7 +39,7 @@
       <SQL>
       SELECT `x`
       FROM (
-        SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY RAND()) AS `col01`
+        SELECT *, ROW_NUMBER() OVER (ORDER BY RAND()) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -99,7 +99,7 @@
       explain(mutate(db, y = x + 1))
     Output
       <SQL>
-      SELECT `test`.*, `x` + 1.0 AS `y`
+      SELECT *, `x` + 1.0 AS `y`
       FROM `test`
       
       <PLAN>

--- a/tests/testthat/_snaps/backend-oracle.md
+++ b/tests/testthat/_snaps/backend-oracle.md
@@ -15,7 +15,7 @@
       head(mf)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       FETCH FIRST 6 ROWS ONLY
 
@@ -91,7 +91,7 @@
       <SQL>
       SELECT `x`
       FROM (
-        SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY DBMS_RANDOM.VALUE()) AS `col01`
+        SELECT *, ROW_NUMBER() OVER (ORDER BY DBMS_RANDOM.VALUE()) AS `col01`
         FROM `df`
       ) `q01`
       WHERE (`col01` <= 1)

--- a/tests/testthat/_snaps/backend-postgres.md
+++ b/tests/testthat/_snaps/backend-postgres.md
@@ -151,7 +151,7 @@
       explain(mutate(db, y = x + 1))
     Output
       <SQL>
-      SELECT "test".*, "x" + 1.0 AS "y"
+      SELECT *, "x" + 1.0 AS "y"
       FROM "test"
       
       <PLAN>

--- a/tests/testthat/_snaps/backend-snowflake.md
+++ b/tests/testthat/_snaps/backend-snowflake.md
@@ -27,7 +27,7 @@
       mutate(mf, rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS `rown`
       FROM `df`
 
 ---
@@ -36,9 +36,7 @@
       mutate(group_by(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT
-        `df`.*,
-        ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY (SELECT NULL)) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY (SELECT NULL)) AS `rown`
       FROM `df`
 
 ---
@@ -47,7 +45,7 @@
       mutate(arrange(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
       FROM `df`
       ORDER BY `y`
 

--- a/tests/testthat/_snaps/backend-sqlite.md
+++ b/tests/testthat/_snaps/backend-sqlite.md
@@ -30,7 +30,7 @@
       explain(filter(db, x > 2))
     Output
       <SQL>
-      SELECT `test`.*
+      SELECT *
       FROM `test`
       WHERE (`x` > 2.0)
       

--- a/tests/testthat/_snaps/backend-teradata.md
+++ b/tests/testthat/_snaps/backend-teradata.md
@@ -10,7 +10,7 @@
     Code
       sql_render(head(mf))
     Output
-      <SQL> SELECT TOP 6 `df`.*
+      <SQL> SELECT TOP 6 *
       FROM `df`
 
 # lead, lag work
@@ -18,7 +18,7 @@
     Code
       sql_render(mutate(group_by(mf, y), val2 = lead(x, order_by = x)))
     Output
-      <SQL> SELECT `df`.*, LEAD(`x`, 1, NULL) OVER (PARTITION BY `y` ORDER BY `x`) AS `val2`
+      <SQL> SELECT *, LEAD(`x`, 1, NULL) OVER (PARTITION BY `y` ORDER BY `x`) AS `val2`
       FROM `df`
 
 ---
@@ -26,7 +26,7 @@
     Code
       sql_render(mutate(group_by(mf, y), val2 = lag(x, order_by = x)))
     Output
-      <SQL> SELECT `df`.*, LAG(`x`, 1, NULL) OVER (PARTITION BY `y` ORDER BY `x`) AS `val2`
+      <SQL> SELECT *, LAG(`x`, 1, NULL) OVER (PARTITION BY `y` ORDER BY `x`) AS `val2`
       FROM `df`
 
 # weighted.mean
@@ -44,7 +44,7 @@
       mutate(mf, rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS `rown`
       FROM `df`
 
 ---
@@ -53,9 +53,7 @@
       mutate(group_by(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT
-        `df`.*,
-        ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY (SELECT NULL)) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY (SELECT NULL)) AS `rown`
       FROM `df`
 
 ---
@@ -64,7 +62,7 @@
       mutate(arrange(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
       FROM `df`
       ORDER BY `y`
 
@@ -76,7 +74,7 @@
       <SQL>
       SELECT TOP 6 `q01`.*
       FROM (
-        SELECT DISTINCT `df`.*
+        SELECT DISTINCT *
         FROM `df`
       ) AS `q01`
 

--- a/tests/testthat/_snaps/explain.md
+++ b/tests/testthat/_snaps/explain.md
@@ -4,7 +4,7 @@
       show_query(out)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE (`x` > 0.0)
 

--- a/tests/testthat/_snaps/query-select.md
+++ b/tests/testthat/_snaps/query-select.md
@@ -6,7 +6,7 @@
       <SQL SELECT>
       From:
         <table_path> `df`
-      Select:   `df`.*
+      Select:   *
       Where:    `x` > 1
       Order by: `x`
       Limit:    10

--- a/tests/testthat/_snaps/query-set-op.md
+++ b/tests/testthat/_snaps/query-set-op.md
@@ -6,7 +6,7 @@
         <SQL SELECT>
         From:
           <table_path> `lf1`
-        Select:   `lf1`.*, NULL
+        Select:   *, NULL
       
         UNION
       

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -407,7 +407,7 @@
       
       UNION ALL
       
-      SELECT `q01`.*, NULL AS `y`
+      SELECT *, NULL AS `y`
       FROM (
         SELECT `df_y`.*
         FROM `df_y`

--- a/tests/testthat/_snaps/tidyeval-across.md
+++ b/tests/testthat/_snaps/tidyeval-across.md
@@ -142,7 +142,7 @@
       filter(lf, if_all(a:b, ~ . > 0))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`a` > 0.0 AND `b` > 0.0))
 
@@ -152,7 +152,7 @@
       filter(lf, if_any(a:b, ~ . > 0))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`a` > 0.0 OR `b` > 0.0))
 
@@ -162,7 +162,7 @@
       mutate(lf, c = if_all(a:b, ~ . > 0))
     Output
       <SQL>
-      SELECT `df`.*, (`a` > 0.0 AND `b` > 0.0) AS `c`
+      SELECT *, (`a` > 0.0 AND `b` > 0.0) AS `c`
       FROM `df`
 
 ---
@@ -171,7 +171,7 @@
       mutate(lf, c = if_any(a:b, ~ . > 0))
     Output
       <SQL>
-      SELECT `df`.*, (`a` > 0.0 OR `b` > 0.0) AS `c`
+      SELECT *, (`a` > 0.0 OR `b` > 0.0) AS `c`
       FROM `df`
 
 # if_all/any uses every column as default
@@ -180,7 +180,7 @@
       filter(lf, if_all(.fns = ~ . > 0))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`a` > 0.0 AND `b` > 0.0))
 
@@ -190,7 +190,7 @@
       filter(lf, if_any(.fns = ~ . > 0))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`a` > 0.0 OR `b` > 0.0))
 
@@ -200,7 +200,7 @@
       filter(lf, if_all(a:b))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`a` AND `b`))
 
@@ -210,7 +210,7 @@
       filter(lf, if_any(a:b))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       WHERE ((`a` OR `b`))
 

--- a/tests/testthat/_snaps/translate-sql-window.md
+++ b/tests/testthat/_snaps/translate-sql-window.md
@@ -24,7 +24,7 @@
       mutate(mf, rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER () AS `rown`
+      SELECT *, ROW_NUMBER() OVER () AS `rown`
       FROM `df`
 
 ---
@@ -33,7 +33,7 @@
       mutate(group_by(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (PARTITION BY `y`) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY `y`) AS `rown`
       FROM `df`
 
 ---
@@ -42,7 +42,7 @@
       mutate(arrange(group_by(mf, y), y), rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY `y`) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY `y` ORDER BY `y`) AS `rown`
       FROM `df`
       ORDER BY `y`
 
@@ -52,7 +52,7 @@
       mutate(arrange(mf, y), rown = row_number())
     Output
       <SQL>
-      SELECT `df`.*, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
+      SELECT *, ROW_NUMBER() OVER (ORDER BY `y`) AS `rown`
       FROM `df`
       ORDER BY `y`
 
@@ -62,7 +62,7 @@
       show_query(mutate(window_order(window_frame(lf, -3, 0), x), z = sum(y, na.rm = TRUE)))
     Output
       <SQL>
-      SELECT `df`.*, SUM(`y`) OVER (ORDER BY `x` ROWS 3 PRECEDING) AS `z`
+      SELECT *, SUM(`y`) OVER (ORDER BY `x` ROWS 3 PRECEDING) AS `z`
       FROM `df`
 
 ---
@@ -72,7 +72,7 @@
     Output
       <SQL>
       SELECT
-        `df`.*,
+        *,
         SUM(`y`) OVER (ORDER BY `x` ROWS BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING) AS `z`
       FROM `df`
 

--- a/tests/testthat/_snaps/verb-arrange.md
+++ b/tests/testthat/_snaps/verb-arrange.md
@@ -3,7 +3,7 @@
     Code
       sql_render(out)
     Output
-      <SQL> SELECT `test-verb-arrange`.*
+      <SQL> SELECT *
       FROM `test-verb-arrange`
       ORDER BY `y`
 
@@ -16,7 +16,7 @@
       arrange(lf, a)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       ORDER BY `a`
     Code
@@ -24,7 +24,7 @@
       arrange(arrange(lf, a), b)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       ORDER BY `b`
     Code
@@ -47,7 +47,7 @@
       arrange(arrange(lf, a))
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
     Code
       arrange(select(arrange(lf, a), -a))
@@ -72,9 +72,9 @@
       arrange(head(lf, 1), a)
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
-        SELECT `df`.*
+        SELECT *
         FROM `df`
         LIMIT 1
       ) AS `q01`
@@ -83,7 +83,7 @@
       head(arrange(lf, a), 1)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
       ORDER BY `a`
       LIMIT 1
@@ -91,9 +91,9 @@
       arrange(head(arrange(lf, a), 1), b)
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
-        SELECT `df`.*
+        SELECT *
         FROM `df`
         ORDER BY `a`
         LIMIT 1
@@ -153,7 +153,7 @@
       <SQL>
       SELECT `LHS`.*, `c`
       FROM (
-        SELECT `df`.*
+        SELECT *
         FROM `df`
       ) AS `LHS`
       LEFT JOIN `df`
@@ -170,7 +170,7 @@
       <SQL>
       SELECT `LHS`.*
       FROM (
-        SELECT `df`.*
+        SELECT *
         FROM `df`
       ) AS `LHS`
       WHERE EXISTS (
@@ -181,7 +181,7 @@
       union(arrange(lf, a), rf)
     Output
       <SQL>
-      SELECT `df`.*, NULL AS `c`
+      SELECT *, NULL AS `c`
       FROM `df`
       ORDER BY `a`
       
@@ -196,7 +196,7 @@
       Joining with `by = join_by(a)`
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
         SELECT `df_LHS`.*, `c`
         FROM `df` AS `df_LHS`
@@ -210,7 +210,7 @@
       Joining with `by = join_by(a)`
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
         SELECT `df_LHS`.*
         FROM `df` AS `df_LHS`
@@ -224,9 +224,9 @@
       arrange(union(lf, rf), a)
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
-        SELECT `df`.*, NULL AS `c`
+        SELECT *, NULL AS `c`
         FROM `df`
       
         UNION

--- a/tests/testthat/_snaps/verb-count.md
+++ b/tests/testthat/_snaps/verb-count.md
@@ -35,7 +35,7 @@
       add_count(db, g, sort = TRUE)
     Output
       <SQL>
-      SELECT `df`.*, COUNT(*) OVER (PARTITION BY `g`) AS `n`
+      SELECT *, COUNT(*) OVER (PARTITION BY `g`) AS `n`
       FROM `df`
       ORDER BY `n` DESC
 
@@ -45,7 +45,7 @@
       add_count(group_by(db, g))
     Output
       <SQL>
-      SELECT `df`.*, COUNT(*) OVER (PARTITION BY `g`) AS `n`
+      SELECT *, COUNT(*) OVER (PARTITION BY `g`) AS `n`
       FROM `df`
 
 # .drop is not supported

--- a/tests/testthat/_snaps/verb-distinct.md
+++ b/tests/testthat/_snaps/verb-distinct.md
@@ -4,9 +4,9 @@
       (out <- distinct(head(lf, 2), x, y))
     Output
       <SQL>
-      SELECT DISTINCT `q01`.*
+      SELECT DISTINCT *
       FROM (
-        SELECT `df`.*
+        SELECT *
         FROM `df`
         LIMIT 2
       ) AS `q01`
@@ -19,9 +19,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT
-          `df`.*,
-          ROW_NUMBER() OVER (PARTITION BY `x` ORDER BY `y` DESC) AS `col01`
+        SELECT *, ROW_NUMBER() OVER (PARTITION BY `x` ORDER BY `y` DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` = 1)
@@ -34,7 +32,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, ROW_NUMBER() OVER (PARTITION BY `x` ORDER BY `x`) AS `col01`
+        SELECT *, ROW_NUMBER() OVER (PARTITION BY `x` ORDER BY `x`) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` = 1)

--- a/tests/testthat/_snaps/verb-expand.md
+++ b/tests/testthat/_snaps/verb-expand.md
@@ -20,7 +20,7 @@
       tidyr::expand(df_lazy, nesting(x, y))
     Output
       <SQL>
-      SELECT DISTINCT `df`.*
+      SELECT DISTINCT *
       FROM `df`
 
 # expand accepts expressions
@@ -47,7 +47,7 @@
       tidyr::expand(df_lazy, tidyr::nesting(x, y))
     Output
       <SQL>
-      SELECT DISTINCT `df`.*
+      SELECT DISTINCT *
       FROM `df`
 
 # expand respects groups
@@ -73,7 +73,7 @@
       tidyr::expand(lazy_frame(x = 1), x, y = NULL)
     Output
       <SQL>
-      SELECT DISTINCT `df`.*
+      SELECT DISTINCT *
       FROM `df`
 
 # expand() errors when expected

--- a/tests/testthat/_snaps/verb-fill.md
+++ b/tests/testthat/_snaps/verb-fill.md
@@ -10,7 +10,7 @@
         MAX(`n1`) OVER (PARTITION BY `..dbplyr_partition_1`) AS `n1`
       FROM (
         SELECT
-          `df`.*,
+          *,
           SUM(CASE WHEN ((`n1` IS NULL)) THEN 0 ELSE 1 END) OVER (ORDER BY `id` DESC ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partition_1`
         FROM `df`
       ) AS `q01`
@@ -75,7 +75,7 @@
         MAX(`n1`) OVER (PARTITION BY `..dbplyr_partition_1`) AS `n1`
       FROM (
         SELECT
-          `df`.*,
+          *,
           SUM(CASE WHEN ((`n1` IS NULL)) THEN 0 ELSE 1 END) OVER (ORDER BY `id` ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partition_1`
         FROM `df`
       ) AS `q01`
@@ -104,7 +104,7 @@
         MAX(`n1`) OVER (PARTITION BY `group`, `..dbplyr_partition_1`) AS `n1`
       FROM (
         SELECT
-          `df`.*,
+          *,
           SUM(CASE WHEN ((`n1` IS NULL)) THEN 0 ELSE 1 END) OVER (PARTITION BY `group` ORDER BY `id` ROWS UNBOUNDED PRECEDING) AS `..dbplyr_partition_1`
         FROM `df`
       ) AS `q01`

--- a/tests/testthat/_snaps/verb-filter.md
+++ b/tests/testthat/_snaps/verb-filter.md
@@ -3,7 +3,7 @@
     Code
       remote_query(lf1)
     Output
-      <SQL> SELECT `df`.*
+      <SQL> SELECT *
       FROM `df`
       WHERE (`x` > 3.0) AND (`y` < 3.0)
 
@@ -14,7 +14,7 @@
     Output
       <SQL> SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, AVG(`x`) OVER () AS `col01`
+        SELECT *, AVG(`x`) OVER () AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` > 3.0) AND (`y` < 3.0)
@@ -66,7 +66,7 @@
       <SQL>
       SELECT `x`
       FROM (
-        SELECT `df`.*, MAX(`x`) OVER () AS `col01`
+        SELECT *, MAX(`x`) OVER () AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`x` = `col01`) AND (`x` IN (1, 2))
@@ -131,9 +131,9 @@
       (out <- filter(lf, x_mean > 1))
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
-        SELECT `df`.*, AVG(`x`) OVER (PARTITION BY `g`, `h`) AS `x_mean`
+        SELECT *, AVG(`x`) OVER (PARTITION BY `g`, `h`) AS `x_mean`
         FROM `df`
       ) AS `q01`
       WHERE (`x_mean` > 1.0)
@@ -151,7 +151,7 @@
       SELECT `g`, `h`, `x_mean`
       FROM (
         SELECT
-          `q01`.*,
+          *,
           SUM(`x_mean`) OVER (PARTITION BY `g` ROWS UNBOUNDED PRECEDING) AS `col01`
         FROM (
           SELECT `g`, `h`, AVG(`x`) AS `x_mean`

--- a/tests/testthat/_snaps/verb-mutate.md
+++ b/tests/testthat/_snaps/verb-mutate.md
@@ -6,7 +6,7 @@
       <SQL>
       SELECT 0.0 AS `x`
       FROM (
-        SELECT DISTINCT `df`.*
+        SELECT DISTINCT *
         FROM `df`
       ) AS `q01`
 
@@ -16,7 +16,7 @@
       (expect_no_error(mutate(lf, r = row_number())))
     Output
       <SQL>
-      SELECT `q01`.*, ROW_NUMBER() OVER () AS `r`
+      SELECT *, ROW_NUMBER() OVER () AS `r`
       FROM (
         SELECT `g`
         FROM `df`
@@ -75,7 +75,7 @@
     Output
       <SQL> SELECT `x`, SQRT(`y`) AS `y`
       FROM (
-        SELECT `df`.*, 2.0 AS `y`
+        SELECT *, 2.0 AS `y`
         FROM `df`
       ) AS `q01`
 
@@ -99,9 +99,9 @@
     Code
       remote_query(lf)
     Output
-      <SQL> SELECT `q01`.*, `y` + 1.0 AS `z`
+      <SQL> SELECT *, `y` + 1.0 AS `z`
       FROM (
-        SELECT `df`.*, 2.0 AS `y`
+        SELECT *, 2.0 AS `y`
         FROM `df`
       ) AS `q01`
 
@@ -149,9 +149,9 @@
       mutate(lf, x1 = x + 1, x2 = x1 + 1)
     Output
       <SQL>
-      SELECT `q01`.*, `x1` + 1.0 AS `x2`
+      SELECT *, `x1` + 1.0 AS `x2`
       FROM (
-        SELECT `df`.*, `x` + 1.0 AS `x1`
+        SELECT *, `x` + 1.0 AS `x1`
         FROM `df`
       ) AS `q01`
 
@@ -189,7 +189,7 @@
     Code
       remote_query(lf)
     Output
-      <SQL> SELECT `df`.*, 3.0 AS `y`
+      <SQL> SELECT *, 3.0 AS `y`
       FROM `df`
 
 # temp var with nested arguments
@@ -199,7 +199,7 @@
     Output
       <SQL> SELECT `x`, `y` * 2.0 AS `z`
       FROM (
-        SELECT `df`.*, 2.0 AS `y`
+        SELECT *, 2.0 AS `y`
         FROM `df`
       ) AS `q01`
 

--- a/tests/testthat/_snaps/verb-pivot-longer.md
+++ b/tests/testthat/_snaps/verb-pivot-longer.md
@@ -47,7 +47,7 @@
       values_drop_na = TRUE)
     Output
       <SQL>
-      SELECT `q01`.*
+      SELECT *
       FROM (
         SELECT 'x' AS `name`, `x` AS `value`
         FROM `df`
@@ -65,7 +65,7 @@
       sql
     Output
       <SQL>
-      SELECT `q01`.*, NULL AS `y`
+      SELECT *, NULL AS `y`
       FROM (
         SELECT `id`, '1' AS `n`, `x_1` AS `x`
         FROM `df`

--- a/tests/testthat/_snaps/verb-select.md
+++ b/tests/testthat/_snaps/verb-select.md
@@ -6,7 +6,7 @@
       <SQL>
       SELECT `x`
       FROM (
-        SELECT DISTINCT `df`.*
+        SELECT DISTINCT *
         FROM `df`
       ) AS `q01`
 
@@ -193,7 +193,7 @@
       <SQL>
       SELECT `x`
       FROM (
-        SELECT `df`.*, 1.0 AS `z`
+        SELECT *, 1.0 AS `z`
         FROM `df`
       ) AS `q01`
 
@@ -203,7 +203,7 @@
       select(select(lf, 2:1), 2:1)
     Output
       <SQL>
-      SELECT `df`.*
+      SELECT *
       FROM `df`
 
 ---
@@ -253,7 +253,7 @@
         [34mFROM[39m `df`
       ),
       `q02` [34mAS[39m (
-        [34mSELECT[39m `q01`.*
+        [34mSELECT[39m *
         [34mFROM[39m `q01`
         [34mWHERE[39m (`z` = 1.0)
       )

--- a/tests/testthat/_snaps/verb-set-ops.md
+++ b/tests/testthat/_snaps/verb-set-ops.md
@@ -4,20 +4,20 @@
       union(union_all(lf1, lf2), lf3)
     Output
       <SQL>
-      SELECT `lf1`.*, NULL AS `z`
+      SELECT *, NULL AS `z`
       FROM `lf1`
       
       UNION ALL
       
-      SELECT `q01`.*, NULL AS `z`
+      SELECT *, NULL AS `z`
       FROM (
-        SELECT NULL AS `x`, `lf2`.*
+        SELECT NULL AS `x`, *
         FROM `lf2`
       ) AS `q01`
       
       UNION
       
-      SELECT NULL AS `x`, NULL AS `y`, `lf3`.*
+      SELECT NULL AS `x`, NULL AS `y`, *
       FROM `lf3`
 
 ---
@@ -28,19 +28,19 @@
     Output
       <SQL>
       WITH `q01` AS (
-        SELECT `lf1`.*, NULL AS `z`
+        SELECT *, NULL AS `z`
         FROM `lf1`
       ),
       `q02` AS (
-        SELECT NULL AS `x`, `lf2`.*
+        SELECT NULL AS `x`, *
         FROM `lf2`
       ),
       `q03` AS (
-        SELECT `q01`.*, NULL AS `z`
+        SELECT *, NULL AS `z`
         FROM `q02` AS `q01`
       ),
       `q04` AS (
-        SELECT NULL AS `x`, NULL AS `y`, `lf3`.*
+        SELECT NULL AS `x`, NULL AS `y`, *
         FROM `lf3`
       ),
       `q05` AS (

--- a/tests/testthat/_snaps/verb-slice.md
+++ b/tests/testthat/_snaps/verb-slice.md
@@ -74,7 +74,7 @@
       <SQL>
       SELECT `x`, `id`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x` DESC) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x` DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -84,7 +84,7 @@
       <SQL>
       SELECT `x`, `id`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x` DESC) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x` DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -94,7 +94,7 @@
       <SQL>
       SELECT `x`, `id`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x` * -1 DESC) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x` * -1 DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -189,7 +189,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x`) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x`) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -199,7 +199,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x`, `y`) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x`, `y`) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -209,7 +209,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `y`, `x`) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `y`, `x`) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -222,7 +222,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x` DESC) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x` DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -232,7 +232,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `x` DESC, `y` DESC) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `x` DESC, `y` DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)
@@ -242,7 +242,7 @@
       <SQL>
       SELECT `x`, `y`
       FROM (
-        SELECT `df`.*, RANK() OVER (ORDER BY `y` DESC, `x` DESC) AS `col01`
+        SELECT *, RANK() OVER (ORDER BY `y` DESC, `x` DESC) AS `col01`
         FROM `df`
       ) AS `q01`
       WHERE (`col01` <= 1)

--- a/tests/testthat/_snaps/verb-window.md
+++ b/tests/testthat/_snaps/verb-window.md
@@ -31,9 +31,7 @@
         x))
     Output
       <SQL>
-      SELECT
-        `q01`.*,
-        SUM(`x`) OVER (ORDER BY `y2` ROWS UNBOUNDED PRECEDING) AS `x_cum`
+      SELECT *, SUM(`x`) OVER (ORDER BY `y2` ROWS UNBOUNDED PRECEDING) AS `x_cum`
       FROM (
         SELECT `x`, `y` AS `y2`
         FROM `df`
@@ -43,9 +41,7 @@
         x))
     Output
       <SQL>
-      SELECT
-        `q01`.*,
-        SUM(`x`) OVER (ORDER BY `y2` ROWS UNBOUNDED PRECEDING) AS `x_cum`
+      SELECT *, SUM(`x`) OVER (ORDER BY `y2` ROWS UNBOUNDED PRECEDING) AS `x_cum`
       FROM (
         SELECT `x`, `y` AS `y2`
         FROM `df`

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -470,7 +470,7 @@ test_that("if_all/any is wrapped in parentheses #1153", {
 
   expect_equal(
     lf |> filter(if_any(c(a, b)) & c == 3) |> remote_query(),
-    sql("SELECT `df`.*\nFROM `df`\nWHERE ((`a` OR `b`) AND `c` = 3.0)")
+    sql("SELECT *\nFROM `df`\nWHERE ((`a` OR `b`) AND `c` = 3.0)")
   )
 })
 
@@ -514,11 +514,11 @@ test_that("if_any() and if_all() expansions deal with single inputs", {
   # Single inputs
   expect_equal(
     filter(d, if_any(x, ~FALSE)) |> remote_query(),
-    sql("SELECT `df`.*\nFROM `df`\nWHERE ((FALSE))")
+    sql("SELECT *\nFROM `df`\nWHERE ((FALSE))")
   )
   expect_equal(
     filter(d, if_all(x, ~FALSE)) |> remote_query(),
-    sql("SELECT `df`.*\nFROM `df`\nWHERE ((FALSE))")
+    sql("SELECT *\nFROM `df`\nWHERE ((FALSE))")
   )
 })
 
@@ -635,12 +635,12 @@ test_that("can `arrange()` with `pick()` selection", {
 
   expect_identical(
     arrange(df, pick(x, y)) |> remote_query(),
-    sql("SELECT `df`.*\nFROM `df`\nORDER BY `x`, `y`")
+    sql("SELECT *\nFROM `df`\nORDER BY `x`, `y`")
   )
 
   expect_identical(
     arrange(df, pick(x), y) |> remote_query(),
-    sql("SELECT `df`.*\nFROM `df`\nORDER BY `x`, `y`")
+    sql("SELECT *\nFROM `df`\nORDER BY `x`, `y`")
   )
 })
 

--- a/tests/testthat/test-translate-sql-window.R
+++ b/tests/testthat/test-translate-sql-window.R
@@ -279,7 +279,6 @@ test_that("names windows automatically", {
     select = lf1$lazy_query$select,
     select_operation = "mutate",
     in_vars = op_vars(lf),
-    table_alias = "df",
     con = simulate_sqlite(),
     use_star = TRUE
   )
@@ -314,7 +313,6 @@ test_that("names windows automatically", {
     select = lf2$lazy_query$select,
     select_operation = "mutate",
     in_vars = op_vars(lf),
-    table_alias = "df",
     con = simulate_sqlite(),
     use_star = TRUE
   )
@@ -357,7 +355,6 @@ test_that("only name windows if they appear multiple times", {
     select = lf$lazy_query$select,
     select_operation = "mutate",
     in_vars = op_vars(lf),
-    table_alias = "df",
     con = simulate_sqlite(),
     use_star = TRUE
   )
@@ -391,7 +388,6 @@ test_that("name windows only if supported", {
     select = lf$lazy_query$select,
     select_operation = "mutate",
     in_vars = op_vars(lf),
-    table_alias = "df",
     con = simulate_hana(),
     use_star = TRUE
   )

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -181,7 +181,7 @@ test_that("new columns take precedence over global variables", {
 test_that("constants do not need a new query", {
   expect_equal(
     lazy_frame(x = 1, y = 2) |> mutate(z = 2, z = 3) |> remote_query(),
-    sql("SELECT `df`.*, 3.0 AS `z`\nFROM `df`")
+    sql("SELECT *, 3.0 AS `z`\nFROM `df`")
   )
 })
 
@@ -443,17 +443,17 @@ test_that("mutate() uses star", {
 
   expect_equal(
     lf |> mutate(z = 1L) |> remote_query(),
-    sql("SELECT `df`.*, 1 AS `z`\nFROM `df`")
+    sql("SELECT *, 1 AS `z`\nFROM `df`")
   )
 
   expect_equal(
     lf |> mutate(a = 1L, .before = 1) |> remote_query(),
-    sql("SELECT 1 AS `a`, `df`.*\nFROM `df`")
+    sql("SELECT 1 AS `a`, *\nFROM `df`")
   )
 
   expect_equal(
     lf |> transmute(a = 1L, x, y, z = 2L) |> remote_query(),
-    sql("SELECT 1 AS `a`, `df`.*, 2 AS `z`\nFROM `df`")
+    sql("SELECT 1 AS `a`, *, 2 AS `z`\nFROM `df`")
   )
 
   # does not use * if `use_star = FALSE`
@@ -472,7 +472,7 @@ test_that("mutate generates simple expressions", {
     mutate(y = x + 1L) |>
     sql_build()
 
-  expect_equal(out$select, sql('`df`.*', y = '`x` + 1'))
+  expect_equal(out$select, sql('*', y = '`x` + 1'))
 })
 
 test_that("mutate can drop variables with NULL", {
@@ -492,7 +492,7 @@ test_that("var = NULL works when var is in original data", {
 
 test_that("var = NULL when var is in final output", {
   lf <- lazy_frame(x = 1) |> mutate(y = NULL, y = 3)
-  expect_equal(sql_build(lf)$select, sql("`df`.*", y = "3.0"))
+  expect_equal(sql_build(lf)$select, sql("*", y = "3.0"))
   expect_equal(op_vars(lf), c("x", "y"))
   expect_snapshot(remote_query(lf))
 })
@@ -514,7 +514,7 @@ test_that("mutate_all generates correct sql", {
   out <- lazy_frame(x = 1) |>
     dplyr::mutate_all(list(one = ~ . + 1L, two = ~ . + 2L)) |>
     sql_build()
-  expect_equal(out$select, sql('`df`.*', one = '`x` + 1', two = '`x` + 2'))
+  expect_equal(out$select, sql('*', one = '`x` + 1', two = '`x` + 2'))
 })
 
 test_that("mutate_all scopes nested quosures correctly", {

--- a/tests/testthat/test-verb-set-ops.R
+++ b/tests/testthat/test-verb-set-ops.R
@@ -67,7 +67,7 @@ test_that("can combine multiple union in one query", {
     union(lf3)
 
   out <- lf_union |> mutate(a = x + y) |> sql_build()
-  expect_equal(out$select, sql("`q01`.*", a = "`x` + `y`"))
+  expect_equal(out$select, sql("*", a = "`x` + `y`"))
 })
 
 test_that("intersect and setdiff work for supported backends", {


### PR DESCRIPTION
This seems like it should be safe, since there's no ambiguity when there's only a single table, and that's what `lazy_select_query` represents.

Fixes #1577. Fixes #1485. Fixes #1482.

@mgirlich do you have time to review a few dbplyr PRs? 