### PR TITLE
Refactor `sql_table_prefix()`

### DIFF
--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -206,12 +206,12 @@ simulate_mssql <- function(version = "15.0") {
   parts <- rows_prep(con, table, from, by, lvl = 0)
 
   update_cols_esc <- sql(sql_escape_ident(con, update_cols))
-  update_values <- sql_table_prefix(con, update_cols, "...y")
+  update_values <- sql_table_prefix(con, "...y", update_cols)
   update_clause <- sql(paste0(update_cols_esc, " = ", update_values))
 
   insert_cols <- c(by, update_cols)
   insert_cols_esc <- sql(sql_escape_ident(con, insert_cols))
-  insert_cols_qual <- sql_table_prefix(con, insert_cols, "...y")
+  insert_cols_qual <- sql_table_prefix(con, "...y", insert_cols)
 
   clauses <- list(
     sql_clause("MERGE INTO", table),

--- a/R/backend-mysql.R
+++ b/R/backend-mysql.R
@@ -235,7 +235,7 @@ sql_query_update_from.MariaDBConnection <- function(
 
   # https://stackoverflow.com/a/19346375/946850
   parts <- rows_prep(con, table, from, by, lvl = 0)
-  update_cols <- sql_table_prefix(con, names(update_values), table)
+  update_cols <- sql_table_prefix(con, table, names(update_values))
 
   clauses <- list(
     sql_clause_update(table),

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -92,12 +92,12 @@ sql_query_upsert.Oracle <- function(
   # https://oracle-base.com/articles/9i/merge-statement
   parts <- rows_prep(con, table, from, by, lvl = 0)
   update_cols_esc <- sql(sql_escape_ident(con, update_cols))
-  update_values <- sql_table_prefix(con, update_cols, ident("...y"))
+  update_values <- sql_table_prefix(con, "...y", update_cols)
   update_clause <- sql(paste0(update_cols_esc, " = ", update_values))
 
   insert_cols <- c(by, update_cols)
   insert_cols_esc <- escape(ident(insert_cols), parens = FALSE, con = con)
-  insert_values <- sql_table_prefix(con, insert_cols, "...y")
+  insert_values <- sql_table_prefix(con, "...y", insert_cols)
 
   clauses <- list(
     sql_clause("MERGE INTO", table),

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -440,7 +440,7 @@ sql_query_upsert.PqConnection <- function(
   )
 
   update_values <- set_names(
-    sql_table_prefix(con, update_cols, "excluded"),
+    sql_table_prefix(con, "excluded", update_cols),
     update_cols
   )
   update_cols <- sql_escape_ident(con, update_cols)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -968,7 +968,7 @@ sql_query_upsert.DBIConnection <- function(
     con = con
   )
 
-  update_values <- sql_table_prefix(con, update_cols, "...y")
+  update_values <- sql_table_prefix(con, "...y", update_cols)
   update_cols <- sql_escape_ident(con, update_cols)
 
   updated_cte <- list(
@@ -1053,7 +1053,7 @@ sql_named_cols <- function(con, cols, table = NULL) {
   nms <- names2(cols)
   nms[nms == cols] <- ""
 
-  cols <- sql_table_prefix(con, cols, table)
+  cols <- sql_table_prefix(con, table, cols)
   cols <- set_names(ident_q(cols), nms)
   escape(cols, collapse = NULL, con = con)
 }

--- a/R/rows.R
+++ b/R/rows.R
@@ -233,7 +233,7 @@ rows_update.tbl_lazy <- function(
     con <- remote_con(x)
     update_cols <- setdiff(colnames(y), by)
     update_values <- set_names(
-      sql_table_prefix(con, update_cols, "...y"),
+      sql_table_prefix(con, "...y", update_cols),
       update_cols
     )
 
@@ -315,8 +315,8 @@ rows_patch.tbl_lazy <- function(
 
     update_cols <- setdiff(colnames(y), by)
     update_values <- sql_coalesce(
-      sql_table_prefix(con, update_cols, table),
-      sql_table_prefix(con, update_cols, "...y")
+      sql_table_prefix(con, table, update_cols),
+      sql_table_prefix(con, "...y", update_cols)
     )
     update_values <- set_names(update_values, update_cols)
 

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -32,11 +32,7 @@ sql_escape_ident.default <- function(con, x) {
 }
 #' @export
 sql_escape_ident.TestConnection <- function(con, x) {
-  if (methods::is(x, "SQL")) {
-    x
-  } else {
-    sql_quote(x, "`")
-  }
+  sql_quote(x, "`")
 }
 
 sql_escape_string <- function(con, x) {


### PR DESCRIPTION
I began by simplifying `sql_star()` which eliminated the special case in `sql_escape_ident.TestConnection()`. Then I could inline `sql_qualify_var()` into `sql_table_prefix()`. I then noticed that all current uses supply a table, so I dropped the `NULL` case and default value, and flipped the argument order for clarity.