### PR TITLE
Drop `base_symbols`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dbplyr (development version)
 
 * Redshift: fixed syntax error in `date_build()` translation (#1512).
+* dbplyr now longer attempts to translate `pi` to `PI()`. This caused problems if you had a column called `pi` (#1531).
 * Ensure `str_like()` and `str_ilike()` have consistent behaviour on SQL Server (@edward-burn, #1669).
 * SQL Server: `if`/`ifelse()`, and `if_else()` now use `CASE WHEN` instead of `IIF`. This ensures the handling of `NULL`s matches the R's `NA` handling rules (#1569). 
 * `if_else()` uses simpler translation for `missing` (#1573).

--- a/R/backend-.R
+++ b/R/backend-.R
@@ -360,11 +360,6 @@ base_scalar <- sql_translator(
   str_wrap = sql_not_supported("str_wrap")
 )
 
-base_symbols <- sql_translator(
-  pi = sql("PI()"),
-  `*` = sql("*"),
-  `NULL` = sql("NULL")
-)
 sql_exp <- function(a, x) {
   a <- as.integer(a)
   if (identical(a, 1L)) {

--- a/R/translate-sql.R
+++ b/R/translate-sql.R
@@ -195,10 +195,7 @@ sql_data_mask <- function(
   idents <- lapply(names, ident)
   name_env <- ceply(idents, escape, con = con, parent = special_calls2)
 
-  # Known sql expressions
-  symbol_env <- env_clone(base_symbols, parent = name_env)
-
-  new_data_mask(symbol_env, top_env)
+  new_data_mask(name_env, top_env)
 }
 
 is_infix_base <- function(x) {


### PR DESCRIPTION
* `NULL` doesn't do anything
* `*` errors with "cannot translate a primitive function to SQL"
* `pi` mismatches to columns in `select()`, and in `mutate()` it's already inlined

Fixes #1531

Before:

``` r
library(dbplyr)
library(dplyr, warn.conflicts = FALSE)

lf <- lazy_frame(x = 1, y = 2, pi = 2)
# Incorrect uses function
lf |> select(pi) |> show_query()
#> <SQL>
#> SELECT PI() AS `pi`
#> FROM `df`
# Already inlines pi
lf |> select(x) |> mutate(y = pi) |> show_query()
#> <SQL>
#> SELECT `x`, 3.14159265358979 AS `y`
#> FROM `df`
# Errors
lf |> mutate(y = count(`*`)) |> show_query()
#> Error:
#> ! Cannot translate a primitive function to SQL.
#> ℹ Do you want to force evaluation in R with (e.g.) `!!x` or `local(x)`?
# Already works
lf |> mutate(y = f(1, NULL)) |> show_query()
#> <SQL>
#> SELECT `x`, f(1.0, NULL) AS `y`, PI() AS `pi`
#> FROM `df`
```

<sup>Created on 2025-12-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

After

``` r
library(dbplyr)
library(dplyr, warn.conflicts = FALSE)

lf <- lazy_frame(x = 1, y = 2, pi = 2)
# Incorrect uses function
lf |> select(pi) |> show_query()
#> <SQL>
#> SELECT `pi`
#> FROM `df`
# Already inlines pi
lf |> select(x) |> mutate(y = pi) |> show_query()
#> <SQL>
#> SELECT `x`, 3.14159265358979 AS `y`
#> FROM `df`
# Errors
lf |> mutate(y = count(`*`)) |> show_query()
#> Error:
#> ! Cannot translate a primitive function to SQL.
#> ℹ Do you want to force evaluation in R with (e.g.) `!!x` or `local(x)`?
# Already works
lf |> mutate(y = f(1, NULL)) |> show_query()
#> <SQL>
#> SELECT `x`, f(1.0, NULL) AS `y`, `pi`
#> FROM `df`
```

<sup>Created on 2025-12-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>