### PR TITLE
Drop `dbplyr_query_select()`

### DIFF
--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -185,7 +185,7 @@ sql_query_fields <- function(con, sql, ...) {
 #' @export
 sql_query_fields.DBIConnection <- function(con, sql, ...) {
   sql <- as_table_source(sql, con)
-  dbplyr_query_select(
+  sql_query_select(
     con,
     sql("*"),
     dbplyr_sql_subquery(con, sql),
@@ -361,34 +361,6 @@ sql_query_select.DBIConnection <- function(
     order_by = sql_clause_order_by(order_by, subquery, limit),
     limit = sql_clause_limit(con, limit),
     lvl = lvl
-  )
-}
-dbplyr_query_select <- function(
-  con,
-  select,
-  from,
-  where = NULL,
-  group_by = NULL,
-  having = NULL,
-  order_by = NULL,
-  limit = NULL,
-  distinct = FALSE,
-  ...
-) {
-  check_2ed(con)
-  # TODO should add argument `window` after tidyverse/dplyr#4663
-  # TODO should add argument `subquery` after tidyverse/dplyr#4663
-  sql_query_select(
-    con,
-    select,
-    from,
-    where = where,
-    group_by = group_by,
-    having = having,
-    order_by = order_by,
-    limit = limit,
-    distinct = distinct,
-    ...
   )
 }
 

--- a/R/lazy-ops.R
+++ b/R/lazy-ops.R
@@ -86,7 +86,7 @@ sql_render.base_query <- function(
     from
   } else {
     from <- escape(from, con = con)
-    dbplyr_query_select(con, sql("*"), from, lvl = lvl)
+    sql_query_select(con, sql("*"), from, lvl = lvl)
   }
 }
 

--- a/R/query-select.R
+++ b/R/query-select.R
@@ -143,7 +143,7 @@ sql_render.select_query <- function(
     lvl = lvl
   )
 
-  dbplyr_query_select(
+  sql_query_select(
     con,
     query$select,
     from,


### PR DESCRIPTION
In general, we only need the `dbplyr_` functions when we generate SQL then use it, which is not the case here.