### PR TITLE
Fix `copy_to()` same-source check

### DIFF
--- a/R/verb-copy-to.R
+++ b/R/verb-copy-to.R
@@ -69,7 +69,7 @@ copy_to.src_sql <- function(
 
   name <- as_table_path(name, dest$con)
 
-  if (inherits(df, "tbl_sql") && same_src(df, dest)) {
+  if (inherits(df, "tbl_sql") && same_src(df$src, dest)) {
     out <- compute(
       df,
       name = name,

--- a/tests/testthat/test-verb-copy-to.R
+++ b/tests/testthat/test-verb-copy-to.R
@@ -13,6 +13,17 @@ test_that("can copy to from remote sources", {
   expect_equal(collect(df_3), df)
 })
 
+test_that("copy_to() within same source uses compute() and ignores types", {
+  con <- local_sqlite_connection()
+  df_1 <- copy_to(con, tibble(x = 1L), "df1", types = c(x = "INT"))
+  df_2 <- copy_to(con, df_1, "df2", types = c(x = "DOUBLE"))
+
+  expect_equal(
+    DBI::dbGetQuery(con, "SELECT typeof(x) FROM df2")[[1]],
+    "integer"
+  )
+})
+
 test_that("only overwrite existing table if explicitly requested", {
   con <- local_sqlite_connection()
   local_db_table(con, data.frame(x = 1:5), "df")


### PR DESCRIPTION
`copy_to(con, tbl_sql, ...)` was always taking the cross-source branch (collect + dbWriteTable) instead of `compute()`, because `same_src(df, dest)` dispatches to `same_src.tbl_sql()`, which requires `y` to inherit from `tbl_sql`, but `dest` is a `src_sql`. Compare `df$src` to `dest` so both sides are `src_sql` and dispatch reaches `same_src.src_sql()`.