### PR TITLE
Simplify `is_lazy_select_query_simple()`

### DIFF
--- a/R/lazy-select-query.R
+++ b/R/lazy-select-query.R
@@ -103,23 +103,16 @@ new_lazy_select <- function(
 }
 
 # projection = only select (including rename) from parent query
-# identity = selects exactly the same variable as the parent query
 is_lazy_select_query_simple <- function(
   x,
   ignore_where = FALSE,
-  ignore_group_by = FALSE,
-  select = c("projection", "identity")
+  ignore_group_by = FALSE
 ) {
   if (!is_lazy_select_query(x)) {
     return(FALSE)
   }
 
-  select <- arg_match(select, c("projection", "identity"))
-  if (select == "projection" && !is_projection(x$select$expr)) {
-    return(FALSE)
-  }
-
-  if (select == "identity" && !is_select_identity(x$select, op_vars(x$x))) {
+  if (!is_projection(x$select$expr)) {
     return(FALSE)
   }
 

--- a/R/remote.R
+++ b/R/remote.R
@@ -74,13 +74,7 @@ remote_table.lazy_base_local_query <- function(x, null_if_local = TRUE) {
 
 #' @export
 remote_table.lazy_query <- function(x, null_if_local = TRUE) {
-  if (
-    !is_lazy_select_query_simple(x, ignore_group_by = TRUE, select = "identity")
-  ) {
-    return()
-  }
-
-  remote_table(x$x)
+  NULL
 }
 
 #' @export

--- a/R/verb-joins.R
+++ b/R/verb-joins.R
@@ -494,8 +494,7 @@ join_inline_select <- function(lq, by, on, semi = FALSE) {
   can_inline <- is_lazy_select_query_simple(
     lq,
     ignore_where = semi,
-    ignore_group_by = semi,
-    select = "projection"
+    ignore_group_by = semi
   )
 
   if (is_empty(on) && can_inline) {


### PR DESCRIPTION
We no longer need to complicate `remote_table()` for this case, since `add_select()` already inlines it.