### PR TITLE
fix: typo in base_no_win — "lad" should be "lag"

### DIFF
--- a/R/backend-.R
+++ b/R/backend-.R
@@ -683,7 +683,7 @@ base_no_win <- sql_translator(
   first = win_absent("first"),
   last = win_absent("last"),
   lead = win_absent("lead"),
-  lag = win_absent("lad"),
+  lag = win_absent("lag"),
   order_by = win_absent("order_by"),
   str_flatten = win_absent("str_flatten"),
   count = win_absent("count")


### PR DESCRIPTION
## Summary

Fixes a typo in `R/backend-.R` in the `base_no_win` translator: `win_absent("lad")` should be `win_absent("lag")`.

## Impact

Without this fix, backends that don't support window functions (e.g. SQLite < 3.25) produce a confusing error message when users try to use `lag()`:

> Window function `lad()` is not supported by this database.

instead of:

> Window function `lag()` is not supported by this database.

## Validation

- `devtools::test(filter = "^backend-$")` — 61 tests pass
- `devtools::test(filter = "^backend-sqlite$")` — 24 tests pass
- No remaining instances of the typo in the codebase

## Notes

This is a single-character fix in `R/backend-.R:686`. No other files are affected.
