### PR TITLE
fix: typos in new-backend vignette and test comment

### DIFF
--- a/R/sql-dialect.R
+++ b/R/sql-dialect.R
@@ -130,7 +130,7 @@ sql_has_table_alias_with_as <- function(con) {
   if (is_sql_dialect(dialect)) {
     dialect$has$table_alias_with_as
   } else {
-    # For backward comptaibility
+    # For backward compatibility
     TRUE
   }
 }
@@ -141,7 +141,7 @@ sql_has_window_clause <- function(con) {
   if (is_sql_dialect(dialect)) {
     dialect$has$window_clause
   } else {
-    # For backward comptaibility
+    # For backward compatibility
     FALSE
   }
 }

--- a/tests/testthat/test-backend-.R
+++ b/tests/testthat/test-backend-.R
@@ -6,7 +6,7 @@ test_that("base_no_win includes all aggregates and window functions", {
   # All aggregates must be included in window functions
   expect_equal(setdiff(names(base_agg), names(base_win)), character())
 
-  # All window functions all need to be in no_in
+  # All window functions need to be in base_no_win
   expect_equal(setdiff(names(base_win), names(base_no_win)), character())
 })
 

--- a/vignettes/new-backend.Rmd
+++ b/vignettes/new-backend.Rmd
@@ -75,13 +75,13 @@ sql_dialect.myConnectionClass <- function(con) {
 The `new_sql_dialect()` function requires two arguments:
 
 * `dialect`: A unique name for your backend (used to create the class name).
-* `quote_identifier`: A function that quotes identifiers. This will typically b e either a call to `sql_quote()` or to `DBI::dbQuoteIdentifier()`
+* `quote_identifier`: A function that quotes identifiers. This will typically be either a call to `sql_quote()` or to `DBI::dbQuoteIdentifier()`
 
 `new_sql_dialect()` has a number of additional arguments that describe the capabilities of the SQL dialect; see `?new_sql_dialect` for details.
 
 The dialect system allows you to write methods that dispatch on the dialect class (e.g., `sql_translation.sql_dialect_mybackend`) rather than the connection class. This makes it easier to share SQL generation code between different connection types that use the same database (e.g. direct, ODBC, JDBC, ADBC). 
 
-In general, generics that start with `sql_` should have a sql_dialect method, and generics that start with `db_` should use a DBI connection method. It should be relatively rare to need a method for `db_` generic, but occassionally dbplyr's SQL generation system is not quite flexible enough. If you find this, it's worth filing an issue so I can look into it.
+In general, generics that start with `sql_` should have a sql_dialect method, and generics that start with `db_` should use a DBI connection method. It should be relatively rare to need a method for `db_` generic, but occasionally dbplyr's SQL generation system is not quite flexible enough. If you find this, it's worth filing an issue so I can look into it.
 
 ## Copying, computing, collecting and collapsing
 
@@ -163,13 +163,13 @@ You can define translation methods either on your connection class or on your di
 sql_translation.sql_dialect_mybackend <- function(con) {
   sql_variant(
     scalar = sql_translator(base_scalar, ...), # Functions in SELECT (non-aggregated)
-    aggregate = sql_translator(base_aggregate, ...), # Aggregation functions (mean, sum, etc.)
+    aggregate = sql_translator(base_agg, ...), # Aggregation functions (mean, sum, etc.)
     window = sql_translator(base_win, ...) # Window functions (lead, lag, rank, etc.)
   )
 }
 ```
 
-Each translator will inherits from the base (ANSI SQL) translator and overrides only what's different for your backend:
+Each translator will inherit from the base (ANSI SQL) translator and overrides only what's different for your backend:
 
 ```{r, eval = FALSE}
 sql_translator(


### PR DESCRIPTION
## Summary

Four small fixes in `vignettes/new-backend.Rmd` and one in a test comment:

**Vignette fixes:**
1. `b e` → `be` (extra space splitting the word, line 78)
2. `occassionally` → `occasionally` (misspelling, line 84)
3. `base_aggregate` → `base_agg` (line 166) — the code example referenced a non-existent variable; the actual exported name is `base_agg`
4. `will inherits` → `will inherit` (subject-verb agreement, line 172)

**Test fix:**
5. `test-backend-.R` line 9: comment `no_in` → `base_no_win` (matching the actual object being tested)

## Validation

- All changes are in documentation/comments only, no functional code modified
- Verified `base_agg` is the correct exported variable name (confirmed in `NAMESPACE` and `R/backend-.R`)
- Verified consistency: all other uses of `base_agg` in the vignette (lines 212, 231) already use the correct name