### PR TITLE
fix: grammar errors in docs and incorrect SQL function name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ revdep/checks
 revdep/library
 docs
 /scratch/
+dbplyr.Rcheck/
+dbplyr_*.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
   )
 Description: A 'dplyr' back end for databases that allows you to work with
     remote database tables as if they are in-memory data frames.  Basic
-    features works with any database that has a 'DBI' back end; more
+    features work with any database that has a 'DBI' back end; more
     advanced features require 'SQL' translation to be provided by the
     package author.
 License: MIT + file LICENSE

--- a/R/translate-sql-scalar.R
+++ b/R/translate-sql-scalar.R
@@ -132,7 +132,7 @@ sql_cot <- function() {
 }
 
 #' @rdname sql_translation_scalar
-#' @param rand_expr An string giving an SQL expression that generates a
+#' @param rand_expr A string giving an SQL expression that generates a
 #'   random number between 0 and 1, e.g. `"RANDOM()"`.
 #' @param min,max Range of random values.
 #' @export

--- a/R/verb-joins.R
+++ b/R/verb-joins.R
@@ -26,7 +26,7 @@
 #'     as possible by giving more data to the query planner.
 #'
 #'   * `"inline"`: `y` will be inlined into the query using [copy_inline()].
-#'     This is should faster for small datasets and doesn't require write
+#'     This should be faster for small datasets and doesn't require write
 #'     access.
 #'
 #'   `TRUE` (`"temp-table"`) and `FALSE` (`"none"`) are also accepted for
@@ -36,7 +36,7 @@
 #'   there are matching indexes in `x`.
 #' @param sql_on A custom join predicate as an SQL expression.
 #'   Usually joins use column equality, but you can perform more complex
-#'   queries by supply `sql_on` which should be a SQL expression that
+#'   queries by supplying `sql_on` which should be a SQL expression that
 #'   uses `LHS` and `RHS` aliases to refer to the left-hand side or
 #'   right-hand side of the join respectively.
 #' @param na_matches Should NA (NULL) values match one another?

--- a/man/dbplyr-package.Rd
+++ b/man/dbplyr-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A 'dplyr' back end for databases that allows you to work with remote database tables as if they are in-memory data frames. Basic features works with any database that has a 'DBI' back end; more advanced features require 'SQL' translation to be provided by the package author.
+A 'dplyr' back end for databases that allows you to work with remote database tables as if they are in-memory data frames. Basic features work with any database that has a 'DBI' back end; more advanced features require 'SQL' translation to be provided by the package author.
 }
 \seealso{
 Useful links:

--- a/man/intersect.tbl_lazy.Rd
+++ b/man/intersect.tbl_lazy.Rd
@@ -29,7 +29,7 @@ database as \code{x}. \verb{*_join()} will automatically run \code{ANALYZE} on t
 created table in the hope that this will make your queries as efficient
 as possible by giving more data to the query planner.
 \item \code{"inline"}: \code{y} will be inlined into the query using \code{\link[=copy_inline]{copy_inline()}}.
-This is should faster for small datasets and doesn't require write
+This should be faster for small datasets and doesn't require write
 access.
 }
 

--- a/man/join.tbl_sql.Rd
+++ b/man/join.tbl_sql.Rd
@@ -161,7 +161,7 @@ database as \code{x}. \verb{*_join()} will automatically run \code{ANALYZE} on t
 created table in the hope that this will make your queries as efficient
 as possible by giving more data to the query planner.
 \item \code{"inline"}: \code{y} will be inlined into the query using \code{\link[=copy_inline]{copy_inline()}}.
-This is should faster for small datasets and doesn't require write
+This should be faster for small datasets and doesn't require write
 access.
 }
 
@@ -198,7 +198,7 @@ for multiple use a unique key and for unmatched a foreign key constraint.}
 
 \item{sql_on}{A custom join predicate as an SQL expression.
 Usually joins use column equality, but you can perform more complex
-queries by supply \code{sql_on} which should be a SQL expression that
+queries by supplying \code{sql_on} which should be a SQL expression that
 uses \code{LHS} and \code{RHS} aliases to refer to the left-hand side or
 right-hand side of the join respectively.}
 

--- a/man/rows-db.Rd
+++ b/man/rows-db.Rd
@@ -109,7 +109,7 @@ database as \code{x}. \verb{*_join()} will automatically run \code{ANALYZE} on t
 created table in the hope that this will make your queries as efficient
 as possible by giving more data to the query planner.
 \item \code{"inline"}: \code{y} will be inlined into the query using \code{\link[=copy_inline]{copy_inline()}}.
-This is should faster for small datasets and doesn't require write
+This should be faster for small datasets and doesn't require write
 access.
 }
 

--- a/man/sql_translation_scalar.Rd
+++ b/man/sql_translation_scalar.Rd
@@ -35,7 +35,7 @@ Will signal error if not correct.}
 
 \item{type}{SQL type name as a string.}
 
-\item{rand_expr}{An string giving an SQL expression that generates a
+\item{rand_expr}{A string giving an SQL expression that generates a
 random number between 0 and 1, e.g. \code{"RANDOM()"}.}
 
 \item{min, max}{Range of random values.}

--- a/vignettes/new-backend.Rmd
+++ b/vignettes/new-backend.Rmd
@@ -75,13 +75,13 @@ sql_dialect.myConnectionClass <- function(con) {
 The `new_sql_dialect()` function requires two arguments:
 
 * `dialect`: A unique name for your backend (used to create the class name).
-* `quote_identifier`: A function that quotes identifiers. This will typically b e either a call to `sql_quote()` or to `DBI::dbQuoteIdentifier()`
+* `quote_identifier`: A function that quotes identifiers. This will typically be either a call to `sql_quote()` or to `DBI::dbQuoteIdentifier()`
 
 `new_sql_dialect()` has a number of additional arguments that describe the capabilities of the SQL dialect; see `?new_sql_dialect` for details.
 
 The dialect system allows you to write methods that dispatch on the dialect class (e.g., `sql_translation.sql_dialect_mybackend`) rather than the connection class. This makes it easier to share SQL generation code between different connection types that use the same database (e.g. direct, ODBC, JDBC, ADBC). 
 
-In general, generics that start with `sql_` should have a sql_dialect method, and generics that start with `db_` should use a DBI connection method. It should be relatively rare to need a method for `db_` generic, but occassionally dbplyr's SQL generation system is not quite flexible enough. If you find this, it's worth filing an issue so I can look into it.
+In general, generics that start with `sql_` should have a sql_dialect method, and generics that start with `db_` should use a DBI connection method. It should be relatively rare to need a method for `db_` generic, but occasionally dbplyr's SQL generation system is not quite flexible enough. If you find this, it's worth filing an issue so I can look into it.
 
 ## Copying, computing, collecting and collapsing
 
@@ -169,14 +169,14 @@ sql_translation.sql_dialect_mybackend <- function(con) {
 }
 ```
 
-Each translator will inherits from the base (ANSI SQL) translator and overrides only what's different for your backend:
+Each translator will inherit from the base (ANSI SQL) translator and override only what's different for your backend:
 
 ```{r, eval = FALSE}
 sql_translator(
   base_scalar, # Inherit most translations
   # Override specific functions for your backend
   `+` = sql_infix("+"),
-  mean = sql_aggregate("AVERAGE", "mean")
+  mean = sql_aggregate("AVG", "mean")
 )
 ```
 


### PR DESCRIPTION
## Summary

Fixes documentation issues:

1. **DESCRIPTION**: Subject-verb agreement — "features works" → "features work"
2. **vignettes/new-backend.Rmd**: Incorrect SQL function — "AVERAGE" → "AVG" (the standard SQL aggregate is AVG, not AVERAGE)
3. **vignettes/new-backend.Rmd**: Spacing typo — "b e" → "be"
4. **vignettes/new-backend.Rmd**: Misspelling — "occassionally" → "occasionally"
5. **vignettes/new-backend.Rmd**: Grammar error — "will inherits" → "will inherit"
6. **R/translate-sql-scalar.R**: Article error — "An string" → "A string"
7. **R/verb-joins.R**: Grammar error — "queries by supply" → "queries by supplying"

## Files changed (10)

- .gitignore (add Rcheck and tarball patterns)
- DESCRIPTION
- R/translate-sql-scalar.R
- R/verb-joins.R
- man/dbplyr-package.Rd (regenerated)
- man/intersect.tbl_lazy.Rd (regenerated)
- man/join.tbl_sql.Rd (regenerated)
- man/rows-db.Rd (regenerated)
- man/sql_translation_scalar.Rd (regenerated)
- vignettes/new-backend.Rmd

## Validation

- R CMD build succeeded
- R CMD check --no-manual --no-vignettes --no-tests passed (Status: OK, only expected vignette warnings)
- roxygen2::roxygenise() regenerated affected man pages cleanly

## Notes

- No test changes needed — these are doc-only fixes.
