### PR TITLE
Revert SQL server if translation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # dbplyr (development version)
 
+* SQL Server: `if`/`ifelse()`, and `if_else()` now use `CASE WHEN` instead of `IIF`. This ensures the handling of `NULL`s matches the R's `NA` handling rules (#1569). 
 * `if_else()` uses simpler translation for `missing` (#1573).
 * New translations for stringr function `str_ilike()` for Postgres, Redshift, and Snowflake (@edward-burn, #1628).
 * Argument `ignore_case` for `str_like()` has been deprecated (@edward-burn, #1630).

--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -641,19 +641,13 @@ mssql_infix_boolean <- function(if_bit, if_bool) {
   }
 }
 
-mssql_sql_if <- function(cond, if_true, if_false = NULL, missing = NULL) {
-  cond_sql <- with_mssql_bool(eval_tidy(cond))
-  if (is_null(missing) || quo_is_null(missing)) {
-    if_true_sql <- escape(eval_tidy(if_true), con = sql_current_con())
-    if (is_null(if_false) || quo_is_null(if_false)) {
-      if_false_sql <- NULL
-    } else {
-      if_false_sql <- escape(eval_tidy(if_false), con = sql_current_con())
-    }
-    sql_expr(IIF(!!cond_sql, !!if_true_sql, !!if_false_sql))
-  } else {
-    sql_if(cond, if_true, if_false, missing)
-  }
+mssql_sql_if <- function(
+  cond,
+  if_true,
+  if_false = quo(NULL),
+  missing = quo(NULL)
+) {
+  with_mssql_bool(sql_if(cond, if_true, if_false, missing))
 }
 
 mssql_case_when <- function(...) {

--- a/tests/testthat/_snaps/backend-mssql.md
+++ b/tests/testthat/_snaps/backend-mssql.md
@@ -113,7 +113,7 @@
       mutate(mf, z = ifelse(x == 1L, 1L, 2L))
     Output
       <SQL>
-      SELECT `df`.*, IIF(`x` = 1, 1, 2) AS `z`
+      SELECT `df`.*, CASE WHEN (`x` = 1) THEN 1 WHEN NOT (`x` = 1) THEN 2 END AS `z`
       FROM `df`
 
 ---

--- a/tests/testthat/test-backend-mssql.R
+++ b/tests/testthat/test-backend-mssql.R
@@ -25,22 +25,6 @@ test_that("custom scalar translated correctly", {
   expect_translation(con, substr(x, 1, 2), "SUBSTRING(`x`, 1, 2)")
   expect_translation(con, trimws(x), "LTRIM(RTRIM(`x`))")
   expect_translation(con, paste(x, y), "`x` + ' ' + `y`")
-  expect_translation(
-    con,
-    if_else(x, "true", "false", "missing"),
-    "CASE WHEN `x` THEN 'true' WHEN NOT `x` THEN 'false' ELSE 'missing' END"
-  )
-  expect_translation(
-    con,
-    ifelse(x, "true", "false"),
-    "IIF(`x`, 'true', 'false')"
-  )
-  expect_translation(con, ifelse(x, "true", NULL), "IIF(`x`, 'true', NULL)")
-  expect_translation(
-    con,
-    if (x) "true" else "false",
-    "IIF(`x`, 'true', 'false')"
-  )
 
   expect_error(
     translate_sql(bitwShiftL(x, 2L), con = con),


### PR DESCRIPTION
Since `IIF(NULL, 1, 2)` returns `2`, but `ifelse(NA, 1, 2)` returns `NA`.

Fixes #1569.