### PR TITLE
fix: correct show_query() doc typo and add examples for set operations

### DIFF
--- a/R/verb-explain.R
+++ b/R/verb-explain.R
@@ -1,6 +1,6 @@
 #' Show generated SQL and query plan
 #'
-#' `show_sql()` displays the SQL query that will be dispatched to the database;
+#' `show_query()` displays the SQL query that will be dispatched to the database;
 #' `explain()` displays both the SQL query and the query plan.
 #'
 #' @param ... For `explain()`, further arguments to [remote_query_plan()].

--- a/R/verb-set-ops.R
+++ b/R/verb-set-ops.R
@@ -7,6 +7,15 @@
 #' @inheritParams left_join.tbl_lazy
 #' @param ... Must be empty.
 #' @param all If `TRUE`, includes all matches in output, not just unique rows.
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
+#' library(dplyr, warn.conflicts = FALSE)
+#'
+#' lf1 <- lazy_frame(x = 1, y = 2)
+#' lf2 <- lazy_frame(x = 1, y = 3)
+#'
+#' intersect(lf1, lf2)
+#' union(lf1, lf2)
+#' setdiff(lf1, lf2)
 #' @exportS3Method dplyr::intersect
 #' @importFrom dplyr intersect
 intersect.tbl_lazy <- function(x, y, copy = "none", ..., all = FALSE) {

--- a/man/intersect.tbl_lazy.Rd
+++ b/man/intersect.tbl_lazy.Rd
@@ -45,3 +45,15 @@ These are methods for the dplyr generics \code{dplyr::intersect()},
 \code{dplyr::union()}, and \code{dplyr::setdiff()}. They are translated to
 \code{INTERSECT}, \code{UNION}, and \code{EXCEPT} respectively.
 }
+\examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
+library(dplyr, warn.conflicts = FALSE)
+
+lf1 <- lazy_frame(x = 1, y = 2)
+lf2 <- lazy_frame(x = 1, y = 3)
+
+intersect(lf1, lf2)
+union(lf1, lf2)
+setdiff(lf1, lf2)
+\dontshow{\}) # examplesIf}
+}

--- a/man/show_query.Rd
+++ b/man/show_query.Rd
@@ -24,6 +24,6 @@ For \code{show_query()}, ignored.}
 Use the \code{sql_options} argument instead.}
 }
 \description{
-\code{show_sql()} displays the SQL query that will be dispatched to the database;
+\code{show_query()} displays the SQL query that will be dispatched to the database;
 \code{explain()} displays both the SQL query and the query plan.
 }


### PR DESCRIPTION
## Summary

Two small documentation improvements:

1. **Fix `show_query()` doc typo**: The `@description` in `verb-explain.R` referenced `show_sql()` which doesn't exist — the actual function is `show_query()`. Fixed the Rd source.

2. **Add `@examples` for set operations**: `intersect.tbl_lazy`, `union.tbl_lazy`, `union_all.tbl_lazy`, and `setdiff.tbl_lazy` had no examples. Added lightweight examples using `lazy_frame()` (no live database required, guarded by `@examplesIf requireNamespace("RSQLite", quietly = TRUE)`).

## Changes

- `R/verb-explain.R`: `show_sql()` → `show_query()` in `@description`
- `R/verb-set-ops.R`: Added `@examples` block
- `man/show_query.Rd`: Regenerated
- `man/intersect.tbl_lazy.Rd`: Regenerated

## Tests

- `roxygen2::roxygenise()` regenerated both Rd files cleanly
- `tools::checkRd()` passed on both Rd files
- Full `testthat::test_local()` suite: all failures are pre-existing (missing external DB drivers: RPostgres, MSSQL, ADBI); no new failures introduced