### PR TITLE
Update check for `*` to correct inline `filter()` before `summarise()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # dbplyr (development version)
 
+* A `filter()` followed by a `summarise()` is once again inlined correctly (#1707).
 * `src_memdb()` and `tbl_memdb()` are deprecated; use `memdb()` and `copy_to(memdb(), df)` instead. New `local_memdb_frame()` for use in tests.
 * `arrange()` now applies consecutively, matching dplyr's behavior: `arrange(y) |> arrange(x)` is now equivalent to `arrange(x, y)`. Empty `arrange()` now preserves existing ordering instead of clearing it (#789).
 * `distinct()` with computed columns now ignores grouping, matching dplyr's behavior (#1081).

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -108,7 +108,7 @@ select_query_clauses <- function(x, subquery = FALSE) {
     where = length(x$where) > 0,
     group_by = length(x$group_by) > 0,
     having = length(x$having) > 0,
-    select = !identical(unname(x$select), sql("*")),
+    select = !is_select_star(x$select),
     distinct = x$distinct,
     window = length(x$window) > 0,
     order_by = (!subquery || !is.null(x$limit)) && length(x$order_by) > 0,
@@ -116,6 +116,15 @@ select_query_clauses <- function(x, subquery = FALSE) {
   )
 
   ordered(names(present)[present], levels = names(present))
+}
+
+is_select_star <- function(x) {
+  if (length(x) != 1) {
+    return(FALSE)
+  } else {
+    # * is never quoted and always comes at the end
+    grepl("\\*$", x)
+  }
 }
 
 #' @export

--- a/tests/testthat/_snaps/query-select.md
+++ b/tests/testthat/_snaps/query-select.md
@@ -27,3 +27,56 @@
       Error in `sql_clause_select()`:
       ! Query contains no columns
 
+# can generate SELECT query with all clauses
+
+    Code
+      show_query(lf)
+    Output
+      <SQL>
+      SELECT DISTINCT `all-clauses`.*, `a` + 1.0 AS `b`
+      FROM `all-clauses`
+      WHERE (`a` > 1.0)
+      ORDER BY `a`
+
+# summarise + head is collapsed
+
+    Code
+      show_query(lf)
+    Output
+      <SQL>
+      SELECT `x`, SUM(`y`) AS `y`
+      FROM `df`
+      GROUP BY `x`
+      LIMIT 1
+
+# select + arrange/filter is collapsed
+
+    Code
+      show_query(lf_filter)
+    Output
+      <SQL>
+      SELECT `y`
+      FROM `df`
+      WHERE (`x` = 1.0)
+
+---
+
+    Code
+      show_query(lf_arrange)
+    Output
+      <SQL>
+      SELECT `y`
+      FROM `df`
+      ORDER BY `x`
+
+# filter + summarise is collapsed
+
+    Code
+      show_query(lf)
+    Output
+      <SQL>
+      SELECT `g`, AVG(`y`) AS `y`
+      FROM `df`
+      WHERE (`x` = 1.0)
+      GROUP BY `g`
+


### PR DESCRIPTION
Fixes #1707