### PR TITLE
Check that `anyNA()` never emits a `na.rm` warning

### DIFF
--- a/R/backend-.R
+++ b/R/backend-.R
@@ -484,7 +484,7 @@ sql_exp <- function(a, x) {
 }
 
 sql_any_na <- function(x, window = FALSE) {
-  exp <- expr(any(is.na(!!x)))
+  exp <- expr(any(is.na(!!x), na.rm = TRUE))
   translate_sql(!!exp, con = sql_current_con(), window = window)
 }
 

--- a/tests/testthat/_snaps/translate-sql-aggregate.md
+++ b/tests/testthat/_snaps/translate-sql-aggregate.md
@@ -1,3 +1,15 @@
+# aggregation functions warn once if na.rm = FALSE
+
+    Code
+      translate_sql(mean(x, na.rm = FALSE), con = con)
+    Condition
+      Warning:
+      Missing values are always removed in SQL aggregation functions.
+      Use `na.rm = TRUE` to silence this warning
+      This warning is displayed once every 8 hours.
+    Output
+      <SQL> AVG("x") OVER ()
+
 # warns informatively with unsupported function
 
     Code

--- a/tests/testthat/helper-expectation.R
+++ b/tests/testthat/helper-expectation.R
@@ -21,3 +21,8 @@ expect_translation_snapshot <- function(con, expr, ..., error = FALSE) {
 }
 
 scrub_sqlite_version <- \(x) gsub(sqlite_version(), "<version>", x)
+
+local_show_na_rm_warning <- function(frame = caller_env()) {
+  reset_warning_verbosity("dbplyr_check_na_rm")
+  local_mocked_bindings(is_testing = function() FALSE, .env = frame)
+}

--- a/tests/testthat/test-translate-sql-aggregate.R
+++ b/tests/testthat/test-translate-sql-aggregate.R
@@ -1,13 +1,9 @@
 test_that("aggregation functions warn once if na.rm = FALSE", {
+  local_show_na_rm_warning()
   con <- dialect_ansi()
-  reset_warning_verbosity("dbplyr_check_na_rm")
-  local_mocked_bindings(is_testing = function() FALSE)
 
   expect_no_warning(translate_sql(mean(x, na.rm = TRUE), con = con))
-  expect_warning(
-    translate_sql(mean(x, na.rm = FALSE), con = con),
-    "Missing values"
-  )
+  expect_snapshot(translate_sql(mean(x, na.rm = FALSE), con = con))
   expect_no_warning(translate_sql(mean(x, na.rm = FALSE), con = con))
 })
 

--- a/tests/testthat/test-translate-sql.R
+++ b/tests/testthat/test-translate-sql.R
@@ -107,6 +107,14 @@ test_that("anyNA() translates like any(is.na()) (#1814)", {
   expect_translation(con, anyNA(x), 'MAX(("x" IS NULL)) OVER ()', window = TRUE)
 })
 
+test_that("anyNA() never warns about na.rm", {
+  local_show_na_rm_warning()
+
+  con <- dialect_ansi()
+  expect_no_warning(translate_sql(anyNA(x), con = con, window = FALSE))
+  expect_no_warning(translate_sql(anyNA(x), con = con, window = TRUE))
+})
+
 test_that("connection affects quoting character", {
   lf <- lazy_frame(field1 = 1, field2 = 2, con = dialect_sqlite())
   out <- select(lf, field1)


### PR DESCRIPTION
And introduce a helper to make that a bit easier to do.