### PR TITLE
Polish upsert for postgres

### DIFF
--- a/R/backend-postgres.R
+++ b/R/backend-postgres.R
@@ -452,7 +452,7 @@ sql_query_upsert.PqConnection <- function(
     sql_clause_from(parts$from),
     # `WHERE true` is required for SQLite
     sql("WHERE true"),
-    sql_clause("ON CONFLICT ", by_sql),
+    sql_clause("ON CONFLICT", by_sql),
     sql("DO UPDATE"),
     sql_clause_set(update_cols, update_values),
     sql_returning_cols(con, returning_cols, table)

--- a/R/db-sql.R
+++ b/R/db-sql.R
@@ -387,8 +387,8 @@ db_supports_table_alias_with_as.TestConnection <- function(con) {
 #' @examples
 #' sql_query_upsert(
 #'   con = simulate_postgres(),
-#'   table = ident("airlines"),
-#'   from = ident("df"),
+#'   table = "airlines",
+#'   from = "df",
 #'   by = "carrier",
 #'   update_cols = "name"
 #' )

--- a/man/sql_query_insert.Rd
+++ b/man/sql_query_insert.Rd
@@ -162,8 +162,8 @@ values are then inserted outside of the CTE.
 \examples{
 sql_query_upsert(
   con = simulate_postgres(),
-  table = ident("airlines"),
-  from = ident("df"),
+  table = "airlines",
+  from = "df",
   by = "carrier",
   update_cols = "name"
 )

--- a/tests/testthat/_snaps/backend-postgres.md
+++ b/tests/testthat/_snaps/backend-postgres.md
@@ -141,7 +141,7 @@
         FROM "df_y"
       ) AS "...y"
       WHERE true
-      ON CONFLICT  ("c", "d")
+      ON CONFLICT ("c", "d")
       DO UPDATE
       SET "a" = "excluded"."a", "b" = "excluded"."b"
       RETURNING "df_x"."a", "df_x"."b" AS "b2"


### PR DESCRIPTION
* Remove extraneous space in `ON CONFLICT`
* Drop redundant `ident()` from example