### PR TITLE
Eliminate `src_sqlite()`

### DIFF
--- a/R/memdb.R
+++ b/R/memdb.R
@@ -8,7 +8,8 @@
 #' `memdb_frame()` works like [tibble::tibble()], but instead of creating a new
 #' data frame in R, it creates a table in `memdb()`. `local_memdb_frame()`
 #' is like `memdb_frame()` but the table will be automatically deleted when
-#' the current scope ends. It's useful for tests.
+#' the current scope ends. It's useful for tests. But beware: this function
+#' will overwrite an existing table of the same name.
 #'
 #' @inheritParams tibble::tibble
 #' @param .name Name of table in database: defaults to a random name that's
@@ -45,7 +46,7 @@ local_memdb_frame <- function(
   ...,
   frame = caller_env()
 ) {
-  tbl <- copy_to(memdb(), tibble(...), .name)
+  tbl <- copy_to(memdb(), tibble(...), .name, overwrite = TRUE)
   withr::defer(DBI::dbRemoveTable(memdb(), .name), envir = frame)
   tbl
 }

--- a/man/memdb.Rd
+++ b/man/memdb.Rd
@@ -39,7 +39,8 @@ dbplyr without having to connect to a "real" database.
 \code{memdb_frame()} works like \code{\link[tibble:tibble]{tibble::tibble()}}, but instead of creating a new
 data frame in R, it creates a table in \code{memdb()}. \code{local_memdb_frame()}
 is like \code{memdb_frame()} but the table will be automatically deleted when
-the current scope ends. It's useful for tests.
+the current scope ends. It's useful for tests. But beware: this function
+will overwrite an existing table of the same name.
 }
 \examples{
 library(dplyr)

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -33,12 +33,6 @@ cache_test_con <- function(name, get_args) {
   }
 }
 
-test_sqlite <- function() {
-  cache_test_con("sqlite", function() {
-    list(drv = RSQLite::SQLite(), dbname = ":memory:")
-  })
-}
-
 test_postgres <- function() {
   cache_test_con("postgres", function() {
     if (on_github_postgres()) {

--- a/tests/testthat/test-backend-sqlite.R
+++ b/tests/testthat/test-backend-sqlite.R
@@ -117,7 +117,7 @@ test_that("date extraction agrees with R", {
 
 test_that("can explain a query", {
   db <- copy_to(
-    test_sqlite(),
+    memdb(),
     data.frame(x = 1:5),
     name = "test",
     indexes = list("x"),

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -1,10 +1,5 @@
 test_that("remote_table returns name when it makes sense", {
-  mf <- copy_to(
-    test_sqlite(),
-    tibble(x = 5),
-    name = "refxiudlph",
-    overwrite = TRUE
-  )
+  mf <- local_memdb_frame("refxiudlph", x = 5)
 
   # produces name after `group_by()`
   expect_equal(
@@ -19,12 +14,7 @@ test_that("remote_table returns name when it makes sense", {
 })
 
 test_that("remote_table returns null for computed tables", {
-  mf <- copy_to(
-    test_sqlite(),
-    tibble(x = 5, y = 1),
-    name = "refxiudlph",
-    overwrite = TRUE
-  )
+  mf <- local_memdb_frame("refxiudlph", x = 5, y = 1)
   expect_equal(remote_table(mf), table_path("`refxiudlph`"))
 
   expect_null(mf |> filter(x == 3) |> remote_table())

--- a/tests/testthat/test-sql-build.R
+++ b/tests/testthat/test-sql-build.R
@@ -1,10 +1,5 @@
 test_that("rendering table wraps in SELECT *", {
-  out <- copy_to(
-    test_sqlite(),
-    tibble(x = 1),
-    name = "test-sql-build",
-    overwrite = TRUE
-  )
+  out <- local_memdb_frame("test-sql-build", x = 1)
   expect_snapshot(out |> sql_render())
   expect_equal(out |> collect(), tibble(x = 1))
 })

--- a/tests/testthat/test-tbl-sql.R
+++ b/tests/testthat/test-tbl-sql.R
@@ -25,12 +25,7 @@ test_that("same_src distinguishes srcs", {
 })
 
 test_that("has nice print method", {
-  mf <- copy_to(
-    test_sqlite(),
-    tibble(x = 1, y = 1),
-    name = "tbl_sum_test",
-    overwrite = TRUE
-  )
+  mf <- local_memdb_frame("tbl_sum_test", x = 1, y = 1)
   expect_snapshot(mf, transform = scrub_sqlite_version)
 
   out2 <- mf |> group_by(x, y) |> arrange(x) |> mutate(z = x + y)

--- a/tests/testthat/test-verb-arrange.R
+++ b/tests/testthat/test-verb-arrange.R
@@ -30,12 +30,7 @@ test_that("correctly inlines across all verbs", {
 # sql_render --------------------------------------------------------------
 
 test_that("quoting for rendering ordered grouped table", {
-  db <- copy_to(
-    test_sqlite(),
-    tibble(x = 1, y = 2),
-    name = "test-verb-arrange",
-    overwrite = TRUE
-  )
+  db <- local_memdb_frame("test-verb-arrange", x = 1, y = 2)
   out <- db |> group_by(x) |> arrange(y) |> ungroup()
   expect_snapshot(sql_render(out))
   expect_equal(collect(out), tibble(x = 1, y = 2))

--- a/tests/testthat/test-verb-mutate.R
+++ b/tests/testthat/test-verb-mutate.R
@@ -67,12 +67,7 @@ test_that("can refer to fresly created values", {
     collect()
   expect_equal(out1, tibble(x1 = 1, x2 = 2, x3 = 3, x4 = 4))
 
-  out2 <- copy_to(
-    test_sqlite(),
-    tibble(x = 1),
-    name = "multi_mutate",
-    overwrite = TRUE
-  ) |>
+  out2 <- local_memdb_frame("multi_mutate", x = 1) |>
     mutate(x = x + 1, x = x + 2, x = x + 4)
   expect_equal(collect(out2), tibble(x = 8))
   expect_snapshot(show_query(out2))

--- a/tests/testthat/test-verb-summarise.R
+++ b/tests/testthat/test-verb-summarise.R
@@ -195,12 +195,7 @@ test_that("catches `.by` with grouped-df", {
 # sql-render --------------------------------------------------------------
 
 test_that("quoting for rendering summarized grouped table", {
-  out <- copy_to(
-    test_sqlite(),
-    tibble(x = 1),
-    name = "verb-summarise",
-    overwrite = TRUE
-  ) |>
+  out <- local_memdb_frame("verb-summarise", x = 1) |>
     group_by(x) |>
     summarise(n = n())
   expect_snapshot(out |> sql_render())

--- a/tests/testthat/test-verb-uncount.R
+++ b/tests/testthat/test-verb-uncount.R
@@ -1,10 +1,5 @@
 test_that("symbols weights are dropped in output", {
-  df <- copy_to(
-    test_sqlite(),
-    tibble(x = 1, w = 1),
-    name = "test",
-    overwrite = TRUE
-  )
+  df <- local_memdb_frame("test", x = 1, w = 1)
   expect_equal(dbplyr_uncount(df, w) |> collect(), tibble(x = 1))
 
   expect_snapshot(


### PR DESCRIPTION
And make `local_memdb_frame()` easier to use interactively by setting `overwrite = TRUE`