### PR TITLE
Update join WHERE clause if variables are renamed

### DIFF
--- a/R/verb-joins.R
+++ b/R/verb-joins.R
@@ -485,6 +485,19 @@ add_join <- function(
 
   x_lq$joins <- vctrs::vec_rbind(x_lq$joins, joins_data)
   x_lq$table_names <- vctrs::vec_rbind(x_lq$table_names, table_names_y)
+
+  # Update WHERE clause if any x variables were renamed (#1770)
+  if (length(x_lq$where) > 0) {
+    old_names <- x_lq$vars$name
+    new_names <- vars$name[seq_along(x_lq$vars$name)]
+    renamed <- old_names != new_names
+
+    x_lq$where <- replace_sym(
+      x_lq$where,
+      old_names[renamed],
+      syms(new_names[renamed])
+    )
+  }
   x_lq$vars <- vars
 
   x_lq

--- a/tests/testthat/test-query-join.R
+++ b/tests/testthat/test-query-join.R
@@ -40,6 +40,20 @@ test_that("multi_join where clause uses qualified column names", {
   expect_snapshot(left_join(lf1, lf3, by = "x") |> filter(y.x > 1))
 })
 
+test_that("where clause is updated when vars are renamed by later join (#1770)", {
+  lf1 <- lazy_frame(x = 1, y = 2, .name = "t1")
+  lf2 <- lazy_frame(x = 1, z = 3, .name = "t2")
+  lf3 <- lazy_frame(x = 1, z = 4, .name = "t3")
+
+  # When z gets renamed to z.x, the filter should use the new name
+  out <- lf1 |>
+    left_join(lf2, by = "x") |>
+    filter(z == 1) |>
+    left_join(lf3, by = "x")
+
+  expect_equal(out$lazy_query$where, list(expr(z.x == 1)))
+})
+
 test_that("generated sql doesn't change unexpectedly", {
   lf <- lazy_frame(x = 1, y = 2)
 


### PR DESCRIPTION
Fixes #1770

This makes me a bit nervous that there are other places I have missed where we might need to update WHERE.