### PR TITLE
Use correct quote identifier for Spark SQL

### DIFF
--- a/R/backend-spark-sql.R
+++ b/R/backend-spark-sql.R
@@ -31,7 +31,7 @@ NULL
 dialect_spark_sql <- function() {
   new_sql_dialect(
     "spark_sql",
-    quote_identifier = function(x) sql_quote(x, '"'),
+    quote_identifier = function(x) sql_quote(x, "`"),
     has_window_clause = TRUE
   )
 }

--- a/tests/testthat/test-backend-spark-sql.R
+++ b/tests/testthat/test-backend-spark-sql.R
@@ -1,15 +1,11 @@
 test_that("simulate_spark_sql() still works", {
-  expect_translation(simulate_spark_sql(), x + 1, '"x" + 1.0')
+  expect_translation(simulate_spark_sql(), x + 1, "`x` + 1.0")
 })
 
 test_that("custom clock functions translated correctly", {
   con <- dialect_spark_sql()
-  expect_translation(
-    con,
-    add_years(x, 1),
-    'ADD_MONTHS("x", 1.0 * 12)'
-  )
-  expect_translation(con, add_days(x, 1), 'DATE_ADD("x", 1.0)')
+  expect_translation(con, add_years(x, 1), "ADD_MONTHS(`x`, 1.0 * 12)")
+  expect_translation(con, add_days(x, 1), "DATE_ADD(`x`, 1.0)")
   expect_error(
     translate_sql(add_days(x, 1, "dots", "must", "be empty"), con = con),
     class = "rlib_error_dots_nonempty"
@@ -22,27 +18,27 @@ test_that("custom clock functions translated correctly", {
   expect_translation(
     con,
     date_build(year_column, 1L, 1L),
-    'MAKE_DATE("year_column", 1, 1)'
+    "MAKE_DATE(`year_column`, 1, 1)"
   )
   expect_translation(
     con,
     get_year(date_column),
-    'DATE_PART(\'YEAR\', "date_column")'
+    "DATE_PART('YEAR', `date_column`)"
   )
   expect_translation(
     con,
     get_month(date_column),
-    'DATE_PART(\'MONTH\', "date_column")'
+    "DATE_PART('MONTH', `date_column`)"
   )
   expect_translation(
     con,
     get_day(date_column),
-    'DATE_PART(\'DAY\', "date_column")'
+    "DATE_PART('DAY', `date_column`)"
   )
   expect_translation(
     con,
     date_count_between(date_column_1, date_column_2, "day"),
-    'DATEDIFF("date_column_2", "date_column_1")'
+    "DATEDIFF(`date_column_2`, `date_column_1`)"
   )
   expect_snapshot(
     error = TRUE,
@@ -70,12 +66,12 @@ test_that("difftime is translated correctly", {
   expect_translation(
     con,
     difftime(start_date, end_date, units = "days"),
-    'DATEDIFF("end_date", "start_date")'
+    "DATEDIFF(`end_date`, `start_date`)"
   )
   expect_translation(
     con,
     difftime(start_date, end_date),
-    'DATEDIFF("end_date", "start_date")'
+    "DATEDIFF(`end_date`, `start_date`)"
   )
 
   expect_snapshot(


### PR DESCRIPTION
Fixes #1840