### PR TITLE
`sql_join_tbls()` refactoring

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,9 @@
 
 S3method("$",tbl_lazy)
 S3method("[",dbplyr_table_path)
+S3method("[",sql)
 S3method("[[",dbplyr_table_path)
+S3method("[[",sql)
 S3method(add_count,tbl_lazy)
 S3method(anti_join,tbl_lazy)
 S3method(arrange,tbl_lazy)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -990,13 +990,7 @@ sql_query_upsert.DBIConnection <- function(
   updated_sql <- sql_format_clauses(updated_cte, lvl = 1, con)
   update_name <- sql(escape(ident("updated"), con = con))
 
-  join_by <- list(
-    x = by,
-    y = by,
-    x_as = "updated",
-    y_as = "...y",
-    condition = "="
-  )
+  join_by <- new_join_by(by, x_as = "updated", y_as = "...y")
   where <- sql_join_tbls(con, by = join_by, na_matches = "never")
 
   clauses <- list2(

--- a/R/query-join.R
+++ b/R/query-join.R
@@ -345,11 +345,13 @@ sql_join_tbls <- function(con, by, na_matches) {
 
     if (na_matches == "na") {
       compare <- purrr::map_chr(seq_along(lhs), function(i) {
-        sql_expr_matches(sql(lhs[[i]]), sql(rhs[[i]]), con = con)
+        sql_expr_matches(con, lhs[[i]], rhs[[i]])
       })
     } else {
       by$condition[by$condition == "=="] <- "="
-      compare <- paste0(lhs, " ", by$condition, " ", rhs)
+      compare <- purrr::map_chr(seq_along(lhs), function(i) {
+        sql_glue2(con, "{lhs[i]} {.sql by$condition[[i]]} {rhs[i]}")
+      })
     }
 
     sql(compare)
@@ -378,6 +380,6 @@ sql_qualify_var <- function(con, table, var) {
 
     sql(paste0(table, ".", var))
   } else {
-    var
+    sql(var)
   }
 }

--- a/R/query-semi-join.R
+++ b/R/query-semi-join.R
@@ -32,8 +32,7 @@ print.semi_join_query <- function(x, ...) {
 
   if (length(x$where)) {
     cat_line("Where:")
-    where <- purrr::map_chr(x$where, as_label)
-    cat_line(indent(paste0(where)))
+    cat_line(indent(x$where))
   }
 
   cat_line("X:")

--- a/R/rows.R
+++ b/R/rows.R
@@ -763,12 +763,11 @@ target_table <- function(x, in_place) {
 }
 
 rows_prep <- function(con, table, from, by, lvl = 0) {
-  y_name <- "...y"
-  join_by <- list(x = by, y = by, x_as = y_name, y_as = table, condition = "=")
+  join_by <- new_join_by(by, x_as = "...y", y_as = table)
   where <- sql_join_tbls(con, by = join_by, na_matches = "never")
 
   list(
-    from = sql_query_wrap(con, from, y_name, lvl = lvl),
+    from = sql_query_wrap(con, from, join_by$x_as, lvl = lvl),
     where = where
   )
 }
@@ -776,7 +775,7 @@ rows_prep <- function(con, table, from, by, lvl = 0) {
 rows_insert_prep <- function(con, table, from, cols, by, lvl = 0) {
   out <- rows_prep(con, table, from, by, lvl = lvl)
 
-  join_by <- list(x = by, y = by, x_as = table, y_as = "...y", condition = "=")
+  join_by <- new_join_by(by, x_as = table, y_as = "...y")
   where <- sql_join_tbls(con, by = join_by, na_matches = "never")
   out$conflict_clauses <- sql_clause_where_exists(table, where, not = TRUE)
 

--- a/R/sql.R
+++ b/R/sql.R
@@ -12,6 +12,15 @@ sql <- function(...) {
   structure(x, class = c("sql", "character"))
 }
 
+#' @export
+`[.sql` <- function(x, i) {
+  sql(NextMethod())
+}
+#' @export
+`[[.sql` <- function(x, i) {
+  sql(NextMethod())
+}
+
 # See setOldClass definition in zzz.R
 
 # c() is also called outside of the dbplyr context so must supply default

--- a/tests/testthat/_snaps/join-by-compat.md
+++ b/tests/testthat/_snaps/join-by-compat.md
@@ -1,0 +1,15 @@
+# join_by checks inputs
+
+    Code
+      new_join_by("x", c("x", "y"))
+    Condition
+      Error in `new_join_by()`:
+      ! `x` and `y` must have the same length.
+      i This is an internal error that was detected in the dbplyr package.
+        Please report it at <https://github.com/tidyverse/dbplyr/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
+    Code
+      new_join_by("x", "y", c("<", ">"))
+    Condition
+      Error in `new_join_by()`:
+      ! Can't recycle `condition` (size 2) to size 1.
+

--- a/tests/testthat/_snaps/query-semi-join.md
+++ b/tests/testthat/_snaps/query-semi-join.md
@@ -9,7 +9,7 @@
       By:
         x-x
       Where:
-        "`df_RHS`.`z` = 2.0"
+        `df_RHS`.`z` = 2.0
       X:
         <table_path> `df`
       Y:

--- a/tests/testthat/_snaps/translate-sql-conditional.md
+++ b/tests/testthat/_snaps/translate-sql-conditional.md
@@ -10,7 +10,7 @@
     Code
       out$select[[2]]
     Output
-      [1] "CASE WHEN (`x` > 1) THEN 'a' END"
+      <SQL> CASE WHEN (`x` > 1) THEN 'a' END
 
 # case_when translates correctly to ELSE when TRUE ~ is used 2
 

--- a/tests/testthat/test-join-by-compat.R
+++ b/tests/testthat/test-join-by-compat.R
@@ -1,0 +1,12 @@
+test_that("new_join_by has useful defaults", {
+  out <- new_join_by(c("x", "y"))
+  expect_equal(out$y, c("x", "y"))
+  expect_equal(out$condition, c("==", "=="))
+})
+
+test_that("join_by checks inputs", {
+  expect_snapshot(error = TRUE, {
+    new_join_by("x", c("x", "y"))
+    new_join_by("x", "y", c("<", ">"))
+  })
+})

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -146,7 +146,7 @@ test_that("across doesn't select columns from `.by` #1493", {
     )
 
   expect_snapshot(out)
-  expect_equal(sql_build(out)$select[1], "`g`")
+  expect_equal(sql_build(out)$select[1], sql("`g`"))
 })
 
 test_that("can't use `.by` with `.groups`", {


### PR DESCRIPTION
* Construct both `na_matches` cases similarly
* Preserve `sql()` class when subsetting
* Standardise `join_by()` construction