### PR TITLE
fix: grammar errors in arrange() and ident() roxygen docs

### DIFF
--- a/R/ident.R
+++ b/R/ident.R
@@ -6,7 +6,7 @@
 #' primarily in [translate_sql()] to label variables as identifiers; use
 #' elsewhere should be regarded with suspicion.
 #'
-#' `ident()` is for internal use only; if you need to supply an table name that
+#' `ident()` is for internal use only; if you need to supply a table name that
 #' is qualified with schema or catalog use `I()`.
 #'
 #' @param ... A character vector, or name-value pairs.

--- a/R/verb-arrange.R
+++ b/R/verb-arrange.R
@@ -1,16 +1,16 @@
 #' Arrange rows by column values
 #'
 #' @description
-#' This is an method for the dplyr [arrange()] generic. It generates
+#' This is a method for the dplyr [arrange()] generic. It generates
 #' the `ORDER BY` clause of the SQL query. It also affects the
 #' [window_order()] of windowed expressions in [mutate.tbl_lazy()].
 #'
-#' Note that `ORDER BY` clauses can not generally appear in subqueries, which
+#' Note that `ORDER BY` clauses cannot generally appear in subqueries, which
 #' means that you should `arrange()` as late as possible in your pipelines.
 #'
 #' @section Missing values:
-#' Unlike R, most databases sorts `NA` (`NULL`s) at the front. You can
-#' can override this behaviour by explicitly sorting on `is.na(x)`.
+#' Unlike R, most databases sort `NA` (`NULL`s) at the front. You can
+#' override this behaviour by explicitly sorting on `is.na(x)`.
 #'
 #' @param .data A lazy data frame backed by a database query.
 #' @inheritParams dplyr::arrange

--- a/man/arrange.tbl_lazy.Rd
+++ b/man/arrange.tbl_lazy.Rd
@@ -22,17 +22,17 @@ query, and use \code{\link[=collect.tbl_sql]{collect()}} to execute the query
 and return data to R.
 }
 \description{
-This is an method for the dplyr \code{\link[dplyr:arrange]{arrange()}} generic. It generates
+This is a method for the dplyr \code{\link[dplyr:arrange]{arrange()}} generic. It generates
 the \verb{ORDER BY} clause of the SQL query. It also affects the
 \code{\link[=window_order]{window_order()}} of windowed expressions in \code{\link[=mutate.tbl_lazy]{mutate.tbl_lazy()}}.
 
-Note that \verb{ORDER BY} clauses can not generally appear in subqueries, which
+Note that \verb{ORDER BY} clauses cannot generally appear in subqueries, which
 means that you should \code{arrange()} as late as possible in your pipelines.
 }
 \section{Missing values}{
 
-Unlike R, most databases sorts \code{NA} (\code{NULL}s) at the front. You can
-can override this behaviour by explicitly sorting on \code{is.na(x)}.
+Unlike R, most databases sort \code{NA} (\code{NULL}s) at the front. You can
+override this behaviour by explicitly sorting on \code{is.na(x)}.
 }
 
 \examples{

--- a/man/ident.Rd
+++ b/man/ident.Rd
@@ -20,7 +20,7 @@ quoting them using the identifier rules for your database. It is used
 primarily in \code{\link[=translate_sql]{translate_sql()}} to label variables as identifiers; use
 elsewhere should be regarded with suspicion.
 
-\code{ident()} is for internal use only; if you need to supply an table name that
+\code{ident()} is for internal use only; if you need to supply a table name that
 is qualified with schema or catalog use \code{I()}.
 }
 \examples{


### PR DESCRIPTION
## Summary

Fixes four grammar errors in roxygen documentation that affect generated man pages:

### R/verb-arrange.R
1. **Wrong article**: `an method` -> `a method` (line 4)
2. **Non-standard spelling**: `can not` -> `cannot` (line 8) — standard English style guides prefer the single-word form
3. **Subject-verb agreement**: `databases sorts` -> `databases sort` (line 12) — plural subject requires plural verb
4. **Duplicated word**: `You can can override` -> `You can override` (lines 12-13)

### R/ident.R
5. **Wrong article**: `an table` -> `a table` (line 9)

## Files changed
- `R/verb-arrange.R` (roxygen source)
- `R/ident.R` (roxygen source)
- `man/arrange.tbl_lazy.Rd` (regenerated)
- `man/ident.Rd` (regenerated)

## Testing
- `devtools::test(filter = "arrange")`: PASS (33 tests)
- `devtools::test(filter = "ident")`: PASS (3 tests)
- `tools::checkRd()`: no errors on both man pages
