### PR TITLE
Simplify `if_else()` translation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # dbplyr (development version)
 
+* `if_else()` uses simpler translation for `missing` (#1573).
 * New translations for stringr function `str_ilike()` for Postgres, Redshift, and Snowflake (@edward-burn, #1628).
 * Argument `ignore_case` for `str_like()` has been deprecated (@edward-burn, #1630).
 * Corrected error message for `quantile()` and `median()` in `mutate()` on Redshift (@edward-burn, #1571).

--- a/R/translate-sql-conditional.R
+++ b/R/translate-sql-conditional.R
@@ -108,24 +108,16 @@ sql_if <- function(cond, if_true, if_false = quo(NULL), missing = quo(NULL)) {
   # CASE
   #   WHEN <cond> THEN `if_true`
   #   WHEN NOT <cond> THEN `if_false`
-  #   WHEN <cond> IS NULL THEN `missing`
+  #   ELSE `missing`
   # END
-  #
-  # Together these cases cover every possible case. So, if `if_false` and
-  # `missing` are identical they can be simplified to `ELSE <if_false>`
-  if (!quo_is_null(if_false) && identical(if_false, missing)) {
-    out <- glue_sql2(con, out, " ELSE {.val enpared_if_false} END")
-    return(out)
-  }
 
-  if (!quo_is_null(if_false)) {
+  if (!quo_is_null(if_false) && !identical(if_false, missing)) {
     false_sql <- " WHEN NOT {.val enpared_cond} THEN {.val enpared_if_false}"
     out <- paste0(out, false_sql)
   }
 
   if (!quo_is_null(missing)) {
-    missing_cond <- translate_sql(is.na(!!cond), con = con)
-    missing_sql <- " WHEN {.val missing_cond} THEN {.val enpared_missing}"
+    missing_sql <- " ELSE {.val enpared_missing}"
     out <- paste0(out, missing_sql)
   }
 

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -29,7 +29,7 @@ test_that("custom scalar translated correctly", {
   expect_equal(
     test_translate_sql(if_else(x, "true", "false", "missing")),
     sql(
-      "CASE WHEN `x` THEN 'true' WHEN NOT `x` THEN 'false' WHEN (`x` IS NULL) THEN 'missing' END"
+      "CASE WHEN `x` THEN 'true' WHEN NOT `x` THEN 'false' ELSE 'missing' END"
     )
   )
   expect_equal(


### PR DESCRIPTION
Now uses `THEN` for `missing` values

Fixes #1573