### PR TITLE
Don't reference removed `src_postgres()`

### DIFF
--- a/R/data-nycflights13.R
+++ b/R/data-nycflights13.R
@@ -23,7 +23,7 @@ nycflights13_sqlite <- function(path = NULL) {
 
 #' @export
 #' @rdname nycflights13
-#' @param dbname,... Arguments passed on to [src_postgres()]
+#' @param dbname,... Arguments passed on to [DBI::dbConnect()]
 nycflights13_postgres <- function(dbname = "nycflights13", ...) {
   cache_computation("nycflights_postgres", {
     message("Caching nycflights db in postgresql db ", dbname)

--- a/man/nycflights13.Rd
+++ b/man/nycflights13.Rd
@@ -19,7 +19,7 @@ copy_nycflights13(con, ...)
 \arguments{
 \item{path}{location of SQLite database file}
 
-\item{dbname, ...}{Arguments passed on to \code{\link[dplyr:src_dbi]{dplyr::src_postgres()}}}
+\item{dbname, ...}{Arguments passed on to \code{\link[DBI:dbConnect]{DBI::dbConnect()}}}
 }
 \description{
 These functions cache the data from the \code{nycflights13} database in


### PR DESCRIPTION
Part of dplyr 1.2.0 revdeps, since `src_postgres()` was removed.