### PR TITLE
Handle `cols` escaping in `sql_clause_insert()`

### DIFF
--- a/R/backend-mssql.R
+++ b/R/backend-mssql.R
@@ -160,15 +160,9 @@ simulate_mssql <- function(version = "15.0") {
   returning_cols = NULL
 ) {
   parts <- rows_prep(con, table, from, by = list(), lvl = 0)
-  insert_cols <- escape(
-    ident(insert_cols),
-    collapse = ", ",
-    parens = TRUE,
-    con = con
-  )
 
   clauses <- list2(
-    sql_clause_insert(con, insert_cols, table),
+    sql_clause_insert(con, insert_cols, into = table),
     sql_returning_cols(con, returning_cols, "INSERTED"),
     sql_clause_select(con, sql("*")),
     sql_clause_from(parts$from)
@@ -234,7 +228,7 @@ simulate_mssql <- function(version = "15.0") {
     sql("WHEN MATCHED THEN"),
     sql_clause("UPDATE SET", update_clause, lvl = 1),
     sql("WHEN NOT MATCHED THEN"),
-    sql_clause_insert(con, insert_cols_esc, lvl = 1),
+    sql_clause_insert(con, insert_cols, lvl = 1),
     sql_clause("VALUES", insert_cols_qual, parens = TRUE, lvl = 1),
     sql_returning_cols(con, returning_cols, "INSERTED"),
     sql(";")

--- a/R/backend-oracle.R
+++ b/R/backend-oracle.R
@@ -96,7 +96,6 @@ sql_query_upsert.Oracle <- function(
   update_clause <- sql(paste0(update_cols_esc, " = ", update_values))
 
   insert_cols <- c(by, update_cols)
-  insert_cols_esc <- escape(ident(insert_cols), parens = FALSE, con = con)
   insert_values <- sql_table_prefix(con, "...y", insert_cols)
 
   clauses <- list(
@@ -106,7 +105,7 @@ sql_query_upsert.Oracle <- function(
     sql("WHEN MATCHED THEN"),
     sql_clause("UPDATE SET", update_clause, lvl = 1),
     sql("WHEN NOT MATCHED THEN"),
-    sql_clause_insert(con, insert_cols_esc, lvl = 1),
+    sql_clause_insert(con, insert_cols, lvl = 1),
     sql_clause("VALUES", insert_values, parens = TRUE, lvl = 1),
     sql_returning_cols(con, returning_cols, table),
     sql(";")

--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -432,12 +432,6 @@ sql_query_upsert.PqConnection <- function(
 
   insert_cols <- c(by, update_cols)
   select_cols <- ident(insert_cols)
-  insert_cols <- escape(
-    ident(insert_cols),
-    collapse = ", ",
-    parens = TRUE,
-    con = con
-  )
 
   update_values <- set_names(
     sql_table_prefix(con, "excluded", update_cols),
@@ -447,7 +441,7 @@ sql_query_upsert.PqConnection <- function(
 
   by_sql <- escape(ident(by), parens = TRUE, collapse = ", ", con = con)
   clauses <- list(
-    sql_clause_insert(con, insert_cols, table),
+    sql_clause_insert(con, insert_cols, into = table),
     sql_clause_select(con, select_cols),
     sql_clause_from(parts$from),
     # `WHERE true` is required for SQLite

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -498,12 +498,6 @@ sql_query_append.DBIConnection <- function(
 
   # https://stackoverflow.com/questions/25969/insert-into-values-select-from
   parts <- rows_prep(con, table, from, by = list(), lvl = 0)
-  insert_cols <- escape(
-    ident(insert_cols),
-    collapse = ", ",
-    parens = TRUE,
-    con = con
-  )
 
   clauses <- list2(
     sql_clause_insert(con, insert_cols, table),
@@ -610,12 +604,6 @@ sql_query_upsert.DBIConnection <- function(
   parts <- rows_prep(con, table, from, by, lvl = 0)
 
   insert_cols <- c(by, update_cols)
-  insert_cols <- escape(
-    ident(insert_cols),
-    collapse = ", ",
-    parens = TRUE,
-    con = con
-  )
 
   update_values <- sql_table_prefix(con, "...y", update_cols)
   update_cols <- sql_escape_ident(con, update_cols)

--- a/R/rows.R
+++ b/R/rows.R
@@ -786,8 +786,7 @@ rows_insert_prep <- function(con, table, from, cols, by, lvl = 0) {
   where <- sql_join_tbls(con, by = join_by, na_matches = "never")
   out$conflict_clauses <- sql_clause_where_exists(table, where, not = TRUE)
 
-  insert_cols <- escape(ident(cols), collapse = ", ", parens = TRUE, con = con)
-  out$insert_clause <- sql_clause_insert(con, insert_cols, table)
+  out$insert_clause <- sql_clause_insert(con, cols, table)
 
   out
 }

--- a/R/sql-clause.R
+++ b/R/sql-clause.R
@@ -121,11 +121,13 @@ sql_clause_set <- function(lhs, rhs) {
 }
 
 sql_clause_insert <- function(con, cols, into = NULL, lvl = 0) {
+  cols <- sql(sql_escape_ident(con, cols))
+
   if (is.null(into)) {
     sql_clause("INSERT", cols, parens = TRUE, lvl = lvl)
   } else {
-    kw <- paste0("INSERT INTO ", escape(into, con = con))
-    sql_clause(kw, cols, lvl = lvl)
+    kw <- sql_glue2(con, "INSERT INTO {.tbl into}")
+    sql_clause(kw, cols, parens = TRUE, lvl = lvl)
   }
 }
 


### PR DESCRIPTION
Eliminating quite a few uses of `escape()`